### PR TITLE
U/lynnej/add tgaps percent

### DIFF
--- a/doc/metricList.rst
+++ b/doc/metricList.rst
@@ -125,7 +125,7 @@ Core LSST MAF metrics
 - `MagicDiscoveryMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.moMetrics.MagicDiscoveryMetric>`_ 
  	 Count the number of discovery opportunities with very good software for an SSobject.
 - `MaxGapMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.tgaps.MaxGapMetric>`_ 
- 	 Find the maximum gap in observations. Useful for making sure there is an image within the last year that would
+ 	 Find the maximum gap in between observations.
 - `MaxMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.simpleMetrics.MaxMetric>`_ 
  	 Calculate the maximum of a simData column slice.
 - `MaxPercentMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.simpleMetrics.MaxPercentMetric>`_ 
@@ -151,7 +151,7 @@ Core LSST MAF metrics
 - `MoCompletenessAtTimeMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.moSummaryMetrics.MoCompletenessAtTimeMetric>`_ 
  	 Calculate the completeness (relative to the entire population) <= a given H as a function of time,
 - `MoCompletenessMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.moSummaryMetrics.MoCompletenessMetric>`_ 
- 	 Calculate the fraction of the population that meets `threshold` value or higher.
+ 	 Calculate the fraction of the population that meets ``threshold`` value or higher.
 - `NChangesMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.technicalMetrics.NChangesMetric>`_ 
  	 Compute the number of times a column value changes.
 - `NNightsMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.moMetrics.NNightsMetric>`_ 
@@ -252,6 +252,8 @@ Core LSST MAF metrics
  	 Calculate the fraction of images with a previous template image of desired quality.
 - `TgapsMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.tgaps.TgapsMetric>`_ 
  	 Histogram the times of the gaps between observations.
+- `TgapsPercentMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.tgaps.TgapsPercentMetric>`_ 
+ 	 Compute the fraction of the time gaps between observations that occur in a given time range.
 - `TotalPowerMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.summaryMetrics.TotalPowerMetric>`_ 
  	 Calculate the total power in the angular power spectrum between lmin/lmax.
 - `TransientMetric <source/rubin_sim.maf.metrics.html#rubin_sim.maf.metrics.transientMetrics.TransientMetric>`_ 

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -10,6 +10,7 @@ from .common import standardSummary, lightcurveSummary, filterList, combineMetad
 from .colMapDict import ColMapDict
 from .srdBatch import fOBatch, astrometryBatch, rapidRevisitBatch
 from .descWFDBatch import descWFDBatch
