### PR TITLE
Update healpixSubsetSlicer

### DIFF
--- a/rubin_sim/maf/batches/timeBatch.py
+++ b/rubin_sim/maf/batches/timeBatch.py
@@ -331,7 +331,8 @@ def timeGaps(colmap=None, runName='opsim', nside=64,
     return mb.makeBundlesDictFromList(bundleList)
 
 
-def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata=None):
+def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata=None,
+            slicer=None):
     """Generate a set of statistics about the length and number of seasons.
 
     Parameters
@@ -346,6 +347,8 @@ def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata
         Additional sql constraint to apply to all metrics.
     extraMetadata : str or None, optional
         Additional metadata to use for all outputs.
+    slicer : slicer object (None)
+         Optionally use something other than a HealpixSlicer
 
     Returns
     -------
@@ -364,7 +367,8 @@ def seasons(colmap=None, runName='opsim', nside=64, extraSql=None, extraMetadata
                                                             extraSql=extraSql,
                                                             extraMetadata=metadata)
 
-    slicer = slicers.HealpixSlicer(nside=nside, latCol=decCol, lonCol=raCol, latLonDeg=degrees)
+    if slicer is None:
+        slicer = slicers.HealpixSlicer(nside=nside, latCol=decCol, lonCol=raCol, latLonDeg=degrees)
 
     displayDict = {'group': 'IntraSeason', 'subgroup': 'Season length', 'caption': None, 'order': 0}
 

--- a/rubin_sim/maf/metricBundles/metricBundle.py
+++ b/rubin_sim/maf/metricBundles/metricBundle.py
@@ -163,6 +163,8 @@ class MetricBundle(object):
         self.metricValues = ma.MaskedArray(data=np.empty(shape, dtype),
                                            mask=np.zeros(shape, 'bool'),
                                            fill_value=self.slicer.badval)
+        if hasattr(self.slicer, 'mask'):
+            self.metricValues.mask = self.slicer.mask
 
     def _buildMetadata(self, metadata):
         """If no metadata is provided, process the constraint

--- a/rubin_sim/maf/metricBundles/metricBundleGroup.py
+++ b/rubin_sim/maf/metricBundles/metricBundleGroup.py
@@ -452,7 +452,8 @@ class MetricBundleGroup(object):
         else:
             cache = False
         # Run through all slicepoints and calculate metrics.
-        for i, slice_i in enumerate(slicer):
+        for slice_i in slicer:
+            i = slice_i['slicePoint']['sid']
             slicedata = self.simData[slice_i['idxs']]
             if len(slicedata) == 0:
                 # No data at this slicepoint. Mask data values.
@@ -502,6 +503,7 @@ class MetricBundleGroup(object):
             for b in bDict.values():
                 b.write(outDir=self.outDir, resultsDb=self.resultsDb)
         else:
+            # Just write the metric run information to the resultsDb
             for b in bDict.values():
                 b.writeDb(resultsDb=self.resultsDb)
 

--- a/rubin_sim/maf/plots/spatialPlotters.py
+++ b/rubin_sim/maf/plots/spatialPlotters.py
@@ -175,18 +175,21 @@ class HealpixSkyMap(BasePlotter):
                            'fig':fig.number,
                            'notext': notext}
         # Keys to specify only if present in plotDict
-        for key in ('reso', 'lamb', 'reuse_axes', 'alpha', 'badcolor', 'bgcolor'):
+        for key in ('reso', 'xsize', 'lamb', 'reuse_axes', 'alpha', 'badcolor', 'bgcolor'):
             if key in plotDict:
                 visufunc_params[key] = plotDict[key]
         
         visufunc_params.update(self.healpy_visufunc_params)
         self.healpy_visufunc(metricValue.filled(badval), **visufunc_params)
 
-        # Add a graticule (grid) over the globe.
-        hp.graticule(dpar=30, dmer=30)
         # Add colorbar (not using healpy default colorbar because we want more tickmarks).
         self.ax = plt.gca()
         im = self.ax.get_images()[0]
