### PR TITLE
U/lynnej/add metadata

### DIFF
--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -77,19 +77,19 @@ if __name__ == "__main__":
 
     sim_names = [os.path.basename(name).replace('.db', '') for name in dbFiles]
 
-    trackingDb = db.TrackingDb('.')
+    trackingDb = db.TrackingDb(database=None)
     mafDate, mafVersion = mafUtils.getDateVersion()
     mafVersion = mafVersion['__version__']
 
     for filename, opsim in zip(dbFiles, sim_names):
         # label visits
-        mafUtils.labelVisits(filename)
+        newdb_file = mafUtils.labelVisits(filename)
         # Set and create if needed the output directory
         outDir = opsim + "_sched"
         if os.path.isdir(outDir):
             shutil.rmtree(outDir)
         # Connect to the opsim database
-        opsdb = db.OpsimDatabase(filename)
+        opsdb = db.OpsimDatabase(newdb_file)
         colmap = batches.ColMapDict()
 
         # Set up the bundle dicts
@@ -99,74 +99,73 @@ if __name__ == "__main__":
             tags = ['All', 'WFD']
         else:
             tags = ['All']
-        # Set up appropriate metadata - need to combine args.sqlConstraint
 
         # Some of these metrics are reproduced in other scripts - srd and cadence
         bdict = {}
         plotbundles = []
 
         for tag in tags:
