### PR TITLE
Make documentation easier to read and update

### DIFF
--- a/.github/workflows/python-docs-only.yml
+++ b/.github/workflows/python-docs-only.yml
@@ -1,0 +1,54 @@
+name: Build and Push Documentation
+
+on:
+  # Trigger the workflow manually (otherwise runs automatically after unit tests)
+  workflow_dispatch:
+
+jobs:
+  Docs:
+    name: Build and push documentation
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.8
+          channels: conda-forge,defaults
+          channel-priority: strict
+          show-channel-urls: true
+      - name: configure and install conda and requirements
+        shell: bash -l {0}
+        run: |
+          conda config --set always_yes yes
+          conda install --quiet --file=requirements.txt
+          conda install lsst-documenteer-pipelines
+          conda install ltd-conveyor
+      - name: install rubin_sim
+        shell: bash -l {0}
+        run: |
+          echo `pwd`
+          ls ${{ github.workspace }}
+          python -m pip install . --use-feature=in-tree-build
+      - name: download rubin_sim_data components needed to set up metrics for metricList
+        shell: bash -l {0}
+        run: |
+          export RUBIN_SIM_DATA_DIR=${{ github.workspace }}
+          rs_download_data -d 'maf'
+      - name: conda list
+        shell: bash -l {0}
+        run: conda list
+      - name: build documentation
+        shell: bash -l {0}
+        run: |
+          export RUBIN_SIM_DATA_DIR=${{ github.workspace }}
+          cd doc
+          python metricList.py
+          make html
+      - name: upload documentation
+        shell: bash -l {0}
+        env:
+          LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
+          LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
+        run: |
+          ltd upload --gh --dir doc/_build/html --product rubin-sim

--- a/doc/metricList.py
+++ b/doc/metricList.py
@@ -8,9 +8,14 @@ def makeMetricList(outfile):
 
     f = open(outfile, 'w')
 
-    print("=================", file=f)
-    print("Available metrics", file=f)
-    print("=================", file=f)
+    # Print header
+    print(".. py:currentmodule:: rubin_sim.maf", file=f)
+    print("", file=f)
+    print(".. _rubin_sim.maf_metricList:", file=f)
+    print("", file=f)
+    print("================================", file=f)
+    print("rubin_sim MAF: Available metrics", file=f)
+    print("================================", file=f)
 
 
     print("Core LSST MAF metrics", file=f)
@@ -20,9 +25,9 @@ def makeMetricList(outfile):
         if inspect.isclass(obj):
             modname = inspect.getmodule(obj).__name__
             if modname.startswith('rubin_sim.maf.metrics'):
-                link = "source/rubin_sim.maf.metrics.html#%s.%s" % (modname, obj.__name__)
+                link = f":py:class:`~rubin_sim.maf.metrics.{name}` "
                 simpledoc = inspect.getdoc(obj).split('\n')[0]
-                print("- `%s <%s>`_ \n \t %s" % (name, link, simpledoc), file=f)
+                print(f"- {link} \n \t {simpledoc}", file=f)
     print(" ", file=f)
 
     print("Contributed mafContrib metrics", file=f)
@@ -32,9 +37,9 @@ def makeMetricList(outfile):
         if inspect.isclass(obj):
             modname = inspect.getmodule(obj).__name__
             if modname.startswith('rubin_sim.maf.mafContrib')  and name.endswith('Metric'):
-                link = "source/rubin_sim.maf.mafContrib.html#%s.%s" % (modname, obj.__name__)
+                link = f":py:class:`~rubin_sim.maf.mafContrib.{name}` "
                 simpledoc = inspect.getdoc(obj).split('\n')[0]
-                print("- `%s <%s>`_ \n \t %s" % (name, link, simpledoc), file=f)
+                print(f"- {link} \n \t {simpledoc}", file=f)
     print(" ", file=f)
 
 

--- a/doc/rs_data/index.rst
+++ b/doc/rs_data/index.rst
@@ -13,9 +13,6 @@ and provide information on the current simulated baseline pointing history.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.data
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.data api`
 
 * :ref:`search`

--- a/doc/rs_maf/index.rst
+++ b/doc/rs_maf/index.rst
@@ -59,52 +59,6 @@ For more examples of using MAF, please see our `tutorials`_.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.maf.batches
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.metrics
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.mafContrib
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.slicers
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.db
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.maps
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.stackers
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.plots
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.metricBundles
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.runComparison
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.utils
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.maf.web
-   :no-main-docstr:
-   :no-inheritance-diagram:
+* :ref:`rubin_sim.maf api`
 
 * :ref:`search`

--- a/doc/rs_movingObjects/index.rst
+++ b/doc/rs_movingObjects/index.rst
@@ -16,9 +16,6 @@ rubin_sim data.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.movingObjects
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.movingObjects api`
 
 * :ref:`search`

