### PR TITLE
Make sure not to crash if directory is current directory

### DIFF
--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -85,7 +85,8 @@ if __name__ == "__main__":
         # label visits
         newdb_file = mafUtils.labelVisits(filename)
         # Set and create if needed the output directory
-        outDir = opsim + "_sched"
+        # I guess 'meta' really means to be more like 'conditions' of visits here.
+        outDir = opsim + "_meta"
         if os.path.isdir(outDir):
             shutil.rmtree(outDir)
         # Connect to the opsim database

--- a/rubin_sim/maf/utils/opsimUtils.py
+++ b/rubin_sim/maf/utils/opsimUtils.py
@@ -237,6 +237,8 @@ def labelVisits(opsimdb_file):
     from ..db import OpsimDatabase
 
     ddir = os.path.split(opsimdb_file)[0]
+    if len(ddir) == 0:
+        ddir = '.'
     basename = os.path.split(opsimdb_file)[-1]
     runName = basename.replace('.db', '')
     # The way this is written, in order to be able to freely use the information later, we write back


### PR DESCRIPTION
labelVisits creates a new copy of the opsim database, in order to change the proposal labels. 
The new database is created with a new name .. the way the name was created would crash if this was being run from the current working directory, instead of one directory up.
This PR fixes that bug.