### PR TITLE
U/yoachim/random seed refactor

### DIFF
--- a/rubin_sim/scheduler/detailers/dither_detailer.py
+++ b/rubin_sim/scheduler/detailers/dither_detailer.py
@@ -155,7 +155,7 @@ class Euclid_dither_detailer(Base_detailer):
         if self.per_night:
             if night != self.current_night:
                 self.current_night = night
-                bearing_mag = self.bearing_mag_1[night]
+                bearing_mag = self.bearings_mag_1[night]
                 perp_mag = self.perp_mag_1[night]
                 # Move point a along the bearings
                 self.shifted_dec_a, self.shifted_ra_a = dest(bearing_mag, self.bearing_atob, self.dec_a, self.ra_a)
@@ -163,7 +163,7 @@ class Euclid_dither_detailer(Base_detailer):
                                                              self.shifted_dec_a, self.shifted_ra_a)
 
                 # Shift the second position
-                bearing_mag = self.bearing_mag_2[night]
+                bearing_mag = self.bearings_mag_2[night]
                 perp_mag = self.perp_mag_2[night]
 
                 self.shifted_dec_b, self.shifted_ra_b = dest(bearing_mag, self.bearing_btoa, self.dec_b, self.ra_b)

--- a/rubin_sim/scheduler/surveys/surveys.py
+++ b/rubin_sim/scheduler/surveys/surveys.py
@@ -45,7 +45,7 @@ class Greedy_survey(BaseMarkovDF_survey):
 
         # Check if we need to spin the tesselation
         if self.dither & (conditions.night != self.night):
-            self._spin_fields()
+            self._spin_fields(conditions)
             self.night = conditions.night.copy()
 
         # Let's find the best N from the fields
@@ -351,7 +351,7 @@ class Blob_survey(Greedy_survey):
 
         # Check if we need to spin the tesselation
         if self.dither & (conditions.night != self.night):
-            self._spin_fields()
+            self._spin_fields(conditions)
             self.night = conditions.night.copy()
 
         if self.grow_blob:

--- a/rubin_sim/scheduler/surveys/too_surveys.py
+++ b/rubin_sim/scheduler/surveys/too_surveys.py
@@ -28,7 +28,6 @@ class ToO_master(BaseSurvey):
             for survey in self.surveys:
                 survey.add_observation(observation, indx=indx)
 
-
     def _spawn_new_survey(self, too):
         """Create a new survey object for a ToO we haven't seen before.
 
@@ -127,6 +126,6 @@ class ToO_survey(Blob_survey):
     def generate_observations_rough(self, conditions):
         # Always spin the tesselation before generating a new block.
         if self.dither:
-            self._spin_fields()
+            self._spin_fields(conditions)
         result = super(ToO_survey, self).generate_observations_rough(conditions)
         return result


### PR DESCRIPTION
Update how sky tessellation and rotator angle randomization are handled. This makes it so by default different survey objects will be using the same randomization on a given night. Also makes it so that re-instatiating the scheduler will not reset the randomization (before there was a risk that if one re-instantiated the scheduler at the start of each night, no dithering would ever happen). 