### PR TITLE
Install ltd-conveyor with pip

### DIFF
--- a/.github/workflows/python-tests-doc.yml
+++ b/.github/workflows/python-tests-doc.yml
@@ -78,7 +78,6 @@ jobs:
           conda config --set always_yes yes
           conda install --quiet --file=requirements.txt
           conda install lsst-documenteer-pipelines
-          conda install ltd-conveyor
       - name: install rubin_sim
         shell: bash -l {0}
         run: |
@@ -100,6 +99,10 @@ jobs:
           cd doc
           python metricList.py
           make html
+      - name: Install LTD Conveyor
+        shell: bash -l {0}
+        run: |
+          python -m pip install ltd-conveyor
       - name: upload documentation
         shell: bash -l {0}
         env:


### PR DESCRIPTION
To run `ltd upload` from a PR I've introduced LTD Conveyor 0.8.1, but I've been having trouble with the conda-forge release. This PR switches that installation back to pip for pragmatism.