### PR TITLE
Add XRB Outburst metric

### DIFF
--- a/rubin_sim/maf/mafContrib/xrbMetrics.py
+++ b/rubin_sim/maf/mafContrib/xrbMetrics.py
@@ -1,0 +1,496 @@
+import glob
+import os
+import numpy as np
+from scipy.stats import loguniform
+from ..metrics import BaseMetric
+from ..slicers import UserPointsSlicer
+from rubin_sim.utils import uniformSphere
+from rubin_sim.photUtils import Dust_values
+from rubin_sim.data import get_data_dir
+from rubin_sim.maf.utils import m52snr
+
+__all__ = ["xrb_lc", "XRBPopMetric", "generateXRBPopSlicer"]
+
+
+class xrb_lc(object):
+    """Synthesize XRB outburst lightcurves."""
+
+    def __init__(self, seed=42):
+
+        dust_properties = Dust_values()
+        self.Ax1 = dust_properties.Ax1
+
+        self.rng = np.random.default_rng(seed)
+
+    def lmxb_abs_mags(self, size=1):
+        """Return LMXB absolute magnitudes per LSST filter.
+
+        Absolute magnitude relation is taken from Casares 2018 (2018MNRAS.473.5195C)
+        Colors are taken from M. Johnson+ 2019 (2019MNRAS.484...19J)
+
+        Parameters
+        ----------
+        size : n
+            Rise, decay, and amplitude parameters.
+
+        Returns
+        -------
+        abs_mags : list of dict
+            Absolute magnitudes for each LSST filter.
+        Porbs: array of float
+            Randomized orbital periods in days
+        """
+
+        # Derive random orbital periods from the sample in Casares 18 Table 4
+        # Since there are significant outliers from a single Gaussian sample,
+        # take random choices with replacement and then perturb them by
+        # the width of the main Gaussian
+        catalog_Porb = np.array(
+            [
+                33.85,
+                6.4713,
+                2.5445,
+                1.7557,
+                1.5420,
+                0.5213,
+                0.4326,
+                0.3441,
+                0.3230,
+                0.3205,
+                0.2852,
+                0.2740,
+                0.2122,
+                0.1699,
+                0.1352,
+                0.117,
+                0.1006,
+            ]
+        )
+
+        sample_Porbs = self.rng.choice(catalog_Porb, size=size)
+        sample_Porbs += self.rng.normal(loc=0.0, scale=0.14, size=size)
+
+        # lmxb_abs_mag_r = 4.6 # johnson+18
+        # Casares 18
+        lmxb_abs_mags_r = 4.64 - 3.69 * np.log10(sample_Porbs)
+
+        return [
+            {
+                "u": lmxb_abs_mag_r + 4.14,
+                "g": lmxb_abs_mag_r + 3.24,
+                "r": lmxb_abs_mag_r,
+                "i": lmxb_abs_mag_r + 0.33,
+                "z": lmxb_abs_mag_r + 1.05,
+                "y": lmxb_abs_mag_r + 2.36,
+            }
+            for lmxb_abs_mag_r in lmxb_abs_mags_r
+        ], sample_Porbs
+
+    def outburst_params(self, size=1):
+        """Return a parameters at random characterizing the outburst.
+
+        Uses distributions from Chen, Shrader, & Livio 1997 (ApJ 491, 312).
+
+        Returns
+        -------
+        params : list of dict
+            Rise, decay, and amplitude parameters.
+        """
+
+        # rise timescale (Fig. 11): 50% 1-2 day lognormal,
+        #                           50% loguniform 0.5-50 days
+
+        flip = self.rng.uniform(size=size)
+        w = flip > 0.5
+        tau_rise = np.zeros(size) * np.nan
+        tau_rise[w] = loguniform.rvs(0.5, 50, size=np.sum(w))
+        tau_rise[~w] = self.rng.lognormal(0, 0.2, size=np.sum(~w)) + 0.3
+
+        # amplitude = rng.lognormal(9,1,size=1)[0]
+        # delta_mag = -2.5 * np.log10(amplitude)
+        # The Chen+ 10**4 X-ray flux amplitudes imply -10 optical delta mags,
+        # which are generally larger than observed.
+        # We'll use a fixed -6 delta mag for simplicity
+        delta_mag = -6
+        amplitude = 10 ** (-0.4 * delta_mag) * np.ones(size)
+
+        tau_decay = self.rng.lognormal(2.9, 0.65, size=size)
+
+        duration = (tau_rise + tau_decay) + np.log(amplitude)
+
+        abs_mags, Porbs = self.lmxb_abs_mags(size=size)
+
+        return [
+            {
+                "tau_rise": tr,
+                "tau_decay": td,
+                "amplitude": amp,
+                "outburst_duration": dur,
+                "abs_mag": abs_mag,
+                "orbital_period": Porb,
+            }
+            for (tr, td, amp, dur, abs_mag, Porb) in zip(
+                tau_rise, tau_decay, amplitude, duration, abs_mags, Porbs
+            )
+        ]
+
+    def fred(self, t, amplitude, tau_rise, tau_decay):
+        """Fast-rise, exponential decay function.
+
+        Amplitude is defined at the peak time = sqrt(tau_rise*tau_decay).
+
+        See e.g., Tarnopolski 2021 for discussion.
+
+        Parameters
+        ----------
+        t : array of floats
+            The times relative to the start of the outburst
+        amplitude : float
+            Peak amplitude
+        tau_rise : float
+            E-folding time for the rise
+        tau_decay : float
+            E-folding time for the decay
+        """
+        return (
+            amplitude
+            * np.exp(2 * np.sqrt(tau_rise / tau_decay))
+            * np.exp(-tau_rise / t - t / tau_decay)
+        )
+
+    def lightcurve(self, t, filtername, params):
+        """Generate an XRB outburst lightcurve for given times and a single filter.
+
+        Uses a simple fast-rise, exponential decay with parameters taken from
+        Chen, Shrader, & Livio 1997 (ApJ 491, 312).
+
+        For now we ignore the late time linear decay (Tetarenko+2018a,b, and
+        references therein.)
+
+        Parameters
+        ----------
+        t : array of floats
+            The times relative to the start of the outburst
+        filtername : str
+            The filter. one of ugrizy
+        params : dict
+            parameters for the FRED lightcurve.
+
+        Returns
+        -------
+        lc : array
+            Magnitudes of the outburst at the specified times in the given filter
+        """
+
+        # fill lightcurve with nondetections
+        lc = np.ones(len(t)) * 99
+
+        # FRED
+        woutburst = (t >= 0) & (t <= params["outburst_duration"])
+        if np.sum(woutburst):
+            lc[woutburst] = params["abs_mag"][filtername] + -2.5 * np.log10(
+                self.fred(
+                    t[woutburst],
+                    params["amplitude"],
+                    params["tau_rise"],
+                    params["tau_decay"],
+                )
+            )
+
+        return lc
+
+    def detectable_duration(self, params, ebv, distance):
+        """Determine time range an outburst is detectable with perfect sampling.
+
+        Does not consider visibility constraints.
+
+        Parameters
+        ----------
+        params : dict
+            lightcurve parameters for xrb_lc
+        ebv : float
+            E(B-V)
+        distance : float
+            distance in kpc
+
+        Returns
+        ----------
+        visible_start_time : float
+            first time relative to outburst start that the outburst could be detected
+        visible_end_time : float
+            last time relative to outburst start that the outburst could be detected
+        """
+
+        nmodelt = 10000
+        t = np.linspace(0, params["outburst_duration"], nmodelt)
+
+        lsst_single_epoch_depth = {
+            "u": 23.9,
+            "g": 25.0,
+            "r": 24.7,
+            "i": 24.0,
+            "z": 23.3,
+            "y": 22.1,
+        }
+
+        visible_start_time = np.inf
+        visible_end_time = -np.inf
+
+        for filtername in ["u", "g", "r", "i", "z", "y"]:
+            mags = self.lightcurve(t, filtername, params)
+
+            # Apply dust extinction on the light curve
+            A_x = self.Ax1[filtername] * ebv
+            mags += A_x
+            distmod = 5 * np.log10(distance * 1.0e3) - 5.0
+            mags += distmod
+
+            wdetectable = np.where(mags <= lsst_single_epoch_depth[filtername])[0]
+            if len(wdetectable) == 0:
+                continue
+
+            if t[wdetectable[0]] < visible_start_time:
+                visible_start_time = t[wdetectable[0]]
+
+            if t[wdetectable[-1]] >= visible_end_time:
+                visible_end_time = t[wdetectable[-1]]
+
+        if np.isinf(visible_start_time):
+            return np.nan, np.nan
+
+        return visible_start_time, visible_end_time
+
+
+class XRBPopMetric(BaseMetric):
+    def __init__(
+        self,
+        metricName="XRBPopMetric",
+        mjdCol="observationStartMJD",
+        m5Col="fiveSigmaDepth",
+        filterCol="filter",
+        nightCol="night",
+        ptsNeeded=2,
+        mjd0=59853.5,
+        outputLc=False,
+        badval=-666,
+        **kwargs,
+    ):
+        # maps = ["DustMap"]
+        self.mjdCol = mjdCol
+        self.m5Col = m5Col
+        self.filterCol = filterCol
+        self.nightCol = nightCol
+        self.ptsNeeded = ptsNeeded
+        # `bool` variable, if True the light curve will be exported
+        self.outputLc = outputLc
+
+        self.lightcurves = xrb_lc()
+        self.mjd0 = mjd0
+
+        dust_properties = Dust_values()
+        self.Ax1 = dust_properties.Ax1
+
+        cols = [self.mjdCol, self.m5Col, self.filterCol, self.nightCol]
+        super(XRBPopMetric, self).__init__(
+            col=cols,
+            units="Detected, 0 or 1",
+            metricName=metricName,
+            # maps=maps,
+            badval=badval,
+            **kwargs,
+        )
+
+    def _ever_detect(self, where_detected):
+        """Simple detection criteria: detect at least a certain number of times"""
+        # Detected data points
+        return np.size(where_detected) >= self.ptsNeeded
+
+    def _number_of_detections(self, where_detected):
+        """Count total number of detections."""
+        return len(where_detected)
+
+    def _early_detect(
+        self, where_detected, time, early_window_days=7.0, n_early_detections=2
+    ):
+        """Detection near the start of the outburst.
+
+        Parameters
+        ----------
+        where_detected : array
+            indexes corresponding to 5sigma detections
+        mags : array
+            magnitudes obtained interpolating models on the dataSlice
+        time : array
+            relative times
+        early_window_days : float
+            time since start of outburst
+        n_early_detections : int
+            number of required early detections
+        """
+
+        return np.sum(time[where_detected] <= early_window_days) >= n_early_detections
+
+    def _mean_time_between_detections(self, t):
+        """Calculate the mean time between detections over the visible interval.
+
+        Parameters
+        ----------
+        t : array
+            Times of detections, bracketed by the start and end visibility times
+
+        Return
+        ----------
+        med_dt : float
+             separation between observations.
+        """
+
+        return np.mean(np.sort(np.diff(t)))
+
+    def _possible_to_detect(self, visible_duration):
+        """Return True if the outburst is ever bright enough for LSST to detect
+
+        Parameters
+        ----------
+        visible_duration : float
+            Length of time the outburst is above LSST's fiducial limiting mag.
+            May be nan.
+
+        Return
+        ----------
+        detectable : bool
+             Return True if outburst is ever detectable by LSST.
+        """
+
+        return ~np.isnan(visible_duration)
+
+    def run(self, dataSlice, slicePoint=None):
+        result = {}
+        t = dataSlice[self.mjdCol] - self.mjd0 - slicePoint["start_time"]
+        mags = np.zeros(t.size, dtype=float)
+
+        for filtername in np.unique(dataSlice[self.filterCol]):
+            infilt = np.where(dataSlice[self.filterCol] == filtername)
+            mags[infilt] = self.lightcurves.lightcurve(
+                t[infilt], filtername, slicePoint["outburst_params"]
+            )
+            # Apply dust extinction on the light curve
+            A_x = self.Ax1[filtername] * slicePoint["ebv"]
+            mags[infilt] += A_x
+
+            distmod = 5 * np.log10(slicePoint["distance"] * 1.0e3) - 5.0
+            mags[infilt] += distmod
+
+        # Find the detected points
+        where_detected = np.where((mags < dataSlice[self.m5Col]))[0]
+        # Filters in which the detections happened
+        filters = dataSlice[self.filterCol][where_detected]
+        # Magnitude uncertainties with Gaussian approximation
+        snr = m52snr(mags, dataSlice[self.m5Col])
+        mags_unc = 2.5 * np.log10(1.0 + 1.0 / snr)
+
+        result["possible_to_detect"] = self._possible_to_detect(
+            slicePoint["visible_duration"]
+        )
+        result["ever_detect"] = self._ever_detect(where_detected)
+        result["early_detect"] = self._early_detect(where_detected, t)
+        result["number_of_detections"] = self._number_of_detections(where_detected)
+        result["mean_time_between_detections"] = self._mean_time_between_detections(
+            [
+                slicePoint["visible_start_time"],
+                *t[where_detected].tolist(),
+                slicePoint["visible_end_time"],
+            ]
+        )
+
+        # Export the light curve
+        if self.outputLc is True:
+            wdet = mags < dataSlice[self.m5Col]
+            mags[~wdet] = 99.0
+            result["lc"] = [
+                dataSlice[self.mjdCol],
+                mags,
+                mags_unc,
+                dataSlice[self.m5Col],
+                dataSlice[self.filterCol],
+            ]
+            result["lc_colnames"] = ("t", "mag", "mag_unc", "maglim", "filter")
+
+        return result
+
+    def reduce_possible_to_detect(self, metric):
+        return metric["possible_to_detect"]
+
+    def reduce_ever_detect(self, metric):
+        return metric["ever_detect"]
+
+    def reduce_early_detect(self, metric):
+        return metric["early_detect"]
+
+    def reduce_number_of_detections(self, metric):
+        return metric["number_of_detections"]
+
+    def reduce_mean_time_between_detections(self, metric):
+        return metric["mean_time_between_detections"]
+
+
+def generateXRBPopSlicer(t_start=1, t_end=3652, n_events=10000, seed=42):
+    """Generate a population of XRB events, and put the info about them
+    into a UserPointSlicer object
+
+    Parameters
+    ----------
+    t_start : float (1)
+        The night to start an XRB outburst on (days)
+    t_end : float (3652)
+        The final night of XRBs events
+    n_events : int (10000)
+        The number of XRB outbursts to generate
+    seed : float
+        The seed passed to np.random
+    """
+
+    rng = np.random.default_rng(seed)
+
+    datadir = get_data_dir()
+    xrb_sample = np.genfromtxt(
+        datadir + "/maf/xrb/sample_xrb_positions.csv.gz", delimiter=","
+    )
+
+    nsamples, nfields = xrb_sample.shape
+
+    xrb_lc_gen = xrb_lc()
+
+    # select a random subsample
+    event_idxs = rng.choice(np.arange(nsamples), size=n_events, replace=True)
+    ra = xrb_sample[event_idxs, 0]
+    dec = xrb_sample[event_idxs, 1]
+    distance_kpc = xrb_sample[event_idxs, 2]
+    ebv = xrb_sample[event_idxs, 3]
+
+    start_times = rng.uniform(low=t_start, high=t_end, size=n_events)
+
+    # Set up the slicer to evaluate the catalog we just made
+    slicer = UserPointsSlicer(ra, dec, latLonDeg=True, badval=0)
+    # Add any additional information about each object to the slicer
+    slicer.slicePoints["start_time"] = start_times
+    slicer.slicePoints["distance"] = distance_kpc
+    # use our own 3-d dust map extinctions
+    slicer.slicePoints["ebv"] = ebv
+    # generate random parameters for this event
+    slicer.slicePoints["outburst_params"] = xrb_lc_gen.outburst_params(size=n_events)
+
+    # determine detectable durations
+    visible_starts = []
+    visible_ends = []
+    visible_durations = []
+    for idx, param in enumerate(slicer.slicePoints["outburst_params"]):
+        start, end = xrb_lc_gen.detectable_duration(param, ebv[idx], distance_kpc[idx])
+        visible_starts.append(start)
+        visible_ends.append(end)
+        visible_durations.append(end - start)
+
+    slicer.slicePoints["visible_start_time"] = visible_starts
+    slicer.slicePoints["visible_end_time"] = visible_ends
+    slicer.slicePoints["visible_duration"] = visible_durations
+
+    return slicer


### PR DESCRIPTION
This PR adds a new X-ray binary outburst metric to `mafContrib`.

One new data file is needed in $RUBIN_SIM_DATA_DIR/maf/xrb : it can be downloaded from [this link](https://drive.google.com/file/d/1z7DICvqhbkX-rne-E2ppsvNbFkOBcIWl/view?usp=sharing).

[This notebook](https://github.com/lsst/rubin_sim_notebooks/blob/u/ebellm/xrb_outburst_metric/maf/science/XRB_Metric.ipynb) shows the metric in use as well as some analysis on the baseline sim.  I will make a PR to `rubin_sim_notebooks` for it as well.