### PR TITLE
U/lynnej/add qso counts

### DIFF
--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -103,7 +103,6 @@ if __name__ == "__main__":
 
         # Some of these metrics are reproduced in other scripts - srd and cadence
         bdict = {}
-        plotbundles = []
 
         for tag in tags:
             fO = batches.fOBatch(colmap=colmap, runName=opsim,
@@ -117,23 +116,20 @@ if __name__ == "__main__":
             bdict.update(rapidrevisit)
 
         # Intranight (pairs/time)
-        intranight_all, plots = batches.intraNight(colmap, opsim, extraSql=None)
+        intranight_all = batches.intraNight(colmap, opsim, extraSql=None)
         bdict.update(intranight_all)
-        plotbundles.append(plots)
 
         # Internight (nights between visits)
         for tag in tags:
-            internight, plots = batches.interNight(colmap, opsim, extraSql=sqls[tag],
+            internight = batches.interNight(colmap, opsim, extraSql=sqls[tag],
                                                    extraMetadata=metadata[tag])
             bdict.update(internight)
-            plotbundles.append(plots)
 
         # Intraseason (length of season)
         for tag in tags:
-            season, plots = batches.seasons(colmap=colmap, runName=opsim,
+            season = batches.seasons(colmap=colmap, runName=opsim,
                                             extraSql=sqls[tag], extraMetadata=metadata[tag])
             bdict.update(season)
-            plotbundles.append(plots)
 
         # Run all metadata metrics, All and just WFD.
         for tag in tags:

--- a/bin/maf/run_moving_calc
+++ b/bin/maf/run_moving_calc
@@ -90,32 +90,31 @@ if __name__ == '__main__':
 
     slicer = batches.setupMoSlicer(args.orbitFile, Hrange, obsFile=args.obsFile)
     # Run discovery metrics using 'trailing' losses
-    bdictT, pbundleT = batches.quickDiscoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
-                                                   objtype=args.objtype,
-                                                   constraintMetadata=args.constraintMetadata,
-                                                   constraint=args.constraint,
-                                                   detectionLosses='trailing',
-                                                   albedo=args.albedo, Hmark=args.hMark)
+    bdictT = batches.quickDiscoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
+                                         objtype=args.objtype,
+                                         constraintMetadata=args.constraintMetadata,
+                                         constraint=args.constraint,
+                                         detectionLosses='trailing',
+                                         albedo=args.albedo, Hmark=args.hMark)
     # Run these discovery metrics
     print("Calculating quick discovery metrics with simple trailing losses.")
     bg = mmb.MoMetricBundleGroup(bdictT, outDir=args.outDir, resultsDb=resultsDb)
     bg.runAll()
 
     # Run all discovery metrics using 'detection' losses
-    bdictD, pbundleD = batches.quickDiscoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
-                                                   objtype=args.objtype,
-                                                   constraintMetadata=args.constraintMetadata,
-                                                   constraint=args.constraint,
-                                                   detectionLosses='detection',
-                                                   albedo=args.albedo, Hmark=args.hMark)
-    bdict, pbundle = batches.discoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
-                                            objtype=args.objtype,
-                                            constraintMetadata=args.constraintMetadata,
-                                            constraint=args.constraint,
-                                            detectionLosses='detection',
-                                            albedo=args.albedo, Hmark=args.hMark)
+    bdictD = batches.quickDiscoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
+                                         objtype=args.objtype,
+                                         constraintMetadata=args.constraintMetadata,
+                                         constraint=args.constraint,
+                                         detectionLosses='detection',
+                                         albedo=args.albedo, Hmark=args.hMark)
+    bdict = batches.discoveryBatch(slicer, colmap=colmap, runName=args.opsimRun,
+                                   objtype=args.objtype,
+                                   constraintMetadata=args.constraintMetadata,
+                                   constraint=args.constraint,
+                                   detectionLosses='detection',
+                                   albedo=args.albedo, Hmark=args.hMark)
     bdictD.update(bdict)
