### PR TITLE
add create_metric_set_df

### DIFF
--- a/rubin_sim/maf/runComparison/archive.py
+++ b/rubin_sim/maf/runComparison/archive.py
@@ -9,6 +9,7 @@ __all__ = [
     "get_metric_summaries",
     "get_family_descriptions",
     "describe_families",
+    "create_metric_set_df",
 ]
 
 
@@ -520,3 +521,51 @@ def describe_families(
         fig, ax = None, None  # pylint: disable=invalid-name
 
     return fig, ax
+
+
+def create_metric_set_df(
+    metric_set, metrics, short_name=None, style="-", invert=False, mag=False
+):
+    """Create a DataFrame that defines a metric set.
+
+    Parameters
+    ----------
+    metric_set : `str`
+        The name of a metric set.
+    metrics : `list` [`str`]
+        A list of metric names in the set.
+    short_name : `list` [`str`], optional
+        A list of shorter metric names, by default None
+    style : `list` [`str`], optional
+        The matplotlib line style symbol for lines representing the metric,
+        by default "-"
+    invert : `list` [`bool`], optional
+        Are lower values of the metric better?, by default False
+    mag : `list` [`bool`], optional
+        Is the metric an astronomical magnitude?, by default False
+
+    Returns
+    -------
+    metric_set : `pandas.DataFrame`
+        A table of metrics and normalization and plotting flags defining the
+        content of a metric set.
+    """
+    if short_name is None:
+        short_name = metrics
+
+    metric_set = (
+        pd.DataFrame(
+            {
+                "metric set": metric_set,
+                "metric": metrics,
+                "short_name": short_name,
+                "style": style,
+                "invert": invert,
+                "mag": mag,
+            }
+        )
+        .set_index("metric set")
+        .set_index("metric", append=True, drop=False)
+    )
+
+    return metric_set

--- a/tests/maf/test_archive.py
+++ b/tests/maf/test_archive.py
@@ -167,9 +167,7 @@ class TestArchive(unittest.TestCase):
             metric_set.columns.tolist(),
             ["metric", "short_name", "style", "invert", "mag"],
         )
-        self.assertSequenceEqual(
-            metric_set.index.names, ["metric set", "metric"]
-        )
+        self.assertSequenceEqual(metric_set.index.names, ["metric set", "metric"])
 
 
 run_tests_now = __name__ == "__main__"

--- a/tests/maf/test_archive.py
+++ b/tests/maf/test_archive.py
@@ -48,6 +48,7 @@ class TestArchive(unittest.TestCase):
 
         self.assertEqual(runs.index.name, "run")
 
+    @unittest.skip("skipping long running test.")
     def test_download_runs(self):
         run = maf.get_runs(FAMILY_SOURCE).index.values[0]
 
@@ -155,6 +156,19 @@ class TestArchive(unittest.TestCase):
         plot_metric_set = all_metric_sets.loc["Nvis"]
         fig, ax = maf.describe_families(
             disp_families, summary=summary, plot_metric_set=plot_metric_set
+        )
+
+    def test_create_metric_set_df(self):
+        metrics = ["Urania", "Thalia", "Calliope", "Terpsichore"]
+        metric_set_name = "Muses"
+        metric_set = maf.create_metric_set_df(metric_set_name, metrics)
+        self.assertSequenceEqual(metrics, metric_set.metric.tolist())
+        self.assertSequenceEqual(
+            metric_set.columns.tolist(),
+            ["metric", "short_name", "style", "invert", "mag"],
+        )
+        self.assertSequenceEqual(
+            metric_set.index.names, ["metric set", "metric"]
         )
 
 


### PR DESCRIPTION
As discussed in the scheduler team meeting a few weeks ago, this adds a command to define new metric sets, effectively wrapping cell 42 of the [Getting Data tutorial](https://github.com/lsst/rubin_sim_notebooks/blob/main/maf/tutorial/04_Getting_Data.ipynb) in a function so that a docstring can be added to it.