--- a/doc/rs_photUtils/index.rst
+++ b/doc/rs_photUtils/index.rst
@@ -14,9 +14,6 @@ methods for Rubin Observatory. There are expected throughput curves available in
 Python API
 ==========
 
-.. automodapi:: rubin_sim.photUtils
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.photUtils api`
 
 * :ref:`search`

--- a/doc/rs_scheduler/index.rst
+++ b/doc/rs_scheduler/index.rst
@@ -27,37 +27,6 @@ Description of the :doc:`schema for the output database <output_schema>`.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.scheduler
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.schedulers
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.surveys
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.basis_functions
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.features
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.detailers
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.modelObservatory
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: rubin_sim.scheduler.utils
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.scheduler api`
 
 * :ref:`search`

--- a/doc/rs_site_models/index.rst
+++ b/doc/rs_site_models/index.rst
@@ -15,9 +15,6 @@ as the sunrise and sunset times and planetary positions over the expected lifeti
 Python API
 ==========
 
-.. automodapi:: rubin_sim.site_models
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.site_models api`
 
 * :ref:`search`

--- a/doc/rs_skybrightness/index.rst
+++ b/doc/rs_skybrightness/index.rst
@@ -20,9 +20,6 @@ More details about the rubin_sim version of the model and its validation for Rub
 Python API
 ==========
 
-.. automodapi:: rubin_sim.skybrightness
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.skybrightness api`
 
 * :ref:`search`

