### PR TITLE
U/lynnej/update tracking db entry

### DIFF
--- a/rubin_sim/maf/db/trackingDb.py
+++ b/rubin_sim/maf/db/trackingDb.py
@@ -214,7 +214,7 @@ def addRunToDatabase(mafDir, trackingDbFile, opsimGroup=None,
     trackingDb = TrackingDb(database=trackingDbFile)
     autoOpsimRun = None
     autoOpsimComment = None
-    opsimVersion = opsimVersion
+    autoOpsimVersion = None
     opsimDate = None
     mafVersion = None
     mafDate = None

--- a/rubin_sim/maf/db/trackingDb.py
+++ b/rubin_sim/maf/db/trackingDb.py
@@ -214,7 +214,7 @@ def addRunToDatabase(mafDir, trackingDbFile, opsimGroup=None,
     trackingDb = TrackingDb(database=trackingDbFile)
     autoOpsimRun = None
     autoOpsimComment = None
-    opsimVersion = None
+    opsimVersion = opsimVersion
     opsimDate = None
     mafVersion = None
     mafDate = None
@@ -238,10 +238,10 @@ def addRunToDatabase(mafDir, trackingDbFile, opsimGroup=None,
                 opsimDate = tmp[-1]
                 if len(tmp) > 2:
                     opsimDate = tmp[-2]
-            if tmp[0].startswith('OpsimVersion'):
-                opsimVersion = tmp[1]
+            if tmp[0].startswith('rubin_sim.__version__'):
+                autoOpsimVersion = tmp[1]
                 if len(tmp) > 2:
-                    opsimDate = tmp[-2]
+                    autoOpsimVersion = tmp[-2]
     # And convert formats to '-' (again, multiple versions of configs).
     if mafDate is not None:
         if len(mafDate.split('/')) > 1:
@@ -260,6 +260,8 @@ def addRunToDatabase(mafDir, trackingDbFile, opsimGroup=None,
         opsimRun = autoOpsimRun
     if opsimComment is None:
         opsimComment = autoOpsimComment
+    if opsimVersion is None:
+        opsimVersion = autoOpsimVersion
 
     print('Adding to tracking database at %s:' % (trackingDbFile))
     print(' MafDir = %s' % (mafDir))

--- a/rubin_sim/maf/db/trackingDb.py
+++ b/rubin_sim/maf/db/trackingDb.py
@@ -183,26 +183,28 @@ class TrackingDb(object):
 
 
 def addRunToDatabase(mafDir, trackingDbFile, opsimGroup=None,
-                    opsimRun=None, opsimComment=None,
+                    opsimRun=None, opsimComment=None, opsimVersion=None,
                     mafComment=None, dbFile=None):
     """Adds information about a MAF analysis run to a MAF tracking database.
 
     Parameters
     ----------
-    mafDir : str
+    mafDir : `str`
         Path to the directory where the MAF results are located.
-    trackingDb : str or rubin_sim.maf.TrackingDb
-        Full filename (+path) to the tracking database storing the MAF run information or
-        a TrackingDb object.
-    opsimGroup: str, optional
+    trackingDb : `str`
+        Full filename (+path) to the tracking database storing the MAF run information.
+    opsimGroup: `str`, optional
         Name to use to group this run with other opsim runs. Default None.
-    opsimRun : str, optional
-        Name of the opsim run. If not provided, will attempt to use runName from confSummary.txt.
-    opsimComment : str, optional
-        Comment about the opsim run. If not provided, will attempt to use runComment from confSummary.txt.
-    mafComment : str, optional
+    opsimRun : `str`, optional
+        Name of the opsim run. If not provided, will attempt to use runName from configSummary.txt.
+    opsimComment : `str`, optional
+        Comment about the opsim run. If not provided, will attempt to use runComment from configSummary.txt.
+    opsimVersion : `str`, optional
+        Value to use for the opsim version information. If not provided, will attempt to use the value from
+        configSummary.txt
+    mafComment : `str`, optional
         Comment about the MAF analysis. If not provided, no comment will be recorded.
-    dbFile : str, optional
+    dbFile : `str`, optional
         Relative path + name of the opsim database file. If not provided, no location will be recorded.
     """
     mafDir = os.path.abspath(mafDir)

--- a/rubin_sim/maf/runComparison/runComparison.py
+++ b/rubin_sim/maf/runComparison/runComparison.py
@@ -228,7 +228,6 @@ class RunComparison():
                                                slicerName=metric['slicerName'],
                                                summaryName=metric['summaryMetric'],
                                                verbose=verbose)
-            print(mName, tempStats.shape)
             if self.summaryStats is None:
                 self.summaryStats = tempStats
             else:


### PR DESCRIPTION
This PR just removes an extraneous print statement from runComparison (which was printing the shape of summary metric output to screen, as part of an earlier debugging effort), but more importantly, lets the user set the opsim/scheduler version information for the tracking DB (basically, letting us set a release number by hand when adding runs to the database). 