### PR TITLE
U/lynnej/add vatiras

### DIFF
--- a/bin/maf/generate_ss
+++ b/bin/maf/generate_ss
@@ -15,6 +15,7 @@ def generate_ss_commands(dbfiles=None, pops=None, start_mjd=60218.0, split=False
     orbit_files = {
         "granvik_5k": os.path.join(data_dir, "granvik_5k.txt"),
         "granvik_pha_5k": os.path.join(data_dir, "granvik_pha_5k.txt"),
+        "vatira_10k": os.path.join(data_dir, "vatiras_granvik_10k.txt"),
         "l7_5k": os.path.join(data_dir, "l7_5k.txt"),
         "mba_5k": os.path.join(data_dir, "mba_5k.txt"),
         "occ_rmax5_5k": os.path.join(data_dir, "occ_rmax5_5k.txt"),
@@ -25,6 +26,7 @@ def generate_ss_commands(dbfiles=None, pops=None, start_mjd=60218.0, split=False
     objtypes = {
         "granvik_5k": "NEO",
         "granvik_pha_5k": "PHA",
+        "vatira_10k": "Vatira",
         "l7_5k": "TNO",
         "mba_5k": "MBA",
         "occ_rmax5_5k": "OCC_r5",
@@ -44,6 +46,8 @@ def generate_ss_commands(dbfiles=None, pops=None, start_mjd=60218.0, split=False
             "occ_rmax5_5k",
             "occ_rmax20_5k",
         ]
+        # Vatiras will typically have 0 discoveries.
+        # They should be run for the baseline and neo twilight runs.
     elif pops is not None:
         pp = [p for p in orbit_files.keys() if p == pops]
         if len(pp) == 0:
@@ -68,9 +72,7 @@ def generate_ss_commands(dbfiles=None, pops=None, start_mjd=60218.0, split=False
         for pop in pops:
             objtype = objtypes[pop]
             if split:
-                splitfiles = glob.glob(
-                    os.path.join(data_dir, "split") + f"/*{pop}*"
-                )
+                splitfiles = glob.glob(os.path.join(data_dir, "split") + f"/*{pop}*")
                 outfile_split = outfile.replace(".sh", f"_{pop}_split.sh")
                 # If the output split file already exists, remove it (as we append, not write)
                 if os.path.isfile(outfile_split):
@@ -107,7 +109,8 @@ def generate_ss_commands(dbfiles=None, pops=None, start_mjd=60218.0, split=False
                     f" --startTime {start_mjd}"
                 )
                 print(
-                    f"cat {outfile_split} | parallel -j 10 ; {s3}  ; {s4}", file=output_file
+                    f"cat {outfile_split} | parallel -j 10 ; {s3}  ; {s4}",
+                    file=output_file,
                 )
             else:
                 s1 = f"makeLSSTobs --opsimDb {filename} --orbitFile {orbit_files[pop]}"

--- a/bin/rs_download_data
+++ b/bin/rs_download_data
@@ -17,7 +17,7 @@ def data_dict():
         "maf": "maf_2022_2_24.tgz",
         "maps": "maps_2022_2_28.tgz",
         "movingObjects": "movingObjects_oct_2021.tgz",
-        "orbits": "orbits_oct_2021.tgz",
+        "orbits": "orbits_2022_3_1.tgz",
         "sim_baseline": "sim_baseline_nov_2021.tgz",
         "site_models": "site_models_may_2021.tgz",
         "skybrightness": "skybrightness_may_2021.tgz",

--- a/rubin_sim/maf/batches/movingObjectsBatch.py
+++ b/rubin_sim/maf/batches/movingObjectsBatch.py
@@ -38,6 +38,12 @@ __all__ = [
 def ss_population_defaults(objtype):
     "Provide useful default ranges for H, based on objtype of population type."
     defaults = {}
+    defaults["Vatira"] = {
+        "Hrange": [16, 28, 0.2],
+        "Hmark": 22,
+        "magtype": "asteroid",
+        "char": "inner",
+    }
     defaults["PHA"] = {
         "Hrange": [16, 28, 0.2],
         "Hmark": 22,
@@ -362,56 +368,6 @@ def discoveryBatch(
 
     # 3 pairs in 15 and 3 pairs in 30 done in 'quickDiscoveryBatch' (with vis).
 
-    """
-    # 3 pairs in 12
-    md = metadata + ' 3 pairs in 12 nights' + detectionLosses
-    plotDict = {'title': '%s: %s' % (runName, md)}
-    plotDict.update(basicPlotDict)
-    metric = metrics.DiscoveryMetric(nObsPerNight=2, tMin=0, tMax=90. / 60. / 24.,
-                                     nNightsPerWindow=3, tWindow=12, **colkwargs)
-    childMetrics = _setup_child_metrics(metric)
-    bundle = MoMetricBundle(metric, slicer, constraint,
-                                stackerList=[magStacker],
-                                runName=runName, metadata=md,
-                                childMetrics=childMetrics,
-                                plotDict=plotDict, plotFuncs=plotFuncs,
-                                displayDict=displayDict)
-    _configure_child_bundles(bundle)
-    bundleList.append(bundle)
-
-    # 3 pairs in 20
-    md = metadata + ' 3 pairs in 20 nights' + detectionLosses
-    plotDict = {'title': '%s: %s' % (runName, md)}
-    plotDict.update(basicPlotDict)
-    metric = metrics.DiscoveryMetric(nObsPerNight=2, tMin=0, tMax=90. / 60. / 24.,
-                                     nNightsPerWindow=3, tWindow=20, **colkwargs)
-    childMetrics = _setup_child_metrics(metric)
-    bundle = MoMetricBundle(metric, slicer, constraint,
-                                stackerList=[magStacker],
-                                runName=runName, metadata=md,
-                                childMetrics=childMetrics,
-                                plotDict=plotDict, plotFuncs=plotFuncs,
-                                displayDict=displayDict)
-    _configure_child_bundles(bundle)
-    bundleList.append(bundle)
-
-    # 3 pairs in 25
-    md = metadata + ' 3 pairs in 25 nights' + detectionLosses
-    plotDict = {'title': '%s: %s' % (runName, md)}
-    plotDict.update(basicPlotDict)
-    metric = metrics.DiscoveryMetric(nObsPerNight=2, tMin=0, tMax=90. / 60. / 24.,
-                                     nNightsPerWindow=3, tWindow=25, **colkwargs)
-    childMetrics = _setup_child_metrics(metric)
-    bundle = MoMetricBundle(metric, slicer, constraint,
-                                stackerList=[magStacker],
-                                runName=runName, metadata=md,
-                                childMetrics=childMetrics,
-                                plotDict=plotDict, plotFuncs=plotFuncs,
-                                displayDict=displayDict)
-    _configure_child_bundles(bundle)
-    bundleList.append(bundle)
-    """
-
     # 4 pairs in 20
     md = metadata + " 4 pairs in 20 nights" + detectionLosses
     plotDict = {"title": "%s: %s" % (runName, md)}
@@ -468,16 +424,16 @@ def discoveryBatch(
     _configure_child_bundles(bundle)
     bundleList.append(bundle)
 
-    # 3 quads in 30
-    md = metadata + " 3 quads in 30 nights" + detectionLosses
+    # 1 quad
+    md = metadata + " 1 quad in 1 night" + detectionLosses
     plotDict = {"title": "%s: %s" % (runName, md)}
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=4,
         tMin=0,
         tMax=150.0 / 60.0 / 24.0,
-        nNightsPerWindow=3,
-        tWindow=30,
+        nNightsPerWindow=1,
+        tWindow=2,
         **colkwargs,
     )
     childMetrics = _setup_child_metrics(metric)
@@ -557,42 +513,6 @@ def discoveryBatch(
     _configure_child_bundles(bundle)
     bundleList.append(bundle)
 
-    """
-    # 3 pairs in 30, SNR=5
-    md = metadata + ' 3 pairs in 30 nights SNR=5' + detectionLosses
-    plotDict = {'title': '%s: %s' % (runName, md)}
-    plotDict.update(basicPlotDict)
-    metric = metrics.DiscoveryMetric(nObsPerNight=2, tMin=0, tMax=90. / 60. / 24.,
-                                     nNightsPerWindow=3, tWindow=30, snrLimit=5, **colkwargs)
-    childMetrics = _setup_child_metrics(metric)
-    bundle = MoMetricBundle(metric, slicer, constraint,
-                                stackerList=[magStacker],
-                                runName=runName, metadata=md,
-                                childMetrics=childMetrics,
-                                plotDict=plotDict, plotFuncs=plotFuncs,
-                                displayDict=displayDict)
-    _configure_child_bundles(bundle)
-    bundleList.append(bundle)
-
-
-    # 3 pairs in 30, SNR=4
-    md = metadata + ' 3 pairs in 30 nights SNR=4' + detectionLosses
-    plotDict = {'title': '%s: %s' % (runName, md)}
-    plotDict.update(basicPlotDict)
-    metric = metrics.DiscoveryMetric(nObsPerNight=2, tMin=0, tMax=90. / 60. / 24.,
-                                     nNightsPerWindow=3, tWindow=30, snrLimit=4, **colkwargs)
-    childMetrics = _setup_child_metrics(metric)
-    bundle = MoMetricBundle(metric, slicer, constraint,
-                                stackerList=[magStacker],
-                                runName=runName, metadata=md,
-                                childMetrics=childMetrics,
-                                plotDict=plotDict, plotFuncs=plotFuncs,
-                                displayDict=displayDict)
-    _configure_child_bundles(bundle)
-    bundleList.append(bundle)
-    """
-
-    # Play with SNR.  SNR=3
     # 3 pairs in 15, SNR=3
     md = metadata + " 3 pairs in 15 nights SNR=3" + detectionLosses
     plotDict = {"title": "%s: %s" % (runName, md)}


### PR DESCRIPTION
Add vatira population to orbits / moving objects defaults. 
This population should really only be run for the baseline + twilight NEO runs, and potentially other runs as special interest (if they have low solar elongation visits). 

The other change, to the moving objects batch, removes some commented out lines and adds a metric to look for detections based on a quad of visits in a single night (as in, how the twilight NEO visits are trying to detect objects). 