--- a/doc/rs_skybrightness_pre/index.rst
+++ b/doc/rs_skybrightness_pre/index.rst
@@ -15,9 +15,6 @@ the scheduler by rubin_sim.skybrightness_pre.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.skybrightness_pre
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.skybrightness_pre api`
 
 * :ref:`search`

--- a/doc/rs_utils/index.rst
+++ b/doc/rs_utils/index.rst
@@ -14,9 +14,6 @@ coordinate transform utilities, as well as other useful tools.
 Python API
 ==========
 
-.. automodapi:: rubin_sim.utils
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
+* :ref:`rubin_sim.utils api`
 
 * :ref:`search`

--- a/doc/rubin_sim/index.rst
+++ b/doc/rubin_sim/index.rst
@@ -1,48 +1,171 @@
+.. py:currentmodule:: rubin_sim
+
+.. _rubin_sim.index:
+
 #########
 rubin_sim
 #########
 
 :doc:`Overview <../index>`
 
+:doc:`Table of contents <../toc>`
 
 
+==========
 Python API
 ==========
 
+.. _rubin_sim.utils api:
+
+:doc:`rubin_sim.utils api <../rs_utils/index>`
+==============================================
 .. automodapi:: rubin_sim.utils
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. _rubin_sim.data api:
+
+:doc:`rubin_sim.data api <../rs_data/index>`
+============================================
 .. automodapi:: rubin_sim.data
    :no-main-docstr:
    :no-inheritance-diagram:
 
+
+.. _rubin_sim.photUtils api:
+
+:doc:`rubin_sim.photUtils api <../rs_photUtils/index>`
+======================================================
 .. automodapi:: rubin_sim.photUtils
    :no-main-docstr:
    :no-inheritance-diagram:
 
+
+.. _rubin_sim.site_models api:
+
+:doc:`rubin_sim.site_models api <../rs_site_models/index>`
+==========================================================
 .. automodapi:: rubin_sim.site_models
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. _rubin_sim.skybrightness api:
+
+:doc:`rubin_sim.skybrightness api <../rs_skybrightness/index>`
+==============================================================
 .. automodapi:: rubin_sim.skybrightness
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. _rubin_sim.skybrightness_pre api:
+
+:doc:`rubin_sim.skybrightness_pre api <../rs_skybrightness_pre/index>`
+======================================================================
 .. automodapi:: rubin_sim.skybrightness_pre
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. _rubin_sim.scheduler api:
+
+:doc:`rubin_sim.scheduler api <../rs_scheduler/index>`
+======================================================
 .. automodapi:: rubin_sim.scheduler
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. automodapi:: rubin_sim.scheduler.schedulers
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.surveys
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.basis_functions
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.features
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.detailers
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.modelObservatory
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.scheduler.utils
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+
+.. _rubin_sim.movingObjects api:
+
+:doc:`rubin_sim.movingObjects api <../rs_movingObjects/index>`
+==============================================================
 .. automodapi:: rubin_sim.movingObjects
    :no-main-docstr:
    :no-inheritance-diagram:
 
-.. automodapi:: rubin_sim.maf
+
+.. _rubin_sim.maf api:
+
+:doc:`rubin_sim.maf api <../rs_maf/index>`
+==========================================
+.. automodapi:: rubin_sim.maf.batches
    :no-main-docstr:
    :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.metrics
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.mafContrib
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.slicers
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.db
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.maps
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.stackers
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.plots
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.metricBundles
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.runComparison
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.utils
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: rubin_sim.maf.web
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+
+======
+Search
+======
 
 * :ref:`search`

--- a/rubin_sim/maf/mafContrib/microlensingMetric.py
+++ b/rubin_sim/maf/mafContrib/microlensingMetric.py
@@ -6,6 +6,8 @@ from rubin_sim.utils import hpid2RaDec, equatorialFromGalactic
 import rubin_sim.maf.slicers as slicers
 from rubin_sim.data import get_data_dir
 
+__all__ = ['generateMicrolensingSlicer', 'MicrolensingMetric', 'microlensing_amplification']
+
 # Via Natasha Abrams nsabrams@college.harvard.edu
 def microlensing_amplification(t, impact_parameter=1, crossing_time=1825., peak_time=100,
                                blending_factor = 1):

--- a/rubin_sim/maf/metrics/baseMetric.py
+++ b/rubin_sim/maf/metrics/baseMetric.py
@@ -178,10 +178,10 @@ class BaseMetric(with_metaclass(MetricRegistry, object)):
 
         Parameters
         ----------
-        dataSlice : `np.ndarray`
+        dataSlice : `numpy.recarray`
            Values passed to metric by the slicer, which the metric will use to calculate
            metric values at each slicePoint.
-        slicePoint : `dict`
+        slicePoint : `dict` or None
            Dictionary of slicePoint metadata passed to each metric.
            E.g. the ra/dec of the healpix pixel or opsim fieldId.
 

--- a/rubin_sim/maf/metrics/snNSNMetric.py
+++ b/rubin_sim/maf/metrics/snNSNMetric.py
@@ -18,49 +18,49 @@ class SNNSNMetric(BaseMetric):
 
     Parameters
     -----------
-    metricName : str, optional
+    metricName : `str`, optional
         metric name (default : SNSNRMetric)
-    mjdCol : str, optional
+    mjdCol : `str`, optional
         mjd column name (default : observationStartMJD)
-    RACol : str, optional
+    RACol : `str`, optional
         Right Ascension column name (default : fieldRA)
-    DecCol : str, optional
+    DecCol : `str`, optional
         Declination column name (default : fieldDec)
-    filterCol : str, optional
+    filterCol : `str`, optional
         filter column name (default: filter)
-    m5Col : str, optional
+    m5Col : `str`, optional
         five-sigma depth column name (default : fiveSigmaDepth)
-    exptimeCol : str, optional
+    exptimeCol : `str`, optional
         exposure time column name (default : visitExposureTime)
-    nightCol : str, optional
+    nightCol : `str`, optional
         night column name (default : night)
-    obsidCol : str, optional
+    obsidCol : `str`, optional
         observation id column name (default : observationId)
-    nexpCol : str, optional
+    nexpCol : `str`, optional
         number of exposure column name (default : numExposures)
-    vistimeCol : str, optional
+    vistimeCol : `str`, optional
         visit time column name (default : visitTime)
-    season : list, optional
+    season : `list` of `int`, optional
         list of seasons to process (float)(default: -1 = all seasons)
-    zmin : float, optional
+    zmin : `float`, optional
         min redshift for the study (default: 0.0)
-    zmax : float, optional
+    zmax : `float`, optional
         max redshift for the study (default: 1.2)
-    pixArea: float, optional
+    pixArea : `float`, optional
         pixel area (default: 9.6)
-    verbose: bool, optional
+    verbose : `bool`, optional
         verbose mode (default: False)
-    ploteffi: bool, optional
+    ploteffi : `bool`, optional
         to plot observing efficiencies vs z (default: False)
-    n_bef: int, optional
+    n_bef : `int`, optional
         number of LC points LC before T0 (default:5)
-    n_aft: int, optional
+    n_aft : `int`, optional
         number of LC points after T0 (default: 10)
-    snr_min: float, optional
+    snr_min : `float`, optional
         minimal SNR of LC points (default: 5.0)
-    n_phase_min: int, optional
+    n_phase_min : `int`, optional
         number of LC points with phase<= -5(default:1)
-    n_phase_max: int, optional
+    n_phase_max : `int`, optional
         number of LC points with phase>= 20 (default: 1)
     """
 
@@ -824,28 +824,20 @@ class SNNSNMetric(BaseMetric):
         return res
 
     def zlimdf(self, grp, duration_z):
-        """
-        Method to estimate redshift limits
+        """Estimate redshift limits.
 
         Parameters
         -----------
         grp: `pd.DataFrameGroupBy`
-            DataFrame with efficiencies to estimate redshift limits;
-            season: season
-            pixRA: RA of the pixel
-            pixDec: Dec of the pixel
-            healpixID: pixel ID
-            x1: SN stretch
-            color: SN color
-            z: redshift
-            effi: efficiency
-            effi_err: efficiency error (binomial)
+            DataFrame with efficiencies to estimate redshift limits
+            expected columns are season, pixRA, pixDec, healpixID, x1 (SNstretch), color (SN color),
+            z (redshift), effi (efficiency), effi_err (efficiency error, binomial)
         duration_z: `pd.DataFrame`
             season: season
             z: redshift
             T0_min: min daymax
             T0_max: max daymax
-             season_length: season length
+            season_length: season length
 
         Returns
         ----------

--- a/rubin_sim/maf/metrics/useMetrics.py
+++ b/rubin_sim/maf/metrics/useMetrics.py
@@ -13,6 +13,7 @@ __all__ = ["UseMetric"]
 
 # classes
 
+__all__ = ['UseMetric']
 
 class UseMetric(BaseMetric):  # pylint: disable=too-few-public-methods
     """Metric to classify visits by type of visits"""

--- a/rubin_sim/maf/plots/perceptual_rainbow.py
+++ b/rubin_sim/maf/plots/perceptual_rainbow.py
@@ -1,5 +1,8 @@
 from matplotlib.colors import LinearSegmentedColormap
 
+__all__ = ['makePRCmap']
+
+
 def makePRCmap():
     colors = [[135, 59, 97],
               [143, 64, 127],

--- a/rubin_sim/maf/slicers/timeIntervalSlicers.py
+++ b/rubin_sim/maf/slicers/timeIntervalSlicers.py
@@ -18,6 +18,7 @@ from .baseSlicer import BaseSlicer
 
 # exception classes
 
+__all__ = ['TimeIntervalSlicer', 'BlockIntervalSlicer', 'VisitIntervalSlicer', 'SlicerNotSetup']
 
 class SlicerNotSetup(Exception):
     """Thrown when a slicer is not setup for the method called."""

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -54,7 +54,7 @@ def getFieldData(opsimDb, sqlconstraint):
 
     Returns
     -------
-    numpy.ndarray
+    fieldData : `numpy.ndarray`
         A numpy structured array containing the field information.  This data will ALWAYS be in radians.
     """
     # Get all fields used for all proposals.
@@ -110,7 +110,7 @@ def getSimData(opsimDb, sqlconstraint, dbcols, stackers=None, groupBy='default',
         SQL constraint to apply to query for observations.
     dbcols : `list` [`str`]
         Columns required from the database.
-    stackers : `list` [`rubin_sim.maf.Stackers`], optional
+    stackers : `list` [`rubin_sim.maf.stackers`], optional
         Stackers to be used to generate additional columns. Default None.
     tableName : `str`, optional
         Name of the table to query. Default None uses the opsimDb default.

--- a/rubin_sim/movingObjects/baseObs.py
+++ b/rubin_sim/movingObjects/baseObs.py
@@ -210,7 +210,7 @@ class BaseObs(object):
         bandpassRoot : `str`, optional
             Rootname of the throughput curves in filterlist.
             E.g. throughput curve names are bandpassRoot + filterlist[i] + bandpassSuffix
-            Default "total_" (appropriate for LSST throughput repo).
+            Default total\_ (appropriate for LSST throughput repo).
         bandpassSuffix : `str`, optional
             Suffix for the throughput curves in filterlist.
             Default '.dat' (appropriate for LSST throughput repo).

--- a/rubin_sim/movingObjects/chebyshevUtils.py
+++ b/rubin_sim/movingObjects/chebyshevUtils.py
@@ -288,7 +288,8 @@ def chebfit(t, x, dxdt=None, xMultiplier=None, dxMultiplier=None, nPoly=7):
         raise ValueError("length of x (%s) != length of t (%s)" % (len(x), nPoints))
     if dxdt is None:
         if nPoly > nPoints:
-            raise RuntimeError('Without velocity constraints, nPoly (%d) must be less than %s' % (nPoly, nPoints))
+            raise RuntimeError('Without velocity constraints, nPoly (%d) must be less than %s' % (nPoly,
+                                                                                                  nPoints))
         if nPoly < 2:
             raise RuntimeError('Without velocity constraints, nPoly (%d) must be greater than 2' % nPoly)
     else:

--- a/rubin_sim/photUtils/BandpassDict.py
+++ b/rubin_sim/photUtils/BandpassDict.py
@@ -102,8 +102,7 @@ class BandpassDict(object):
         @param [in] componentList lists the files associated with bandpasses representing
         hardware components shared by all filters
         (defaults to ['detector.dat', 'm1.dat', 'm2.dat', 'm3.dat', 'lens1.dat',
-                      'lense2.dat', 'lenst3.dat']
-        for LSST).  These files are also expected to be stored in filedir
+        'lens2.dat', 'lens3.dat'] for LSST).  These files are also expected to be stored in filedir
 
         @param [in] atmoTransmission is the absolute path to the file representing the
         transmissivity of the atmosphere (defaults to baseline/atmos_std.dat in the LSST

--- a/rubin_sim/skybrightness/allSkyDB.py
+++ b/rubin_sim/skybrightness/allSkyDB.py
@@ -5,6 +5,8 @@ from rubin_sim.data import get_data_dir
 
 # Tools for using an all-sky sqlite DB with cannon and photodiode data from the site.
 
+__all__ = ['allSkyDB', 'diodeSkyDB']
+
 
 def allSkyDB(dateID, sqlQ=None, dtypes=None, dbAddress=None, filt='R'):
     """
@@ -15,8 +17,9 @@ def allSkyDB(dateID, sqlQ=None, dtypes=None, dbAddress=None, filt='R'):
         dataPath = os.path.join(get_data_dir(), 'skybrightness')
         dbAddress = 'sqlite:///'+os.path.join(dataPath, 'photometry', 'skydata.sqlite')
     if sqlQ is None:
-        sqlQ = 'select stars.ra, stars.dec,  obs.alt, obs.starMag, obs.sky, obs.filter from obs, stars where obs.starID = stars.ID and obs.filter = "%s" and obs.dateID = %i;' % (
-            filt, dateID)
+        sqlQ = 'select stars.ra, stars.dec,  obs.alt, obs.starMag, obs.sky, obs.filter from obs, ' \
+               'stars where obs.starID = stars.ID and obs.filter = "%s" and obs.dateID = %i;' \
+               % (filt, dateID)
     if dtypes is None:
         names = ['ra', 'dec', 'alt', 'starMag', 'sky', 'filter']
         types = [float, float, float, float, float, '|S1']

--- a/rubin_sim/skybrightness/interpComponents.py
+++ b/rubin_sim/skybrightness/interpComponents.py
@@ -59,15 +59,15 @@ def intid2id(intids, uintids, uids, dtype=int):
 
 
 def loadSpecFiles(filenames, mags=False):
-    """
-    Load up the ESO spectra.
+    """Load up the ESO spectra.
 
     The ESO npz files contain the following arrays:
-    filterWave: The central wavelengths of the pre-computed magnitudes
-    wave: wavelengths for the spectra
-    spec: array of spectra and magnitudes along with the relevant variable inputs.  For example,
+    * filterWave: The central wavelengths of the pre-computed magnitudes
+    * wave: wavelengths for the spectra
+    * spec: array of spectra and magnitudes along with the relevant variable inputs.  For example,
     airglow has dtype = [('airmass', '<f8'), ('solarFlux', '<f8'), ('spectra', '<f8', (17001,)),
-                         ('mags', '<f8', (6,)]
+    ('mags', '<f8', (6,)]
+
     For each unique airmass and solarFlux value, there is a 17001 elements spectra and 6 magnitudes.
     """
 

--- a/rubin_sim/utils/ObservationMetaData.py
+++ b/rubin_sim/utils/ObservationMetaData.py
@@ -8,86 +8,65 @@ __all__ = ["ObservationMetaData"]
 
 
 class ObservationMetaData(object):
-    """Observation Metadata
+    """Track metadata for a given telescope pointing.
 
     This class contains any metadata for a query which is associated with
     a particular telescope pointing, including bounds in RA and DEC, and
     the time of the observation.
 
-    **Parameters**
+    Parameters
+    ----------
+    pointing : `float`, opt
+        [RA,Dec] float
+        The coordinates of the pointing (in degrees; in the International
+        Celestial Reference System)
+    boundType : `str`, opt
+        characterizes the shape of the field of view.  Current options are 'box, and 'circle'
+    boundLength : `float` or `np.ndarray`, opt
+        is the characteristic length scale of the field of view in degrees.
+        If boundType is 'box', boundLength can be a float (in which case boundLength is
+        half the length of the side of each box) or boundLength can be a numpy array
+        in which case the first argument is half the width of the RA side of the box
+        and the second argument is half the Dec side of the box.
+        If boundType is 'circle,' this will be the radius of the circle.
+        The bound will be centered on the point (pointingRA, pointingDec), however,
+        because objects are stored at their mean RA, Dec in the LSST databases
+        (i.e. they are stored at values of RA, Dec which neglect proper motion), the
+        bounds applied to database queries will be made slightly larger so that queries
+        can be reasonably expected to return all of the objects within the desired field
+        of view once those corrections have been applied.
+    mjd : `float`, opt
+        Either a float (in which case, it will be assumed to be in International
+        Atomic Time), or an instantiation of the ModifiedJulianDate class representing
+        the date of the observation
+    bandpassName : `str` or `list` of `str`, opt
+        a char (e.g. 'u') or list (e.g. ['u', 'g', 'z']) denoting the bandpasses used
+        for this particular observation
+    site : `rubin_sim.utils.Site`, opt
+        an instantiation of the rubin_sim.utils.Site class characterizing the site of the observatory.
+    m5 : `float` or `list` of `float, opt
+        this should be the 5-sigma limiting magnitude in the bandpass or
+        bandpasses specified in bandpassName.  Ultimately, m5 will be stored
+        in a dict keyed to the bandpassName (or Names) you passed in, i.e.
+        you will be able to access m5 from outside of this class using, for
+        example:
+        myObservationMetaData.m5['u']
+    skyBrightness : `float`, opt
+        the magnitude of the sky in the filter specified by bandpassName
+    seeing : `float` or `list` of `float, opt
+        Analogous to m5, corresponds to the seeing in arcseconds in the bandpasses in bandpassName
+    rotSkyPos : `float`, opt
+        The orientation of the telescope in degrees.
+        The convention for rotSkyPos is as follows:
+        rotSkyPos = 0 means north is in the +y direction on the focal plane and east is +x
+        rotSkyPos = 90 means north is +x and east is -y
+        rotSkyPos = -90 means north is -x and east is +y
+        rotSkyPos = 180 means north is -y and east is -x
+        This should be consistent with PhoSim conventions.
 
-        All parameters are optional.  It is possible to instantiate an
-        ObservationMetaData that is empty of data.
-
-        * pointing[RA,Dec] float
-          The coordinates of the pointing (in degrees; in the International
-          Celestial Reference System)
-
-        * boundType characterizes the shape of the field of view.  Current options
-          are 'box, and 'circle'
-
-        * boundLength is the characteristic length scale of the field of view in degrees.
-
-          If boundType is 'box', boundLength can be a float(in which case boundLength is
-          half the length of the side of each box) or boundLength can be a numpy array
-          in which case the first argument is half the width of the RA side of the box
-          and the second argument is half the Dec side of the box.
-
-          If boundType is 'circle,' this will be the radius of the circle.
-
-          The bound will be centered on the point (pointingRA, pointingDec), however,
-          because objects are stored at their mean RA, Dec in the LSST databases
-          (i.e. they are stored at values of RA, Dec which neglect proper motion), the
-          bounds applied to database queries will be made slightly larger so that queries
-          can be reasonably expected to return all of the objects within the desired field
-          of view once those corrections have been applied.
-
-        * mjd :
-          Either a float (in which case, it will be assumed to be in International
-          Atomic Time), or an instantiation of the ModifiedJulianDate class representing
-          the date of the observation
-
-        * bandpassName : a char (e.g. 'u') or list (e.g. ['u', 'g', 'z'])
-          denoting the bandpasses used for this particular observation
-
-        * site: an instantiation of the rubin_sim.utils.Site class characterizing
-          the site of the observatory.
-
-        * m5: float or list
-          this should be the 5-sigma limiting magnitude in the bandpass or
-          bandpasses specified in bandpassName.  Ultimately, m5 will be stored
-          in a dict keyed to the bandpassName (or Names) you passed in, i.e.
-          you will be able to access m5 from outside of this class using, for
-          example:
-
-          myObservationMetaData.m5['u']
-
-        * skyBrightness: float the magnitude of the sky in the
-          filter specified by bandpassName
-
-        * seeing float or list
-          Analogous to m5, corresponds to the seeing in arcseconds in the bandpasses in
-          bandpassName
-
-        * rotSkyPos float
-          The orientation of the telescope in degrees.
-          This is used by the Astrometry mixins in sims_coordUtils.
-
-          The convention for rotSkyPos is as follows:
-
-          rotSkyPos = 0 means north is in the +y direction on the focal plane and east is +x
-
-          rotSkyPos = 90 means north is +x and east is -y
-
-          rotSkyPos = -90 means north is -x and east is +y
-
-          rotSkyPos = 180 means north is -y and east is -x
-
-          This should be consistent with PhoSim conventions.
-
-    **Examples**::
-        >>> data = ObservationMetaData(boundType='box', pointingRA=5.0, pointingDec=15.0,
-                    boundLength=5.0)
+    Examples
+    --------
+    ```>>> data = ObservationMetaData(boundType='box', pointingRA=5.0, pointingDec=15.0, boundLength=5.0)```
 
     """
     def __init__(self, boundType=None, boundLength=None,

--- a/rubin_sim/utils/samplingFunctions.py
+++ b/rubin_sim/utils/samplingFunctions.py
@@ -13,16 +13,16 @@ def spatiallySample_obsmetadata(obsmetadata, size=1, seed=1):
 
     Parameters
     ----------
-    obsmetadata: instance of
-        `sims.catalogs.generation.db.ObservationMetaData`
-    size: integer, optional, defaults to 1
+    obsmetadata : rubin_sim.utils.ObservationMetaData`
+    size : `int`, optional, defaults to 1
         number of samples