+
+        # Add a graticule (grid) over the globe.
+        if 'noGraticule' not in plotDict:
+            hp.graticule(dpar=30, dmer=30)
+
         # Add label.
         if plotDict['label'] is not None:
             plt.figtext(0.8, 0.8, '%s' % (plotDict['label']))

--- a/rubin_sim/maf/slicers/baseSpatialSlicer.py
+++ b/rubin_sim/maf/slicers/baseSpatialSlicer.py
@@ -125,7 +125,7 @@ class BaseSpatialSlicer(BaseSlicer):
             (slicepoint=lonCol/latCol value .. usually ra/dec)."""
 
             # Build dict for slicePoint info
-            slicePoint = {}
+            slicePoint = {'sid': islice}
             sx, sy, sz = simsUtils._xyz_from_ra_dec(self.slicePoints['ra'][islice],
                                                     self.slicePoints['dec'][islice])
             # Query against tree.

--- a/rubin_sim/maf/slicers/healpixComCamSlicer.py
+++ b/rubin_sim/maf/slicers/healpixComCamSlicer.py
@@ -85,7 +85,7 @@ class HealpixComCamSlicer(HealpixSlicer):
             (slicepoint=lonCol/latCol value .. usually ra/dec)."""
 
             # Build dict for slicePoint info
-            slicePoint = {}
+            slicePoint = {'sid': islice}
             if self.useCamera:
                 indices = self.sliceLookup[islice]
                 slicePoint['chipNames'] = self.chipNames[islice]