-            fO = batches.fOBatch(colmap=colmap, runName=args.runName,
+            fO = batches.fOBatch(colmap=colmap, runName=opsim,
                                  extraSql=sqls[tag], extraMetadata=metadata[tag])
             bdict.update(fO)
-            astrometry = batches.astrometryBatch(colmap=colmap, runName=args.runName,
+            astrometry = batches.astrometryBatch(colmap=colmap, runName=opsim,
                                                  extraSql=sqls[tag], extraMetadata=metadata[tag])
             bdict.update(astrometry)
-            rapidrevisit = batches.rapidRevisitBatch(colmap=colmap, runName=args.runName,
+            rapidrevisit = batches.rapidRevisitBatch(colmap=colmap, runName=opsim,
                                                      extraSql=sqls[tag], extraMetadata=metadata[tag])
             bdict.update(rapidrevisit)
 
         # Intranight (pairs/time)
-        intranight_all, plots = batches.intraNight(colmap, args.runName, extraSql=args.sqlConstraint)
+        intranight_all, plots = batches.intraNight(colmap, opsim, extraSql=None)
         bdict.update(intranight_all)
         plotbundles.append(plots)
 
         # Internight (nights between visits)
         for tag in tags:
-            internight, plots = batches.interNight(colmap, args.runName, extraSql=sqls[tag],
+            internight, plots = batches.interNight(colmap, opsim, extraSql=sqls[tag],
                                                    extraMetadata=metadata[tag])
             bdict.update(internight)
             plotbundles.append(plots)
 
         # Intraseason (length of season)
         for tag in tags:
-            season, plots = batches.seasons(colmap=colmap, runName=args.runName,
+            season, plots = batches.seasons(colmap=colmap, runName=opsim,
                                             extraSql=sqls[tag], extraMetadata=metadata[tag])
             bdict.update(season)
             plotbundles.append(plots)
 
         # Run all metadata metrics, All and just WFD.
         for tag in tags:
-            bdict.update(batches.allMetadata(colmap, args.runName, extraSql=sqls[tag],
+            bdict.update(batches.allMetadata(colmap, opsim, extraSql=sqls[tag],
                                              extraMetadata=metadata[tag]))
 
         # Nvisits + m5 maps + Teff maps, All and just WFD.
         for tag in tags:
-            bdict.update(batches.nvisitsM5Maps(colmap, args.runName, runLength=args.nyears,
+            bdict.update(batches.nvisitsM5Maps(colmap, opsim,
                                                extraSql=sqls[tag], extraMetadata=metadata[tag]))
-            bdict.update(batches.tEffMetrics(colmap, args.runName, extraSql=sqls[tag],
+            bdict.update(batches.tEffMetrics(colmap, opsim, extraSql=sqls[tag],
                                              extraMetadata=metadata[tag]))
 
         # Nvisits per proposal and per night.
-        bdict.update(batches.nvisitsPerProp(opsdb, colmap, args.runName,
-                                            extraSql=args.sqlConstraint))
+        bdict.update(batches.nvisitsPerProp(opsdb, colmap, opsim,
+                                            extraSql=None))
 
         # NVisits alt/az LambertSkyMap (all filters, per filter)
-        bdict.update(batches.altazLambert(colmap, args.runName, extraSql=args.sqlConstraint))
+        bdict.update(batches.altazLambert(colmap, opsim, extraSql=None))
 
         # Slew metrics.
-        bdict.update(batches.slewBasics(colmap, args.runName, sqlConstraint=args.sqlConstraint))
+        bdict.update(batches.slewBasics(colmap, opsim, sqlConstraint=None))
 
         # Open shutter metrics.
-        bdict.update(batches.openshutterFractions(colmap, args.runName, extraSql=args.sqlConstraint))
+        bdict.update(batches.openshutterFractions(colmap, opsim, extraSql=None))
 
         # Per night and whole survey filter changes.
-        bdict.update(batches.filtersPerNight(colmap, args.runName, nights=1, extraSql=args.sqlConstraint))
-        bdict.update(batches.filtersWholeSurvey(colmap, args.runName, extraSql=args.sqlConstraint))
+        bdict.update(batches.filtersPerNight(colmap, opsim, nights=1, extraSql=None))
+        bdict.update(batches.filtersWholeSurvey(colmap, opsim, extraSql=None))
 
         # Hourglass plots.
-        #bdict.update(batches.hourglassPlots(colmap, args.runName,
-        #                                    nyears=args.nyears, extraSql=args.sqlConstraint))
+        #bdict.update(batches.hourglassPlots(colmap, opsim,
+        #                                    nyears=args.nyears, extraSql=None))
 
         # Set up the resultsDB
         resultsDb = db.ResultsDb(outDir=outDir)
@@ -174,10 +173,6 @@ if __name__ == "__main__":
         group = mb.MetricBundleGroup(bdict, opsdb, outDir=outDir, resultsDb=resultsDb, saveEarly=False)
         group.runAll(clearMemory=True, plotNow=True)
         resultsDb.close()
-        query = 'select Value from info where Parameter like "featureScheduler version"'
-        opsimVersion = opsdb.query_arbitrary(table='info', query=query)
-        query = 'select Value from info where Parameter like "Date, ymd"'
-        opsimDate  = opsdb.query_arbitrary(table='info', query=query)
 
         # Write configs to disk - these are useful for tracking provenance if we need to re-generate the
         # tracking database, for example (to keep things in a particular order).
@@ -186,7 +181,7 @@ if __name__ == "__main__":
         opsdb.close()
 
         # Add outputs to tracking database. -- note possible race condition if running in parallel.
-        trackingDb.addRun(opsimRun=opsim, opsimVersion=opsimVersion, opsimDate=opsimDate,
+        trackingDb.addRun(opsimRun=opsim, opsimVersion=None, opsimDate=None,
                           mafComment='Metadata', mafVersion=mafVersion, mafDate=mafDate,
                           mafDir=outDir, dbFile=filename, mafRunId=None,
                           opsimGroup=None, opsimComment=None)

--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+import glob
+import shutil
+import matplotlib
+matplotlib.use("Agg")
+
+import rubin_sim.maf.batches as batches
+import rubin_sim.maf.db as db
+import rubin_sim.maf.metricBundles as mb
+import rubin_sim.maf.utils as mafUtils
+
+def setSQL(opsdb, sqlConstraint=None, extraMeta=None):
+    # Fetch the proposal ID values from the database
+    # If there is no proposal database, propids and proptags will be empty dictionaries.
+    propids, proptags = opsdb.fetchPropInfo()
+    sqltags = {'All': sqlConstraint}
+    metadata = {'All': ''}
+    if 'WFD' in proptags:
+        # Construct a WFD SQL where clause so multiple propIDs can query by WFD:
+        wfdWhere = opsdb.createSQLWhere('WFD', proptags)
+        sqltags['WFD'] = wfdWhere
+        metadata['WFD'] = 'WFD'
+    if 'DD' in proptags:
+        ddWhere = opsdb.createSQLWhere('DD', proptags)
+        sqltags['DD'] = ddWhere
+        metadata['DD'] = 'DD'
+    if sqlConstraint is not None:
+        sqltags['WFD'] = '(%s) and (%s)' % (sqlConstraint, wfdWhere)
+        sqltags['DD'] = '(%s) and (%s)' % (sqlConstraint, ddWhere)
+    # Use extra metadata if available
+    if extraMeta is not None and len(extraMeta) > 0:
+        for t in metadata:
+            metadata[t] += ' %s' % extraMeta
+    # else, if sqlconstraint present (only) use that.
+    elif sqlConstraint is not None and len(sqlConstraint) > 0:
+        md = sqlConstraint.replace('=', '').replace('filter', '').replace("'", '')
+        md = md.replace('"', '').replace('  ', ' ')
+        for t in metadata:
+            metadata[t] += ' %s' % md
+    # Reset metadata to None if there was nothing there. (helpful for batches).
+    for t in metadata:
+        if len(metadata[t]) == 0:
+            metadata[t] = None
+    return (propids, proptags, sqltags, metadata)
+
+
+if __name__ == "__main__":
+    """
+    Run the metadata batch on all .db files in a directory.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runNames", type=str, default=None)
+    args = parser.parse_args()
+
+    # If runNames not given, scan for opsim databases in current directory and use those
+    # Note that 'runNames' can be full path to directories
+
+    if args.runNames is None:
+        # Just look for any .db files in this directory
+        runNames = glob.glob('.db')
+        # But remove trackingDb and resultsDb if they're there
+        try:
+            runNames.remove('trackingDb_sqlite.db')
+        except ValueError:
+            pass
+        try:
+            runNames.remove('resultsDb_sqlite.db')
+        except ValueError:
+            pass
+    elif isinstance(args.runNames, str):
+        runNames = [args.runNames]
+    else:
+        runNames = args.runNames
+
+    sim_names = [os.path.basename(name).replace('.db', '') for name in runNames]
+
+    trackingDb = db.TrackingDb('.')
+    mafDate, mafVersion = mafUtils.getDateVersion()
+    mafVersion = mafVersion['__version__']
+
+    for filename, opsim in zip(runNames, sim_names):
+        # Set and create if needed the output directory
+        outDir = opsim + "_sched"
+        if os.path.isdir(outDir):
+            shutil.rmtree(outDir)
+        # Connect to the opsim database
+        opsdb = db.OpsimDatabase(filename)
+        colmap = batches.ColMapDict()
+
+        # Set up the bundle dicts
+        # Set up WFD sql constraint, if possible.
+        propids, proptags, sqls, metadata = setSQL(opsdb)
+        if 'WFD' in sqls:
+            tags = ['All', 'WFD']
+        else:
+            tags = ['All']
+        # Set up appropriate metadata - need to combine args.sqlConstraint
+
+        # Some of these metrics are reproduced in other scripts - srd and cadence
+        bdict = {}
+        plotbundles = []
+
+        for tag in tags:
+            fO = batches.fOBatch(colmap=colmap, runName=args.runName,
+                                 extraSql=sqls[tag], extraMetadata=metadata[tag])
+            bdict.update(fO)
+            astrometry = batches.astrometryBatch(colmap=colmap, runName=args.runName,
+                                                 extraSql=sqls[tag], extraMetadata=metadata[tag])
+            bdict.update(astrometry)
+            rapidrevisit = batches.rapidRevisitBatch(colmap=colmap, runName=args.runName,
+                                                     extraSql=sqls[tag], extraMetadata=metadata[tag])
+            bdict.update(rapidrevisit)
+
+        # Intranight (pairs/time)
+        intranight_all, plots = batches.intraNight(colmap, args.runName, extraSql=args.sqlConstraint)
+        bdict.update(intranight_all)
+        plotbundles.append(plots)
+
+        # Internight (nights between visits)
+        for tag in tags:
+            internight, plots = batches.interNight(colmap, args.runName, extraSql=sqls[tag],
+                                                   extraMetadata=metadata[tag])
+            bdict.update(internight)
+            plotbundles.append(plots)
+
+        # Intraseason (length of season)
+        for tag in tags:
+            season, plots = batches.seasons(colmap=colmap, runName=args.runName,
+                                            extraSql=sqls[tag], extraMetadata=metadata[tag])
+            bdict.update(season)
+            plotbundles.append(plots)
+
+        # Run all metadata metrics, All and just WFD.
+        for tag in tags:
+            bdict.update(batches.allMetadata(colmap, args.runName, extraSql=sqls[tag],
+                                             extraMetadata=metadata[tag]))
+
+        # Nvisits + m5 maps + Teff maps, All and just WFD.
+        for tag in tags:
+            bdict.update(batches.nvisitsM5Maps(colmap, args.runName, runLength=args.nyears,
+                                               extraSql=sqls[tag], extraMetadata=metadata[tag]))
+            bdict.update(batches.tEffMetrics(colmap, args.runName, extraSql=sqls[tag],
+                                             extraMetadata=metadata[tag]))
+
+        # Nvisits per proposal and per night.
+        bdict.update(batches.nvisitsPerProp(opsdb, colmap, args.runName,
+                                            extraSql=args.sqlConstraint))
+
+        # NVisits alt/az LambertSkyMap (all filters, per filter)
+        bdict.update(batches.altazLambert(colmap, args.runName, extraSql=args.sqlConstraint))
+
+        # Slew metrics.
+        bdict.update(batches.slewBasics(colmap, args.runName, sqlConstraint=args.sqlConstraint))
+
+        # Open shutter metrics.
+        bdict.update(batches.openshutterFractions(colmap, args.runName, extraSql=args.sqlConstraint))
+
+        # Per night and whole survey filter changes.
+        bdict.update(batches.filtersPerNight(colmap, args.runName, nights=1, extraSql=args.sqlConstraint))
+        bdict.update(batches.filtersWholeSurvey(colmap, args.runName, extraSql=args.sqlConstraint))
+
+        # Hourglass plots.
+        #bdict.update(batches.hourglassPlots(colmap, args.runName,
+        #                                    nyears=args.nyears, extraSql=args.sqlConstraint))
+
+        # Set up the resultsDB
+        resultsDb = db.ResultsDb(outDir=outDir)
+        # Go and run it
+        group = mb.MetricBundleGroup(bdict, opsdb, outDir=outDir, resultsDb=resultsDb, saveEarly=False)
+        group.runAll(clearMemory=True, plotNow=True)
+        resultsDb.close()
+        query = 'select Value from info where Parameter like "featureScheduler version"'
+        opsimVersion = opsdb.query_arbitrary(table='info', query=query)
+        query = 'select Value from info where Parameter like "Date, ymd"'
+        opsimDate  = opsdb.query_arbitrary(table='info', query=query)
+
+        # Write configs to disk - these are useful for tracking provenance if we need to re-generate the
+        # tracking database, for example (to keep things in a particular order).
+        mafUtils.writeConfigs(opsdb, outDir)
+        # Close connection to opsim database.
+        opsdb.close()
+
+        # Add outputs to tracking database. -- note possible race condition if running in parallel.
+        trackingDb.addRun(opsimRun=opsim, opsimVersion=opsimVersion, opsimDate=opsimDate,
+                          mafComment='Metadata', mafVersion=mafVersion, mafDate=mafDate,
+                          mafDir=outDir, dbFile=filename, mafRunId=None,
+                          opsimGroup=None, opsimComment=None)
+    # Close trackingDB
+    trackingDb.close()

--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -52,36 +52,38 @@ if __name__ == "__main__":
     Run the metadata batch on all .db files in a directory.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("--runNames", type=str, default=None)
+    parser.add_argument("--dbFiles", type=str, default=None)
     args = parser.parse_args()
 
     # If runNames not given, scan for opsim databases in current directory and use those
     # Note that 'runNames' can be full path to directories
 
-    if args.runNames is None:
+    if args.dbFiles is None:
         # Just look for any .db files in this directory
-        runNames = glob.glob('.db')
+        dbFiles = glob.glob('.db')
         # But remove trackingDb and resultsDb if they're there
         try:
-            runNames.remove('trackingDb_sqlite.db')
+            dbFiles.remove('trackingDb_sqlite.db')
         except ValueError:
             pass
         try:
-            runNames.remove('resultsDb_sqlite.db')
+            dbFiles.remove('resultsDb_sqlite.db')
         except ValueError:
             pass
-    elif isinstance(args.runNames, str):
-        runNames = [args.runNames]
+    elif isinstance(args.dbFiles, str):
+        dbFiles = [args.dbFiles]
     else:
-        runNames = args.runNames
+        dbFiles = args.dbFiles
 
-    sim_names = [os.path.basename(name).replace('.db', '') for name in runNames]
+    sim_names = [os.path.basename(name).replace('.db', '') for name in dbFiles]
 
     trackingDb = db.TrackingDb('.')
     mafDate, mafVersion = mafUtils.getDateVersion()
     mafVersion = mafVersion['__version__']
 
-    for filename, opsim in zip(runNames, sim_names):
+    for filename, opsim in zip(dbFiles, sim_names):
+        # label visits
+        mafUtils.labelVisits(filename)
         # Set and create if needed the output directory
         outDir = opsim + "_sched"
         if os.path.isdir(outDir):

--- a/rubin_sim/maf/db/opsimDatabase.py
+++ b/rubin_sim/maf/db/opsimDatabase.py
@@ -262,9 +262,9 @@ class OpsimDatabaseFBS(BaseOpsimDatabase):
         propIds = {}
         # Add WFD and DD tags by default to propTags as we expect these every time. (avoids key errors).
         propTags = {'WFD': [], 'DD': [], 'NES': []}
-        propData = self.query_columns('Proposal', colnames =[self.propIdCol, 'proposalName', 'proposalType'],
+        propData = self.query_columns('Proposal', colnames =['proposalId', 'proposalName', 'proposalType'],
                                       sqlconstraint=None)
-        for propId, propName, propType in zip(propData[self.propIdCol],
+        for propId, propName, propType in zip(propData['proposalId'],
                                               propData['proposalName'],
                                               propData['proposalType']):
             propIds[propId] = propName

--- a/rubin_sim/maf/db/opsimDatabase.py
+++ b/rubin_sim/maf/db/opsimDatabase.py
@@ -183,7 +183,7 @@ class BaseOpsimDatabase(Database):
         -------
         int
         """
-        query = f'select count(distinct({self.mjdCol}) from {self.defaultTable}'
+        query = f'select count(distinct({self.mjdCol})) from {self.defaultTable}'
         data = self.execute_arbitrary(query, dtype=([('nvisits', int)]))
         return data['nvisits'][0]
 

--- a/rubin_sim/maf/runComparison/runComparison.py
+++ b/rubin_sim/maf/runComparison/runComparison.py
@@ -19,9 +19,6 @@ try:
    output_notebook()
 except ImportError:
    _BOKEH_HERE = False
-   warnings.warn('\n'+'The generateDiffHtml method requires bokeh to be installed'+'\n'+
-                 'but it is not needed to use the other methods in this class.'+'\n'+
-                 'Run: pip install bokeh then restart your jupyter notebook kernel.')
 
 __all__ = ['RunComparison']
 

--- a/rubin_sim/maf/stackers/__init__.py
+++ b/rubin_sim/maf/stackers/__init__.py
@@ -10,3 +10,5 @@ from .getColInfo import *
 from .m5OptimalStacker import *
 from .nFollowStacker import *
 from .snStacker import *
+from .labelStackers import *
+

--- a/rubin_sim/maf/stackers/baseStacker.py
+++ b/rubin_sim/maf/stackers/baseStacker.py
@@ -158,6 +158,22 @@ class BaseStacker(with_metaclass(StackerRegistry, object)):
             return self._run(simData)
 
     def _run(self, simData, cols_present=False):
+        """Run the stacker. This is the method to subclass.
+
+        Parameters
+        ----------
+        simData: np.NDarray
+            The observation data, provided by the MAF framework.
+        cols_present: bool, opt
+            Flag to indicate whether the columns to be added are already present in the data.
+            This will also be provided by the MAF framework -- but your _run method can use the value.
+            If it is 'True' and you do trust the existing value, the _run method can simply return simData.
+
+        Returns
+        -------
+        np.NDarray
+            The simdata, with the columns added or updated (or simply already present).
+        """
         # By moving the calculation of these columns to a separate method, we add the possibility of using
         #  stackers with pandas dataframes. The _addStackerCols method won't work with dataframes, but the
         #  _run methods are quite likely to (depending on their details), as they are just populating columns.

--- a/rubin_sim/maf/stackers/labelStackers.py
+++ b/rubin_sim/maf/stackers/labelStackers.py
@@ -1,0 +1,101 @@
+import numpy as np
+import healpy as hp
+
+from rubin_sim.utils import xyz_from_ra_dec, xyz_angular_radius, \
+    _buildTree, _xyz_from_ra_dec
+from rubin_sim.site_models import FieldsDatabase
+
+from .baseStacker import BaseStacker
+
+__all__ = ['OpsimFieldStacker', 'WFDlabelStacker']
+
+
+class OpSimFieldStacker(BaseStacker):
+    """Add the fieldId of the closest OpSim field for each RA/Dec pointing.
+
+    Parameters
+    ----------
+    raCol : str, opt
+        Name of the RA column. Default fieldRA.
+    decCol : str, opt
+        Name of the Dec column. Default fieldDec.
+
+    """
+    colsAdded = ['opsimFieldId']
+
+    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True):
+        self.colsReq = [raCol, decCol]
+        self.units = ['#']
+        self.raCol = raCol
+        self.decCol = decCol
+        self.degrees = degrees
+        fields_db = FieldsDatabase()
+        # Returned RA/Dec coordinates in degrees
+        fieldid, ra, dec = fields_db.get_id_ra_dec_arrays("select * from Field;")
+        asort = np.argsort(fieldid)
+        self.tree = _buildTree(np.radians(ra[asort]),
+                               np.radians(dec[asort]))
+
+    def _run(self, simData, cols_present=False):
+        if cols_present:
+            # Column already present in data; assume it is correct and does not need recalculating.
+            return simData
+
+        if self.degrees:
+            coord_x, coord_y, coord_z = xyz_from_ra_dec(simData[self.raCol],
+                                                        simData[self.decCol])
+            field_ids = self.tree.query_ball_point(list(zip(coord_x, coord_y, coord_z)),
+                                                   xyz_angular_radius())
+
+        else:
+            # use _xyz private method (sending radians)
+            coord_x, coord_y, coord_z = _xyz_from_ra_dec(simData[self.raCol],
+                                                         simData[self.decCol])
+            field_ids = self.tree.query_ball_point(list(zip(coord_x, coord_y, coord_z)),
+                                                   xyz_angular_radius())
+
+        simData['opsimFieldId'] = np.array([ids[0] for ids in field_ids]) + 1
+        return simData
+
+
+class WFDlabelStacker(BaseStacker):
+    """Add a single new column 'WFD' which flags whether a visit is in the hp_footprint
+    (and not tagged as a DD visit).  Calculate hp_footprint to set the WFD footprint.
+    """
+    colsAdded = ['proposalID']
+
+    def __init__(self, hp_footprint):
+        self.colsRequired = ['note', 'fieldRA', 'fieldDec']
+        self.colsAddedDtypes = [int]
+        self.units = [None]
+        self.footprint = hp_footprint
+        self.nside = hp.nside2npix(len(self.footprint))
+
+    def _run(self, simData, cols_present=False):
+        # Set up DD names.
+        d = set()
+        for p in simData['note'].unique():
+            if p.startswith('DD'):
+                d.add(define_ddname(p))
+        # Define dictionary of proposal tags.
+        propTags = {'Other': 0, 'WFD': 1}
+        for i, field in enumerate(d):
+            propTags[field] = i + 2
+        # Identify Healpixels associated with each visit.
+        vec = hp.dir2vec(simData['fieldRA'], so,Data['fieldDec'], lonlat=True)
+        vec = vec.swapaxes(0, 1)
+        radius = np.radians(1.75)  # fov radius
+        propId = np.zeros(len(simData), int)
+        for i, (v, note) in enumerate(zip(vec, simData['note'])):
+            # Identify the healpixels which would be inside this pointing
+            pointing_healpix = hp.query_disc(nside, v, radius, inclusive=False)
+            # The wfd_footprint consists of values of 0/1 if out/in WFD footprint
+            in_wfd = self.footprint[pointing_healpix].sum()
+            # So in_wfd = the number of healpixels which were in the WFD footprint
+            # .. in the # in / total # > limit (0.4) then "yes" it's in WFD
+            propId[i] = np.where(in_wfd / len(pointing_healpix) > 0.4, propTags['WFD'], 0)
+            # BUT override - if the visit was taken for DD, use that flag instead.
+            if note.startswith('DD'):
+                propId[i] = propTags[define_ddname(note)]
+        simData['proposalID'] = propId
+        return simData

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -266,9 +266,6 @@ def labelVisits(opsimdb_file):
     simdata = wfd_stacker.run(simdata)
 
     # Write back proposalId/observation to the table in the new copy of the database.
-    for obsid, pId in zip(simdata['observationId'], simdata['proposalId']):
-        sql = f'UPDATE {tablename} SET proposalId = {pId} WHERE observationId = {obsid}'
-        cursor.execute(sql)
     # Create some indexes
     try:
         indxObsId = f"CREATE UNIQUE INDEX idx_observationId on {tablename} (observationId)"
@@ -285,6 +282,10 @@ def labelVisits(opsimdb_file):
         cursor.execute(indxFilter)
     except OperationalError:
         print('Already had filter index')
+    # Add the proposal id information.
+    for obsid, pId in zip(simdata['observationId'], simdata['proposalId']):
+        sql = f'UPDATE {tablename} SET proposalId = {pId} WHERE observationId = {obsid}'
+        cursor.execute(sql)
     conn.commit()
 
     # Define dictionary of proposal tags.

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -271,10 +271,20 @@ def labelVisits(opsimdb_file):
         cursor.execute(sql)
     # Create some indexes
     try:
-        indxObsId = "CREATE UNIQUE INDEX idx_observationId on {tablename}} (observationId)"
+        indxObsId = f"CREATE UNIQUE INDEX idx_observationId on {tablename} (observationId)"
         cursor.execute(indxObsId)
     except OperationalError:
-        print('Already had observationId index on {tablename}}')
+        print(f'Already had observationId index on {tablename}')
+    try:
+        indxMJD = f"CREATE UNIQUE INDEX idx_observationStartMJD on {tablename} (observationStartMJD);"
+        cursor.execute(indxMJD)
+    except OperationalError:
+        print('Already had observationStartMJD index')
+    try:
+        indxFilter = f"CREATE INDEX idx_filter on {tablename} (filter)"
+        cursor.execute(indxFilter)
+    except OperationalError:
+        print('Already had filter index')
     conn.commit()
 
     # Define dictionary of proposal tags.


### PR DESCRIPTION
Adds the support to 'label' visits as belonging to a user-defined footprint, using a stacker.
Added a function in mafUtils to run that labelling and then write the output back to a new copy of the database -- parts of this could be used to write the output of any stacker back into a new copy of the database, if desired (with some re-writing). 
Adds a script to run the metadata metrics. 
Ran successfully on galfp_v1.8_10yrs.db. 