-    pbundleD.append(pbundle)
 
     # Run these discovery metrics
     print("Calculating full discovery metrics with detection losses.")
@@ -124,17 +123,17 @@ if __name__ == '__main__':
 
     # Run all characterization metrics
     if args.characterization.lower() == 'inner':
-        bdictC, pbundle = batches.characterizationInnerBatch(slicer, colmap=colmap, runName=args.opsimRun,
-                                                             objtype=args.objtype, albedo=args.albedo,
-                                                             constraintMetadata=args.constraintMetadata,
-                                                             constraint=args.constraint,
-                                                             Hmark=args.hMark)
+        bdictC = batches.characterizationInnerBatch(slicer, colmap=colmap, runName=args.opsimRun,
+                                                    objtype=args.objtype, albedo=args.albedo,
+                                                    constraintMetadata=args.constraintMetadata,
+                                                    constraint=args.constraint,
+                                                    Hmark=args.hMark)
     elif args.characterization.lower() == 'outer':
-        bdictC, pbundle = batches.characterizationOuterBatch(slicer, colmap=colmap, runName=args.opsimRun,
-                                                             objtype=args.objtype, albedo=args.albedo,
-                                                             constraintMetadata=args.constraintMetadata,
-                                                             constraint=args.constraint,
-                                                             Hmark=args.hMark)
+        bdictC = batches.characterizationOuterBatch(slicer, colmap=colmap, runName=args.opsimRun,
+                                                    objtype=args.objtype, albedo=args.albedo,
+                                                    constraintMetadata=args.constraintMetadata,
+                                                    constraint=args.constraint,
+                                                    Hmark=args.hMark)
     # Run these characterization metrics
     print("Calculating characterization metrics.")
     bg = mmb.MoMetricBundleGroup(bdictC, outDir=args.outDir, resultsDb=resultsDb)

--- a/bin/rs_download_data
+++ b/bin/rs_download_data
@@ -13,7 +13,7 @@ def data_dict():
     to create tar files and follow any sym links
     tar -chvzf maf_may_2021.tgz maf
     """
-    file_dict = {'maf': 'maf_may_2021.tgz',
+    file_dict = {'maf': 'maf_nov_2021.tgz',
                  'maps': 'maps_may_2021.tgz',
                  'movingObjects': 'movingObjects_oct_2021.tgz',
                  'orbits': 'orbits_oct_2021.tgz',

--- a/bin/rs_download_data
+++ b/bin/rs_download_data
@@ -13,7 +13,7 @@ def data_dict():
     to create tar files and follow any sym links
     tar -chvzf maf_may_2021.tgz maf
     """