--- a/rubin_sim/maf/slicers/opsimFieldSlicer.py
+++ b/rubin_sim/maf/slicers/opsimFieldSlicer.py
@@ -143,7 +143,7 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
                 if (self.slicePoints['ra'] is not None) or (otherSlicer.slicePoints['ra'] is not None):
                     if (np.array_equal(self.slicePoints['ra'], otherSlicer.slicePoints['ra']) &
                             np.array_equal(self.slicePoints['dec'], otherSlicer.slicePoints['dec']) &
-                            np.array_equal(self.slicePoints['sid'], otherSlicer.slicePoints['sid'])):
+                            np.array_equal(self.slicePoints['fid'], otherSlicer.slicePoints['fid'])):
                         result = True
                 # If they have not been setup, check that they have same fields
                 elif ((otherSlicer.fieldIdColName == self.fieldIdColName) &

--- a/rubin_sim/maf/slicers/opsimFieldSlicer.py
+++ b/rubin_sim/maf/slicers/opsimFieldSlicer.py
@@ -98,20 +98,23 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
         # Set basic properties for tracking field information, in sorted order.
         idxs = np.argsort(fieldData[self.fieldIdColName])
         # Set needed values for slice metadata.
-        self.slicePoints['sid'] = fieldData[self.fieldIdColName][idxs]
+        # Note that 'sid' should be the index in the resulting metricData array
+        # For healpix slicers, this == healpixel id. Here, is array 0-len(idxs).
+        self.slicePoints['fid'] = fieldData[self.fieldIdColName][idxs]
+        self.nslice = len(self.slicePoints['fid'])
+        self.slicePoints['sid'] = np.arange(self.nslice)
         if self.latLonDeg:
             self.slicePoints['ra'] = np.radians(fieldData[self.fieldRaColName][idxs])
             self.slicePoints['dec'] = np.radians(fieldData[self.fieldDecColName][idxs])
         else:
             self.slicePoints['ra'] = fieldData[self.fieldRaColName][idxs]
             self.slicePoints['dec'] = fieldData[self.fieldDecColName][idxs]
-        self.nslice = len(self.slicePoints['sid'])
         self._runMaps(maps)
         # Set up data slicing.
         self.simIdxs = np.argsort(simData[self.simDataFieldIdColName])
         simFieldsSorted = np.sort(simData[self.simDataFieldIdColName])
-        self.left = np.searchsorted(simFieldsSorted, self.slicePoints['sid'], 'left')
-        self.right = np.searchsorted(simFieldsSorted, self.slicePoints['sid'], 'right')
+        self.left = np.searchsorted(simFieldsSorted, self.slicePoints['fid'], 'left')
+        self.right = np.searchsorted(simFieldsSorted, self.slicePoints['fid'], 'right')
 
         self.spatialExtent = [simData[self.simDataFieldIdColName].min(),
                               simData[self.simDataFieldIdColName].max()]
@@ -121,7 +124,7 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
         def _sliceSimData(islice):
             idxs = self.simIdxs[self.left[islice]:self.right[islice]]
             # Build dict for slicePoint info
-            slicePoint = {'sid': islice}
+            slicePoint = {'sid': islice, 'fid': self.slicePoints['fid'][islice]}
             for key in self.slicePoints:
                 if (np.shape(self.slicePoints[key])[0] == self.nslice) & \
                         (key != 'bins') & (key != 'binCol'):

--- a/rubin_sim/maf/slicers/opsimFieldSlicer.py
+++ b/rubin_sim/maf/slicers/opsimFieldSlicer.py
@@ -121,7 +121,7 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
         def _sliceSimData(islice):
             idxs = self.simIdxs[self.left[islice]:self.right[islice]]
             # Build dict for slicePoint info
-            slicePoint = {}
+            slicePoint = {'sid': islice}
             for key in self.slicePoints:
                 if (np.shape(self.slicePoints[key])[0] == self.nslice) & \
                         (key != 'bins') & (key != 'binCol'):

--- a/rubin_sim/maf/slicers/timeIntervalSlicers.py
+++ b/rubin_sim/maf/slicers/timeIntervalSlicers.py
@@ -101,6 +101,7 @@ class TimeIntervalSlicer(BaseSlicer):
                 idxs = [idxs]
 
             slice_points = {
+                "sid": islice,
                 "mjd": self.slicePoints["mjd"][islice],
                 "duration": self.slicePoints["duration"][islice],
             }

--- a/tests/maf/test_HealpixSubsetSlicer.py
+++ b/tests/maf/test_HealpixSubsetSlicer.py
@@ -118,7 +118,8 @@ class TestHealpixSlicerIteration(unittest.TestCase):
     def setUp(self):
         self.cameraFootprintFile = os.path.join(get_data_dir(), 'tests', 'fov_map.npz')
         self.nside = 8
-        self.testslicer = HealpixSubsetSlicer(nside=self.nside, hpid=np.arange(0, 10),
+        self.hpid = np.arange(10, 20)
+        self.testslicer = HealpixSubsetSlicer(nside=self.nside, hpid=self.hpid,
                                               verbose=False, lonCol='ra', latCol='dec',
                                               cameraFootprintFile=self.cameraFootprintFile)
         nvalues = 10000
@@ -136,21 +137,21 @@ class TestHealpixSlicerIteration(unittest.TestCase):
         """Test iteration goes through expected range and ra/dec are in expected range (radians)."""
         npix = hp.nside2npix(self.nside)
         for i, s in enumerate(self.testslicer):
-            self.assertEqual(i, s['slicePoint']['sid'])
+            # We do not expect testslicer.slicePoint['sid'] to == i ..
+            # The slicer will only iterate over the subset
+            self.assertEqual(self.hpid[i], s['slicePoint']['sid'])
             ra = s['slicePoint']['ra']
             dec = s['slicePoint']['dec']
             self.assertGreaterEqual(ra, 0)
             self.assertLessEqual(ra, 2*np.pi)
             self.assertGreaterEqual(dec, -np.pi)
             self.assertLessEqual(dec, np.pi)
-        # npix would count starting at 1, while i counts starting at 0 ..
-        #  so add one to check end point
-        self.assertEqual(i+1, npix)
+        self.assertEqual(i+1, len(self.hpid))
 
     def testGetItem(self):
         """Test getting indexed value."""
         for i, s in enumerate(self.testslicer):
-            np.testing.assert_equal(self.testslicer[i], s)
+            np.testing.assert_equal(self.testslicer[self.hpid[i]], s)
 
 
 class TestHealpixSlicerSlicing(unittest.TestCase):

--- a/tests/maf/test_OpsimFieldSlicer.py
+++ b/tests/maf/test_OpsimFieldSlicer.py
@@ -201,10 +201,10 @@ class TestOpsimFieldSlicerIteration(unittest.TestCase):
         """Test iteration goes through expected range and ra/dec are in expected range (radians)."""
         for fid, ra, dec, s in zip(self.fieldData['fieldId'], np.radians(self.fieldData['fieldRA']),
                                    np.radians(self.fieldData['fieldDec']), self.testslicer):
-            self.assertEqual(fid, s['slicePoint']['sid'])
+            self.assertEqual(fid, s['slicePoint']['fid'])
             self.assertEqual(ra, s['slicePoint']['ra'])
             self.assertEqual(dec, s['slicePoint']['dec'])
-            self.assertGreaterEqual(s['slicePoint']['sid'], 0)
+            self.assertGreaterEqual(s['slicePoint']['fid'], 0)
             self.assertLessEqual(s['slicePoint']['ra'], 2*np.pi)
             self.assertGreaterEqual(s['slicePoint']['dec'], -np.pi)
             self.assertLessEqual(s['slicePoint']['dec'], np.pi)
@@ -217,11 +217,11 @@ class TestOpsimFieldSlicerIteration(unittest.TestCase):
             np.testing.assert_array_equal(dict1['idxs'], dict2['idxs'])
             self.assertDictEqual(dict1['slicePoint'], dict2['slicePoint'])
         n = 0
-        self.assertEqual(self.testslicer[n]['slicePoint']['sid'], self.fieldData['fieldId'][n])
+        self.assertEqual(self.testslicer[n]['slicePoint']['fid'], self.fieldData['fieldId'][n])
         self.assertEqual(self.testslicer[n]['slicePoint']['ra'], np.radians(self.fieldData['fieldRA'][n]))
         self.assertEqual(self.testslicer[n]['slicePoint']['dec'], np.radians(self.fieldData['fieldDec'][n]))
         n = len(self.testslicer) - 1
-        self.assertEqual(self.testslicer[n]['slicePoint']['sid'], self.fieldData['fieldId'][n])
+        self.assertEqual(self.testslicer[n]['slicePoint']['fid'], self.fieldData['fieldId'][n])
         self.assertEqual(self.testslicer[n]['slicePoint']['ra'], np.radians(self.fieldData['fieldRA'][n]))
         self.assertEqual(self.testslicer[n]['slicePoint']['dec'], np.radians(self.fieldData['fieldDec'][n]))
 
@@ -245,7 +245,7 @@ class TestOpsimFieldSlicerSlicing(unittest.TestCase):
         # Set up slicer.
         self.testslicer.setupSlicer(self.simData, self.fieldData)
         for s in self.testslicer:
-            didxs = np.where(self.simData['fieldId'] == s['slicePoint']['sid'])
+            didxs = np.where(self.simData['fieldId'] == s['slicePoint']['fid'])
             binidxs = s['idxs']
             self.assertEqual(len(binidxs), len(didxs[0]))
             if len(binidxs) > 0:


### PR DESCRIPTION
Add sid to all slicers, make metricBundle identify points in metric values using 'Sid' instead of a counter.
Then update the iteration in healpixSubsetSlicer, so it *only* iterates over the healpix points in the subset (instead of iterating over all points and only returning data for the points in the subset).
This makes the healpix subset slicer much more usable for something like DDF fields, while maintaining a full healpix map of metricValues (most of them masked) -- which lets you use things like hp.gnomview without having to rebin the pixel values (which was introducing additional granulation). 