### PR TITLE
Add documentation upload workflow step

### DIFF
--- a/.github/workflows/python-tests-doc.yml
+++ b/.github/workflows/python-tests-doc.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           conda config --set always_yes yes
           conda install --quiet --file=requirements.txt
-          conda install documenteer
           conda install lsst-documenteer-pipelines
       - name: install rubin_sim
         shell: bash -l {0}

--- a/.github/workflows/python-tests-doc.yml
+++ b/.github/workflows/python-tests-doc.yml
@@ -21,6 +21,7 @@ jobs:
           conda config --set always_yes yes
           conda install --quiet --file=requirements.txt
           conda install lsst-documenteer-pipelines
+          conda install ltd-conveyor
       - name: install rubin_sim
         shell: bash -l {0}
         run: |
@@ -44,7 +45,8 @@ jobs:
           make html
       - name: upload documentation
         shell: bash -l {0}
+        env:
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
-          echo "This is where the upload magic happens"
-
-
+          ltd upload --gh --dir doc/_build/html --product rubin-sim


### PR DESCRIPTION
This publishes the documentation to https://rubin-sim.lsst.io. For example, the build for this branch is:

https://rubin-sim.lsst.io/v/u-jonathansick-docs-upload