-    file_dict = {'maf': 'maf_nov_2021.tgz',
+    file_dict = {'maf': 'maf_dec1_2021.tgz',
                  'maps': 'maps_may_2021.tgz',
                  'movingObjects': 'movingObjects_oct_2021.tgz',
                  'orbits': 'orbits_oct_2021.tgz',

--- a/rubin_sim/maf/batches/agnBatch.py
+++ b/rubin_sim/maf/batches/agnBatch.py
@@ -100,7 +100,7 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
     s = slicers.HealpixSlicer(nside=nside, latCol=decCol, lonCol=raCol, latLonDeg=degrees)
     plotDict = {'percentileClip': 95}
     displayDict['subgroup'] = 'TimeLags'
-    displayDict['caption'] = 'Comparison of the time between visits compared to a defined ' \ 
+    displayDict['caption'] = 'Comparison of the time between visits compared to a defined ' \
                              f'sampling gap ({lag} days). '
     bundleList.append(mb.MetricBundle(m, s, constraint=sqls['all'], metadata=metadata['all'],
                                       runName=runName, plotDict=plotDict,

--- a/rubin_sim/maf/batches/agnBatch.py
+++ b/rubin_sim/maf/batches/agnBatch.py
@@ -102,7 +102,7 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
     displayDict['subgroup'] = 'TimeLags'
     displayDict['caption'] = 'Comparison of the time between visits compared to a defined ' \
                              f'sampling gap ({lag} days). '
-    bundleList.append(mb.MetricBundle(m, s, constraint=sqls['all'], metadata=metadata['all'],
+    bundleList.append(mb.MetricBundle(m, s, constraint=extraSql, metadata=extraMetadata,
                                       runName=runName, plotDict=plotDict,
                                       summaryMetrics=summaryMetrics, displayDict=displayDict))
 

--- a/rubin_sim/maf/batches/agnBatch.py
+++ b/rubin_sim/maf/batches/agnBatch.py
@@ -90,4 +90,20 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
                                           summaryMetrics=summaryMetrics,
                                           displayDict=displayDict))
 
+
+    nquist_threshold = 2.2
+    lag = 100
+    summaryMetrics = extendedSummary()
+    summaryMetrics += [metrics.AreaThresholdMetric(lower_threshold=nquist_threshold)]
+    m = metrics.AGN_TimeLagMetric(threshold=nquist_threshold, lag=lag,
+                                  mjdCol=colmap['mjd'])
+    s = slicers.HealpixSlicer(nside=nside, latCol=decCol, lonCol=raCol, latLonDeg=degrees)
+    plotDict = {'percentileClip': 95}
+    displayDict['subgroup'] = 'TimeLags'
+    displayDict['caption'] = 'Comparison of the time between visits compared to a defined ' \ 
+                             f'sampling gap ({lag} days). '
+    bundleList.append(mb.MetricBundle(m, s, constraint=sqls['all'], metadata=metadata['all'],
+                                      runName=runName, plotDict=plotDict,
+                                      summaryMetrics=summaryMetrics, displayDict=displayDict))
+
     return mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/agnBatch.py
+++ b/rubin_sim/maf/batches/agnBatch.py
@@ -9,7 +9,7 @@ __all__ = ['agnBatch']
 
 def agnBatch(colmap=None, runName='opsim', nside=64,
         extraSql=None, extraMetadata=None, slicer=None,
-        display_group='AGN', subgroup='AGN'):
+        display_group='AGN'):
     """Generate a set of statistics about the spacing between nights with observations.
 
      Parameters
@@ -47,7 +47,7 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
         slicer = slicers.HealpixSlicer(nside=nside, latCol=decCol, lonCol=raCol, latLonDeg=degrees,
                                        useCache=False)
 
-    displayDict = {'group': display_group, 'subgroup': subgroup, 'caption': None, 'order': 0}
+    displayDict = {'group': display_group,  'order': 0}
 
     # These agn test magnitude values are determined by looking at the baseline median m5 depths
     # For v1.7.1 these values are:
@@ -63,6 +63,7 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
                                   filterCol=colmap['filter'])
         plotDict = {'color': colors[f]}
         displayDict['order'] = orders[f]
+        displayDict['subgroup'] = 'SFError'
         displayDict['caption'] = 'Expected AGN structure function errors, based on observations in ' \
                                  f'{f} band, for an AGN of magnitude {agn_m5[f]:.2f}'
         bundleList.append(mb.MetricBundle(m, slicer, constraint=sqls[f], metadata=metadata[f],

--- a/rubin_sim/maf/batches/agnBatch.py
+++ b/rubin_sim/maf/batches/agnBatch.py
@@ -49,24 +49,26 @@ def agnBatch(colmap=None, runName='opsim', nside=64,
 
     displayDict = {'group': display_group,  'order': 0}
 
-    # Calculate the number of expected QSOs, based on i-band
-    lsstFilter = 'i'
-    sql = sqls[lsstFilter] + ' and note not like "%DD%"'
-    md = metadata[lsstFilter] + ' and non-DD'
-    summaryMetrics = [metrics.SumMetric(metricName='Total QSO')]
-    zmin = 0.3
-    m = metrics.QSONumberCountsMetric(lsstFilter,
-                                      m5Col=colmap['fiveSigmaDepth'], filterCol=colmap['filter'],
-                                      units='mag', extinction_cut=1.0,
-                                      qlf_module='Shen20',
-                                      qlf_model='A',
-                                      SED_model="Richards06",
-                                      zmin=zmin, zmax=None)
-    displayDict['subgroup'] = 'nQSO'
-    displayDict['caption'] = 'The expected number of QSOs in regions of low dust extinction.'
-    bundleList.append(mb.MetricBundle(m, slicer, constraint=sql, metadata=md,
-                                      runName=runName, summaryMetrics=summaryMetrics,
-                                      displayDict=displayDict))
+    # Calculate the number of expected QSOs, in each band
+    for f in filterlist:
+        sql = sqls[f] + ' and note not like "%DD%"'
+        md = metadata[f] + ' and non-DD'
+        summaryMetrics = [metrics.SumMetric(metricName='Total QSO')]
+        zmin = 0.3
+        m = metrics.QSONumberCountsMetric(f,
+                                          m5Col=colmap['fiveSigmaDepth'],
+                                          filterCol=colmap['filter'],
+                                          units='mag', extinction_cut=1.0,
+                                          qlf_module='Shen20',
+                                          qlf_model='A',
+                                          SED_model="Richards06",
+                                          zmin=zmin, zmax=None)
+        displayDict['subgroup'] = 'nQSO'
+        displayDict['caption'] = 'The expected number of QSOs in regions of low dust extinction,' \
+                                 f'based on detectioin in {f} bandpass.'
+        bundleList.append(mb.MetricBundle(m, slicer, constraint=sql, metadata=md,
+                                          runName=runName, summaryMetrics=summaryMetrics,
+                                          displayDict=displayDict))
 
     # Calculate the expected AGN structure function error
     # These agn test magnitude values are determined by looking at the baseline median m5 depths

--- a/rubin_sim/maf/batches/metadataBatch.py
+++ b/rubin_sim/maf/batches/metadataBatch.py
@@ -398,5 +398,5 @@ def metadataMaps(value, colmap=None, runName='opsim',
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    plotBundles = []
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+
+    return mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/movingObjectsBatch.py
+++ b/rubin_sim/maf/batches/movingObjectsBatch.py
@@ -97,7 +97,6 @@ def quickDiscoveryBatch(slicer, colmap=None, runName='opsim', detectionLosses='d
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     basicPlotDict = {'albedo': albedo, 'Hmark': Hmark, 'npReduce': npReduce,
                      'nxbins': 200, 'nybins': 200}
@@ -175,7 +174,7 @@ def quickDiscoveryBatch(slicer, colmap=None, runName='opsim', detectionLosses='d
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def discoveryBatch(slicer, colmap=None, runName='opsim', detectionLosses='detection', objtype='',
@@ -184,7 +183,6 @@ def discoveryBatch(slicer, colmap=None, runName='opsim', detectionLosses='detect
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     basicPlotDict = {'albedo': albedo, 'Hmark': Hmark, 'npReduce': npReduce,
                      'nxbins': 200, 'nybins': 200}
@@ -491,7 +489,7 @@ def discoveryBatch(slicer, colmap=None, runName='opsim', detectionLosses='detect
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def runCompletenessSummary(bdict, Hmark, times, outDir, resultsDb):
@@ -707,7 +705,6 @@ def characterizationInnerBatch(slicer, colmap=None, runName='opsim', objtype='',
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     # Set up a dictionary to pass to each metric for the column names.
     colkwargs = {'mjdCol': colmap['mjd'], 'seeingCol': colmap['seeingGeom'],
@@ -823,7 +820,7 @@ def characterizationInnerBatch(slicer, colmap=None, runName='opsim', objtype='',
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def characterizationOuterBatch(slicer, colmap=None, runName='opsim', objtype='',
@@ -835,7 +832,6 @@ def characterizationOuterBatch(slicer, colmap=None, runName='opsim', objtype='',
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     # Set up a dictionary to pass to each metric for the column names.
     colkwargs = {'mjdCol': colmap['mjd'], 'seeingCol': colmap['seeingGeom'],
@@ -938,7 +934,7 @@ def characterizationOuterBatch(slicer, colmap=None, runName='opsim', objtype='',
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def runFractionSummary(bdict, Hmark, outDir, resultsDb):

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -248,9 +248,9 @@ def scienceRadarBatch(colmap=None, runName='opsim', extraSql=None, extraMetadata
     bundleList.append(bundle)
 
     # General time intervals
-    bundles, p = timeGaps(colmap=colmap, runName=runName, nside=nside,
-                          extraSql=extraSql, extraMetadata=extraMetadata, slicer=None,
-                          display_group=displayDict['group'], subgroup='TimeGaps')
+    bundles = timeGaps(colmap=colmap, runName=runName, nside=nside,
+                       extraSql=extraSql, extraMetadata=extraMetadata, slicer=None,
+                       display_group=displayDict['group'], subgroup='TimeGaps')
     temp_list = []
     for b in bundles:
         temp_list.append(bundles[b])

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -175,7 +175,7 @@ def scienceRadarBatch(colmap=None, runName='opsim', extraSql=None, extraMetadata
     bundleList.append(bundle)
 
     # AGN structure function error
-    agnBundleDict, pbundle = agnBatch(colmap=colmap, runName=runName, nside=nside)
+    agnBundleDict = agnBatch(colmap=colmap, runName=runName, nside=nside)
     for d in agnBundleDict:
         bundleList.append(agnBundleDict[d])
 

--- a/rubin_sim/maf/batches/skycoverage.py
+++ b/rubin_sim/maf/batches/skycoverage.py
@@ -27,7 +27,6 @@ def meanRADec(colmap=None, runName='opsim', extraSql=None, extraMetadata=None):
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     group = 'RA Dec coverage'
 
@@ -59,7 +58,7 @@ def meanRADec(colmap=None, runName='opsim', extraSql=None, extraMetadata=None):
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def eastWestBias(colmap=None, runName='opsim', extraSql=None, extraMetadata=None):
@@ -80,7 +79,6 @@ def eastWestBias(colmap=None, runName='opsim', extraSql=None, extraMetadata=None
     if colmap is None:
         colmap = ColMapDict('opsimV4')
     bundleList = []
-    plotBundles = []
 
     group = 'East vs West'
 
@@ -123,4 +121,4 @@ def eastWestBias(colmap=None, runName='opsim', extraSql=None, extraMetadata=None
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/timeBatch.py
+++ b/rubin_sim/maf/batches/timeBatch.py
@@ -155,8 +155,7 @@ def intraNight(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetad
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    plotBundles = None
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def interNight(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata=None,
@@ -246,8 +245,7 @@ def interNight(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetad
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    plotBundles = None
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def timeGaps(colmap=None, runName='opsim', nside=64,
@@ -330,8 +328,7 @@ def timeGaps(colmap=None, runName='opsim', nside=64,
         bundleList.append(mb.MetricBundle(m3, slicer, constraint=sqls[f], metadata=metadata[f],
                                           runName=runName, summaryMetrics=summaryMetrics,
                                           plotDict=plotDict, plotFuncs=plotFuncs, displayDict=displayDict))
-    plotBundles = None
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)
 
 
 def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata=None):
@@ -406,5 +403,4 @@ def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    plotBundles = None
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/timeSciBatch.py
+++ b/rubin_sim/maf/batches/timeSciBatch.py
@@ -84,5 +84,4 @@ def phaseGap(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadat
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)
-    plotBundles = None
-    return mb.makeBundlesDictFromList(bundleList), plotBundles
+    return mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/metrics/__init__.py
+++ b/rubin_sim/maf/metrics/__init__.py
@@ -38,3 +38,5 @@ from .scalingMetrics import *
 from .useMetrics import *
 from .brownDwarfMetric import *
 from .agnstructure import *
+from .qsoNumberCountsMetric import *
+from .agnTimeLagMetric import *

--- a/rubin_sim/maf/metrics/agnTimeLagMetric.py
+++ b/rubin_sim/maf/metrics/agnTimeLagMetric.py
@@ -1,0 +1,57 @@
+import numpy as np
+from .baseMetric import BaseMetric
+
+__all__ = ['AGN_TimeLagMetric']
+
+
+class AGN_TimeLagMetric(BaseMetric):
+    def __init__(self, lag=100, z=1, log=False, calcType='mean',
+                 mjdCol='observationStartMJD', filterCol='filter',
+                 metricName='AGN_TimeLag_Metric', **kwargs):
+        self.lag = lag
+        self.z = z
+        self.log = log
+        self.calcType = calcType
+        self.mjdCol = mjdCol
+        self.filterCol = filterCol
+        super().__init__(col=[self.mjdCol, self.filterCol], metricName=metricName, **kwargs)
+
+    # Calculate NQUIST value for time-lag and sampling time (redshift is included in formula if desired)
+    def _getNquistValue(self, caden, lag, z):
+        return (lag / ((1 + z) * caden))
+
+    def run(self, dataSlice, slicePoint=None):
+        # Calculate differences in time between visits
+        mv = np.sort(dataSlice[self.mjdCol])
+        val = np.diff(mv)
+        # If there was only one visit; bail out now.
+        if len(val) == 0:
+            return self.badval
+
+        # Otherwise summarize the time differences as:
+        if self.calcType == 'mean':
+            val = np.mean(val)
+        elif self.calcType == 'min':
+            val = np.min(val)
+        elif self.calcType == 'max':
+            val = np.max(val)
+        else:
+            # find the greatest common divisor
+            val = np.rint(val).astype(int)
+            val = np.gcd.reduce(val)
+
+        # Will always have a value at this point
+        nquist = self._getNquistValue(val, self.lag, self.z)
+        if self.log:
+            nquist = np.log(nquist)
+
+        # Threshold nquist value is 2.2,
+        # hence we are aiming to show values higher than threshold (2.2) value
+        threshold = 2.2
+        if self.log:
+            threshold = np.log(threshold)
+
+        if nquist < threshold:
+            nquist = self.badval
+
+        return nquist

--- a/rubin_sim/maf/metrics/agnTimeLagMetric.py
+++ b/rubin_sim/maf/metrics/agnTimeLagMetric.py
@@ -5,15 +5,18 @@ __all__ = ['AGN_TimeLagMetric']
 
 
 class AGN_TimeLagMetric(BaseMetric):
-    def __init__(self, lag=100, z=1, log=False, calcType='mean',
+    def __init__(self, lag=100, z=1, log=False, threshold=2.2, calcType='mean',
                  mjdCol='observationStartMJD', filterCol='filter',
-                 metricName='AGN_TimeLag_Metric', **kwargs):
+                 metricName=None, **kwargs):
         self.lag = lag
         self.z = z
         self.log = log
+        self.threshold = threshold
         self.calcType = calcType
         self.mjdCol = mjdCol
         self.filterCol = filterCol
+        if metricName is None:
+            metricName = f'AGN_TimeLag_{lag}_days'
         super().__init__(col=[self.mjdCol, self.filterCol], metricName=metricName, **kwargs)
 
     # Calculate NQUIST value for time-lag and sampling time (redshift is included in formula if desired)
@@ -47,7 +50,7 @@ class AGN_TimeLagMetric(BaseMetric):
 
         # Threshold nquist value is 2.2,
         # hence we are aiming to show values higher than threshold (2.2) value
-        threshold = 2.2
+        threshold = self.threshold
         if self.log:
             threshold = np.log(threshold)
 

--- a/rubin_sim/maf/metrics/qsoNumberCountsMetric.py
+++ b/rubin_sim/maf/metrics/qsoNumberCountsMetric.py
@@ -1,0 +1,101 @@
+import os
+import numpy as np
+from scipy import interpolate
+import healpy as hp
+
+from rubin_sim.data import get_data_dir
+from .baseMetric import BaseMetric
+from .exgalM5 import ExgalM5
+
+__all__ = ['QSONumberCountsMetric']
+
+class QSONumberCountsMetric(BaseMetric):
+    """
+    Calculate the number of quasars expected with SNR>=5 according to the Shen et al. (2020) QLF -
+    model A in the redshift range zmin < z < zmax. The 5 sigma depths are obtained using the ExgalM5 metric.
+    Only quasars fainter than the saturation magnitude are counted.
+
+    By default, zmin is 0.3 and zmax is the minimum between 6.7 and the redshift at which the Lyman break
+    matches the effective wavelength of the band. For bands izy, zmax is 6.7. This default choice is to
+    match Table 10.2 for i-band quasar counts in the LSST Science book.
+    """
+    def __init__(self, lsstFilter, m5Col='fiveSigmaDepth', units='mag', extinction_cut=1.0,
+                 filterCol='filter', metricName='QSONumberCountsMetric', qlf_module='Shen20',
+                 qlf_model='A', SED_model="Richards06", zmin=0.3, zmax=None, **kwargs):
+        #Declare the effective wavelengths. 
+        self.effwavelen = {'u':367.0, 'g':482.5, 'r':622.2, 'i':754.5, 'z':869.1, 'y':971.0}
+
+        #Dust Extinction limit. Regions with larger extinction and dropped from the counting.
+        self.extinction_cut = extinction_cut
+
+        #Save the filter information.
+        self.filterCol = filterCol
+        self.lsstFilter = lsstFilter
+
+        #Save zmin and zmax, or set zmax to the default value.
+        # The default zmax is the lower number between 6.7 and the redshift at which the
+        # Lyman break (91.2nm) hits the effective wavelength of the filter.
+        # Note that this means that for i, z and y the default value for zmax is 6.7
+        self.zmin = zmin
+        if zmax is None:
+            zmax = np.min([6.7, self.effwavelen[self.lsstFilter]/91.2-1.0])
+        self.zmax = zmax
+
+        #This calculation uses the ExgalM5 metric. So declare that here.
+        self.exgalM5 = ExgalM5(m5Col=m5Col, units=units)
+
+        #Save the input parameters that relate to the QLF model. 
+        self.qlf_module = qlf_module
+        self.qlf_model  = qlf_model
+        self.SED_model  = SED_model
+        
+        #Read the long tables, which the number of quasars expected for a given band,
+        # qlf_module and qlf_model in a range of redshifts and magnitudes.
+        table_name = "Long_Table.LSST{0}.{1}.{2}.{3}.txt".format(self.lsstFilter,
+                                                                 self.qlf_module,
+                                                                 self.qlf_model,
+                                                                 self.SED_model)
+        data_dir = os.path.join(get_data_dir(), 'maf', 'quasarNumberCounts')
+        filename = os.path.join(data_dir, table_name)
+        with open(filename, 'r') as f:
+            mags = np.array([float(x) for x in f.readline().split()])
+            zs = np.array([float(x) for x in f.readline().split()])
+        mz_data = np.loadtxt(filename, skiprows=2)
+
+        #Make the long table cumulative.
+        c_mz_data = np.zeros((mz_data.shape[0]+1, mz_data.shape[1]+1))
+        c_mz_data[1:,1:] = mz_data
+        c_mz_data = np.cumsum(c_mz_data, axis=0)
+        c_mz_data = np.cumsum(c_mz_data, axis=1)        
+        
+        #Create a 2D interpolation object for the long table. 
+        self.Nqso_cumulative = interpolate.interp2d(zs[:-1], mags[:-1], c_mz_data[:-1,:-1], kind='cubic')
+
+        super().__init__(col=[m5Col, filterCol, 'saturation_mag'],
+                         metricName=metricName,
+                         maps=self.exgalM5.maps,
+                         units=units, **kwargs)
+
+    def run(self, dataSlice, slicePoint=None):
+        # exclude areas with high extinction
+        if slicePoint['ebv'] > self.extinction_cut:
+            return self.badval
+        
+        # For the dataslice, get the 5 sigma limiting magnitude.
+        dS = dataSlice[dataSlice[self.filterCol] == self.lsstFilter]
+        mlim5 = self.exgalM5.run(dS, slicePoint)
+        
+        # Get the slicer pixel area.
+        nside = slicePoint['nside']
+        pix_area = hp.nside2pixarea(nside, degrees=True)
+
+        # tranform that limiting magnitude into an expected number of quasars.
+        # If there is more than one, take the faintest.
+        m_bright = np.max(dS['saturation_mag'])
+        N11 = self.Nqso_cumulative(self.zmin, m_bright)
+        N12 = self.Nqso_cumulative(self.zmin, mlim5 )
+        N21 = self.Nqso_cumulative(self.zmax, m_bright)
+        N22 = self.Nqso_cumulative(self.zmax, mlim5 )
+
+        Nqso =  (N22 - N21 - N12 + N11)*pix_area
+        return Nqso

--- a/tests/maf/test_batches.py
+++ b/tests/maf/test_batches.py
@@ -34,11 +34,15 @@ class TestBatches(unittest.TestCase):
         ack = batches.fOBatch()
         ack = batches.astrometryBatch()
         ack = batches.rapidRevisitBatch()
-        ack = batches.agnBatch()
         ack = batches.timeGaps()
         ack = batches.metadataBasics('airmass')
         ack = batches.metadataBasicsAngle('rotskyPos')
         ack = batches.metadataMaps('fiveSigmaDepth')
+
+    @unittest.skipUnless(os.path.isdir(os.path.join(get_data_dir(), 'maf')),
+                         "Skip these batches unless MAF data present, required for setup")
+    def test_batches_with_mafdata(self):
+        ack = batches.agnBatch()
 
     def test_movingObjectsBatches(self):
         slicer = MoObjSlicer()
@@ -48,7 +52,7 @@ class TestBatches(unittest.TestCase):
         ack = batches.characterizationOuterBatch(slicer)
 
     @unittest.skipUnless(os.path.isdir(os.path.join(get_data_dir(), 'maf')),
-                     "Skipping scienceRadarBatch test because operating without full MAF test data")
+                         "Skipping scienceRadarBatch test because operating without full MAF test data")
     def test_scienceRadar(self):
         # Loading the science radar batch requires reading a significant set of input files
         # This test is skipped if running with the lighter set of test data.
@@ -56,10 +60,9 @@ class TestBatches(unittest.TestCase):
         ack = batches.scienceRadarBatch()
 
     @unittest.skipUnless(os.path.isdir(os.path.join(get_data_dir(), 'maf')),
-                     "Skipping glance test because operating without full MAF test data")
+                         "Skipping glance test because operating without full MAF test data")
     def test_glance(self):
         ack = batches.glanceBatch()
-
         database = os.path.join(get_data_dir(), 'tests', 'example_dbv1.7_0yrs.db')
         opsdb = db.OpsimDatabase(database=database)
         resultsDb = db.ResultsDb(outDir=self.outDir)


### PR DESCRIPTION
This PR adds two AGN metrics: counting the total number of QSO detected in any bandpass (using the coadded extragalactic depth) and counting (something like the number of) time intervals where an appropriate time lag can be measured. 

The QSO tables were generated by Roberto Assef (@rjassef on GitHub, see his version here: https://github.com/rjassef/rubin_sim) but in order to separate generation of data from MAF data, the code to generate these LF has been added to lsst-sims at https://github.com/lsst-sims/create_NQSO_tables 

The data file for the new tables is maf_dec1_2021.tgz at https://lsst.ncsa.illinois.edu/sim-data/rubin_sim_data/maf_dec1_2021.tgz