### PR TITLE
Add other requirements to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,12 @@ numpy
 matplotlib
 healpy
 pandas
+numexpr
 palpy
 scipy
 sqlite
 sqlalchemy
+six
 astropy
 pytables
 h5py
@@ -17,3 +19,4 @@ astroplan
 colorcet
 george
 scikit-learn
+requests


### PR DESCRIPTION
Add requests (for rs_download_data), numexpr and six to requirements file. 
These were previously not visible requirements because they came in through other packages but since we use them directly, we should include them. 