+from .timeBatch import timeGaps
 from rubin_sim.maf.mafContrib.LSSObsStrategy.galaxyCountsMetric_extended import GalaxyCountsMetric_extended
 from rubin_sim.maf.mafContrib import (TdePopMetric, generateTdePopSlicer,
                                       generateMicrolensingSlicer, MicrolensingMetric,
@@ -167,10 +168,10 @@ def scienceRadarBatch(colmap=None, runName='opsim', extraSql=None, extraMetadata
 
     metric = TdePopMetric()
     slicer = generateTdePopSlicer()
-    plotDict = {'reduceFunc': np.sum, 'nside': 128}
-    plotFuncs = [plots.HealpixSkyMap()]
+    #plotDict = {'reduceFunc': np.sum, 'nside': 128}
+    #plotFuncs = [plots.HealpixSkyMap()]
     bundle = mb.MetricBundle(metric, slicer, extraSql, runName=runName, metadata=extraMetadata,
-                             plotDict=plotDict, plotFuncs=plotFuncs,
+                             #plotDict=plotDict, plotFuncs=plotFuncs,
                              summaryMetrics=lightcurveSummary(),
                              displayDict=displayDict)
     bundleList.append(bundle)
@@ -242,6 +243,15 @@ def scienceRadarBatch(colmap=None, runName='opsim', extraSql=None, extraMetadata
                              runName=runName, summaryMetrics=lightcurveSummary(),
                              displayDict=displayDict)
     bundleList.append(bundle)
+
+    # General time intervals
+    bundles, p = timeGaps(colmap=colmap, runName=runName, nside=nside,
+                          extraSql=extraSql, extraMetadata=extraMetadata, slicer=None,
+                          display_group=displayDict['group'], subgroup='TimeGaps')
+    temp_list = []
+    for b in bundles:
+        temp_list.append(bundles[b])
+    bundleList.extend(temp_list)
 
     #########################
     # Milky Way

--- a/rubin_sim/maf/metrics/exgalM5.py
+++ b/rubin_sim/maf/metrics/exgalM5.py
@@ -13,9 +13,9 @@ class ExgalM5(BaseMetric):
 
     Parameters
     ----------
-    m5Col : str, optional
+    m5Col : `str`, optional
         Column name for five sigma depth. Default 'fiveSigmaDepth'.
-    unit : str, optional
+    unit : `str`, optional
         Label for units. Default 'mag'.
     """
     def __init__(self, m5Col='fiveSigmaDepth', metricName='ExgalM5', units='mag',
@@ -24,7 +24,8 @@ class ExgalM5(BaseMetric):
         maps = ['DustMap']
         self.m5Col = m5Col
         self.filterCol = filterCol
-        super().__init__(col=[self.m5Col, self.filterCol], maps=maps, metricName=metricName, units=units, **kwargs)
+        super().__init__(col=[self.m5Col, self.filterCol], maps=maps,
+                         metricName=metricName, units=units, **kwargs)
         # Set the default wavelength limits for the lsst filters. These are approximately correct.
         dust_properties = Dust_values()
         self.Ax1 = dust_properties.Ax1

--- a/rubin_sim/maf/metrics/moSummaryMetrics.py
+++ b/rubin_sim/maf/metrics/moSummaryMetrics.py
@@ -12,17 +12,17 @@ def integrateOverH(Mvalues, Hvalues, Hindex = 0.33):
 
     Parameters
     ----------
-    Mvalues : numpy.ndarray
+    Mvalues : `numpy.ndarray`
         The metric values at each H value.
-    Hvalues : numpy.ndarray
+    Hvalues : `numpy.ndarray`
         The H values corresponding to each Mvalue (must be the same length).
-    Hindex : float, optional
+    Hindex : `float`, optional
         The power-law index expected for the H value distribution.
         Default is 0.33  (dN/dH = 10^(Hindex * H) ).
 
     Returns
     --------
-    numpy.ndarray
+    intVals : `numpy.ndarray`
        The integrated or cumulative metric values.
     """
     # Set expected H distribution.
@@ -40,8 +40,12 @@ class ValueAtHMetric(BaseMoMetric):
 
     Parameters
     ----------
-    Hmark : float, optional
+    Hmark : `float`, optional
         The H value at which to look up the metric value. Default = 22.
+
+    Returns
+    -------
+    value: : `float`
     """
     def __init__(self, Hmark=22, **kwargs):
         metricName = 'Value At H=%.1f' %(Hmark)
@@ -67,8 +71,12 @@ class MeanValueAtHMetric(BaseMoMetric):
 
     Parameters
     ----------
-    Hmark : float, optional
+    Hmark : `float`, optional
         The H value at which to look up the metric value. Default = 22.
+
+    Returns
+    -------
+    value: : `float`
     """
     def __init__(self, Hmark=22, reduceFunc=np.mean, metricName=None, **kwargs):
         if metricName is None:
@@ -87,7 +95,7 @@ class MeanValueAtHMetric(BaseMoMetric):
 
 
 class MoCompletenessMetric(BaseMoMetric):
-    """Calculate the fraction of the population that meets `threshold` value or higher.
+    """Calculate the fraction of the population that meets ``threshold`` value or higher.
     This is equivalent to calculating the completeness (relative to the entire population) given
     the output of a Discovery_N_Chances metric, or the fraction of the population that meets a given cutoff
     value for Color determination metrics.
@@ -97,20 +105,20 @@ class MoCompletenessMetric(BaseMoMetric):
 
     Parameters
     ----------
-    threshold : int, optional
+    threshold : `int`, optional
         Count the fraction of the population that exceeds this value. Default = 1.
-    nbins : int, optional
+    nbins : `int`, optional
         If the H values for the metric are not a cloned distribution, then split up H into this many bins.
         Default 20.
-    minHrange : float, optional
+    minHrange : `float`, optional
         If the H values for the metric are not a cloned distribution, then split up H into at least this
         range (otherwise just use the min/max of the H values). Default 1.0
-    cumulative : bool, optional
+    cumulative : `bool`, optional
         If False, simply report the differential fractional value (or differential completeness).
         If True, integrate over the H distribution (using IntegrateOverH) to report a cumulative fraction.
         Default None which becomes True;
         if metricName is set and starts with 'Differential' this will then set to False.
-    Hindex : float, optional
+    Hindex : `float`, optional
         Use Hindex as the power law to integrate over H, if cumulative is True. Default 0.3.
     """
     def __init__(self, threshold=1, nbins=20, minHrange=1.0, cumulative=None, Hindex=0.33, **kwargs):
@@ -193,16 +201,16 @@ class MoCompletenessAtTimeMetric(BaseMoMetric):
 
     Parameters
     ----------
-    times : numpy.ndarray like
+    times : `numpy.ndarray` like
         The bins to distribute the discovery times into. Same units as the discovery time (typically MJD).
-    Hval : float, optional
+    Hval : `float`, optional
         The value of H to count completeness at (or cumulative completeness to).
         Default None, in which case a value halfway through Hvals (the slicer H range) will be chosen.
-    cumulative : bool, optional
+    cumulative : `bool`, optional
         If True, calculate the cumulative completeness (completeness <= H).
         If False, calculate the differential completeness (completeness @ H).
         Default None which becomes 'True' unless metricName starts with 'differential'.
-    Hindex : float, optional
+    Hindex : `float`, optional
         Use Hindex as the power law to integrate over H, if cumulative is True. Default 0.3.
     """
 

--- a/rubin_sim/maf/metrics/tgaps.py
+++ b/rubin_sim/maf/metrics/tgaps.py
@@ -34,8 +34,8 @@ class TgapsMetric(BaseMetric):
         these histograms can be combined and plotted using the 'SummaryHistogram plotter'.
      """
 
-    def __init__(self, timesCol='observationStartMJD', allGaps=False, bins=np.arange(0, 120.0, 5.0)/60./24.,
-                 units='days', **kwargs):
+    def __init__(self, timesCol='observationStartMJD', allGaps=False,
+                 bins=np.arange(0, 120.0, 5.0)/60./24., units='days', **kwargs):
         # Pass the same bins to the plotter.
         self.bins = bins
         self.timesCol = timesCol

--- a/rubin_sim/maf/metrics/tgaps.py
+++ b/rubin_sim/maf/metrics/tgaps.py
@@ -1,7 +1,9 @@
 import numpy as np
 from .baseMetric import BaseMetric
 
-__all__ = ['TgapsMetric', 'NightgapsMetric', 'NVisitsPerNightMetric', 'MaxGapMetric']
+__all__ = ['TgapsMetric', 'TgapsPercentMetric',
+           'NightgapsMetric', 'NVisitsPerNightMetric',
+           'MaxGapMetric']
 
 
 class TgapsMetric(BaseMetric):
@@ -15,18 +17,21 @@ class TgapsMetric(BaseMetric):
 
     Parameters
     ----------
-    timesCol : str, optional
+    timesCol : `str`, optional
         The column name for the exposure times.  Values assumed to be in days.
         Default observationStartMJD.
-    allGaps : bool, optional
+    allGaps : `bool`, optional
         Histogram the gaps between all observations (True) or just successive observations (False)?
         Default is False. If all gaps are used, this metric can become significantly slower.
-    bins : np.ndarray, optional
+    bins : `np.ndarray`, optional
         The bins to use for the histogram of time gaps (in days, or same units as timesCol).
         Default values are bins from 0 to 2 hours, in 5 minute intervals.
 
-    Returns a histogram at each slice point; these histograms can be combined and plotted using the
-    'SummaryHistogram plotter'.
+    Returns
+    -------
+    histogram : `np.ndarray`
+        Returns a histogram of the tgaps at each slice point;
+        these histograms can be combined and plotted using the 'SummaryHistogram plotter'.
      """
 
     def __init__(self, timesCol='observationStartMJD', allGaps=False, bins=np.arange(0, 120.0, 5.0)/60./24.,
@@ -34,7 +39,7 @@ class TgapsMetric(BaseMetric):
         # Pass the same bins to the plotter.
         self.bins = bins
         self.timesCol = timesCol
-        super(TgapsMetric, self).__init__(col=[self.timesCol], metricDtype='object', units=units, **kwargs)
+        super().__init__(col=[self.timesCol], metricDtype='object', units=units, **kwargs)
         self.allGaps = allGaps
 
     def run(self, dataSlice, slicePoint=None):
@@ -52,6 +57,61 @@ class TgapsMetric(BaseMetric):
         return result
 
 
+class TgapsPercentMetric(BaseMetric):
+    """Compute the fraction of the time gaps between observations that occur in a given time range.
+
+    Measure the gaps between observations.  By default, only gaps
+    between neighboring visits are computed.  If allGaps is set to true, all gaps are
+    computed (i.e., if there are observations at 10, 20, 30 and 40 the default will
+    Compute the percent of gaps between specified endpoints.
+
+    This is different from the TgapsMetric in that this only looks at what percent of intervals fall
+    into the specified range, rather than histogramming the entire set of tgaps.
+
+    Parameters
+    ----------
+    timesCol : `str`, opt
+        The column name for the exposure times.  Values assumed to be in days.
+        Default observationStartMJD.
+    allGaps : `bool`, opt
+        Histogram the gaps between all observations (True) or just successive observations (False)?
+        Default is False. If all gaps are used, this metric can become significantly slower.
+    minTime : `float`, opt
+        Minimum time of gaps to include (days). Default 2/24 (2 hours).
+    maxTime : `float`, opt
+        Max time of gaps to include (days). Default 14/24 (14 hours).
+
+    Returns
+    -------
+    percent : `float`
+        Returns a float percent of the CDF between cdfMinTime and cdfMaxTime -
+        (# of tgaps within minTime/maxTime / # of all tgaps).
+     """
+
+    def __init__(self, timesCol='observationStartMJD', allGaps=False,
+                 minTime = 2./24, maxTime=14./24, units='percent', **kwargs):
+        self.timesCol = timesCol
+        assert(minTime <= maxTime)
+        self.minTime = minTime
+        self.maxTime = maxTime
+        super().__init__(col=[self.timesCol], metricDtype='float', units=units, **kwargs)
+        self.allGaps = allGaps
+
+    def run(self, dataSlice, slicePoint=None):
+        if dataSlice.size < 2:
+            return self.badval
+        times = np.sort(dataSlice[self.timesCol])
+        if self.allGaps:
+            allDiffs = []
+            for i in np.arange(1,times.size,1):
+                allDiffs.append((times-np.roll(times,i))[i:])
+            dts = np.concatenate(allDiffs)
+        else:
+            dts = np.diff(times)
+        nInWindow = np.sum((dts >= self.minTime) & (dts <= self.maxTime))
+        return nInWindow/len(dts)*100.
+
+
 class NightgapsMetric(BaseMetric):
     """Histogram the number of nights between observations.
 
@@ -63,18 +123,21 @@ class NightgapsMetric(BaseMetric):
 
     Parameters
     ----------
-    nightCol : str, optional
+    nightCol : `str`, optional
         The column name for the night of each observation.
         Default 'night'.
-    allGaps : bool, optional
+    allGaps : `bool`, optional
         Histogram the gaps between all observations (True) or just successive observations (False)?
         Default is False. If all gaps are used, this metric can become significantly slower.
-    bins : np.ndarray, optional
+    bins : `np.ndarray`, optional
         The bins to use for the histogram of time gaps (in days, or same units as timesCol).
         Default values are bins from 0 to 10 days, in 1 day intervals.
 
-    Returns a histogram at each slice point; these histograms can be combined and plotted using the
-    'SummaryHistogram plotter'.
+    Returns
+    -------
+    histogram : `np.ndarray`
+        Returns a histogram of the deltaT between nights at each slice point;
+        these histograms can be combined and plotted using the 'SummaryHistogram plotter'.
      """
 
     def __init__(self, nightCol='night', allGaps=False, bins=np.arange(0, 10, 1),
@@ -82,8 +145,7 @@ class NightgapsMetric(BaseMetric):
         # Pass the same bins to the plotter.
         self.bins = bins
         self.nightCol = nightCol
-        super(NightgapsMetric, self).__init__(col=[self.nightCol], metricDtype='object',
-                                              units=units, **kwargs)
+        super().__init__(col=[self.nightCol], metricDtype='object', units=units, **kwargs)
         self.allGaps = allGaps
 
     def run(self, dataSlice, slicePoint=None):
@@ -108,23 +170,25 @@ class NVisitsPerNightMetric(BaseMetric):
 
     Parameters
     ----------
-    nightCol : str, optional
+    nightCol : `str`, optional
         The column name for the night of each observation.
         Default 'night'.
-    bins : np.ndarray, optional
+    bins : `np.ndarray`, optional
         The bins to use for the histogram of time gaps (in days, or same units as timesCol).
         Default values are bins from 0 to 5 visits, in steps of 1.
 
-    Returns a histogram at each slice point; these histograms can be combined and plotted using the
-    'SummaryHistogram plotter'.
+    Returns
+    -------
+    histogram : `np.ndarray`
+        Returns a histogram of the number of visits per night at each slice point;
+        these histograms can be combined and plotted using the 'SummaryHistogram plotter'.
      """
 
     def __init__(self, nightCol='night', bins=np.arange(0, 10, 1), units='#', **kwargs):
         # Pass the same bins to the plotter.
         self.bins = bins
         self.nightCol = nightCol
-        super(NVisitsPerNightMetric, self).__init__(col=[self.nightCol], metricDtype='object',
-                                                    units=units, **kwargs)
+        super().__init__(col=[self.nightCol], metricDtype='object', units=units, **kwargs)
 
     def run(self, dataSlice, slicePoint=None):
         n, counts = np.unique(dataSlice[self.nightCol], return_counts=True)
@@ -133,8 +197,19 @@ class NVisitsPerNightMetric(BaseMetric):
 
 
 class MaxGapMetric(BaseMetric):
-    """Find the maximum gap in observations. Useful for making sure there is an image within the last year that would
-    make a good template image.
+    """Find the maximum gap in between observations.
+
+    Useful for making sure there is an image within the last year that would make a good template image.
+
+    Parameters
+    ----------
+    mjdCol : `str`, opt
+        The column name of the night of each observation.
+
+    Returns
+    -------
+    maxGap : `float`
+        The maximum gap (in days) between visits.
     """
 
     def __init__(self, mjdCol='observationStartMJD', **kwargs):

--- a/rubin_sim/maf/plots/specialPlotters.py
+++ b/rubin_sim/maf/plots/specialPlotters.py
@@ -106,7 +106,8 @@ class SummaryHistogram(BasePlotter):
         self.defaultPlotDict = {'title': None, 'xlabel': None, 'ylabel': 'Count', 'label': None,
                                 'cumulative': False, 'xMin': None, 'xMax': None, 'yMin': None, 'yMax': None,
                                 'color': 'b', 'linestyle': '-', 'histStyle': True, 'grid': True,
-                                'metricReduce': metrics.SumMetric(), 'bins': None, 'figsize': None}
+                                'metricReduce': metrics.SumMetric(), 'yscale':None, 'xscale': None,
+                                'bins': None, 'figsize': None}
 
     def __call__(self, metricValue, slicer, userPlotDict, fignum=None):
         """
@@ -150,6 +151,9 @@ class SummaryHistogram(BasePlotter):
         for i in np.arange(finalHist.size):
             finalHist[i] = metric.run(mV[:, i])
 
+        if plotDict['cumulative']:
+            finalHist = finalHist.cumsum()
+
         fig = plt.figure(fignum, figsize=plotDict['figsize'])
         bins = plotDict['bins']
         if plotDict['histStyle']:
@@ -184,5 +188,10 @@ class SummaryHistogram(BasePlotter):
             plotDict['yMin'] = 0
         if plotDict['yMax'] is not None:
             plt.ylim(top=plotDict['yMax'])
+
+        if plotDict['yscale'] is not None:
+            plt.yscale(plotDict['yscale'])
+        if plotDict['xscale'] is not None:
+            plt.xscale(plotDict['xscale'])
 
         return fig.number

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -236,10 +236,13 @@ def labelVisits(opsimdb_file):
     from ..stackers import WFDlabelStacker
     from ..db import OpsimDatabase
 
-    runName = os.path.split(opsimdb_file)[-1].replace('.db', '')
+    ddir = os.path.split(opsimdb_file)[0]
+    basename = os.path.split(opsdb_file)[-1]
+    runName = filename.replace('.db', '')
     # The way this is written, in order to be able to freely use the information later, we write back
     # and modify the original opsim output. This can be problematic - so make a copy first and modify that.
-    newdb_file = 'wfd_' + opsimdb_file
+    # Note also, the new output database will be in the current directory.
+    newdb_file = 'wfd_' + basename
     shutil.copy(opsimdb_file, newdb_file)
 
     # Generate the footprint.
@@ -248,7 +251,7 @@ def labelVisits(opsimdb_file):
     sqlconstraint = 'visitExposureTime > 11 and note not like "%DD%"'
     bundle = MetricBundle(m, s, sqlconstraint, runName=runName)
     opsdb = OpsimDatabase(newdb_file)
-    g = MetricBundleGroup({f'{runName} footprint': bundle}, opsdb)
+    g = MetricBundleGroup({f'{runName} footprint': bundle}, opsdb, outDir=ddir)
     g.runAll()
     wfd_footprint = bundle.metricValues.filled(0)
     wfd_footprint = np.where(wfd_footprint > 750, 1, 0)

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -237,8 +237,8 @@ def labelVisits(opsimdb_file):
     from ..db import OpsimDatabase
 
     ddir = os.path.split(opsimdb_file)[0]
-    basename = os.path.split(opsdb_file)[-1]
-    runName = filename.replace('.db', '')
+    basename = os.path.split(opsimdb_file)[-1]
+    runName = basename.replace('.db', '')
     # The way this is written, in order to be able to freely use the information later, we write back
     # and modify the original opsim output. This can be problematic - so make a copy first and modify that.
     # Note also, the new output database will be in the current directory.

--- a/tests/maf/test_CadenceMetrics.py
+++ b/tests/maf/test_CadenceMetrics.py
@@ -103,6 +103,31 @@ class TestCadenceMetrics(unittest.TestCase):
         Ngaps = np.math.factorial(data.size-1)
         self.assertEqual(np.sum(result3), Ngaps)
 
+    def testTGapsPercentMetric(self):
+        names = ['observationStartMJD']
+        types = [float]
+        data = np.zeros(100, dtype=list(zip(names, types)))
+
+        # All 1-day gaps
+        data['observationStartMJD'] = np.arange(100)
+        # All intervals are one day, so should be 100% within the gap specified
+        metric = metrics.TgapsPercentMetric(minTime=0.5, maxTime=1.5, allGaps=False)
+        result1 = metric.run(data)
+        self.assertEqual(result1, 100)
+
+        # All 2 day gaps
+        data['observationStartMJD'] = np.arange(0, 200, 2)
+        result2 = metric.run(data)
+        self.assertEqual(result2, 0)
+
+        # Run with allGaps = True
+        data = np.zeros(4, dtype=list(zip(names, types)))
+        data['observationStartMJD'] = [1, 2, 3, 4]
+        metric = metrics.TgapsPercentMetric(minTime=0.5, maxTime=1.5, allGaps=True)
+        result3 = metric.run(data)
+        # This should be 50% -- 3 gaps of 1 day, 2 gaps of 2 days, 1 gap of 3 days
+        self.assertEqual(result3, 50)
+
     def testNightGapMetric(self):
         names = ['night']
         types = [float]


### PR DESCRIPTION
Add the TgapsPercent metric from the Bellm cadence note on Long Gaps. 
Add Tgaps metric configured approximately as requested in the note (logarithmic intervals from 30s to 5 years), along with TgapsPercentMetric configured to pick up 2-14 hour and 1 day intervals to the science radar metric batch, via new tgaps batch. 
Add some supporting features to the SummaryHistogram to make nicer looking plot outputs for the Tgaps summary histogram.