-
-    seed: integer, optional, defaults to 1
+    seed : `int`, optional, defaults to 1
         Random Seed used in generating random values
+
     Returns
     -------
-    tuple of ravals, decvalues in radians
+    ravals, thetavals : `np.ndarray`, `np.ndarray`
+        tuple of ravals, decvalues in radians
     """
 
     phi = obsmetadata.pointingRA
@@ -70,17 +70,21 @@ def samplePatchOnSphere(phi, theta, delta, size, seed=1):
 
     Parameters
     ----------
-    phi: float, mandatory, degrees
-        center of the spherical patch in ra with range
-    theta: float, mandatory, degrees
-    delta: float, mandatory, degrees
-    size: int, mandatory
+    phi : `float`,
+        center of the spherical patch in ra with range, degrees
+    theta : `float`
+        degrees
+    delta : `float`
+        degrees
+    size : `int`
         number of samples
-    seed : int, optional, defaults to 1
+    seed : `int`, optional, defaults to 1
         random Seed used for generating values
+
     Returns
     -------
-    tuple of (phivals, thetavals) where phivals and thetavals are arrays of
+    phivals, thetavals : `np.ndarray`, `np.ndarray`
+        tuple of (phivals, thetavals) where phivals and thetavals are arrays of
         size size in degrees.
     """
     np.random.seed(seed)


### PR DESCRIPTION
Moves around python API pages (giving more room to add text on each module page). 
Fixes the links in the metricList page (updating the metricList.py code).
Fixes numerous docstrings (primarily for indentation) and adds even more missing __all__ methods. (note that if __all__ is not included, automodapi will try to build an api documentation stub for imported methods .. not really what we want, so please do add __all__ lines at the top of each file for what should be available for import from the file). 