### PR TITLE
remove Error from names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are only interested in a subset of the data, you can specify which direct
 rs_download_data  --dirs "throughputs,skybrightness,tests,maps"
 ```
 
-If you have a previous installation of rubin_sim or wish to oupdate your data download, the flag `--force` will force an update of the data in the relevant $RUBIN_SIM_DATA_DIR directories. 
+If you have a previous installation of rubin_sim or wish to update your data download, the flag `--force` will force an update of the data in the relevant $RUBIN_SIM_DATA_DIR directories. 
 
 
 **Example notebooks** to test and further explore rubin_sim, are available at [rubin_sim_notebooks](https://github.com/lsst/rubin_sim_notebooks). 

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -181,7 +181,7 @@ def scienceRadarBatch(
             area=18000,
             reduce_func=np.median,
             decreasing=False,
-            metricName="Median Parallax Error (18k)",
+            metricName="Median Parallax Uncert (18k)",
         ),
         metrics.AreaThresholdMetric(
             upper_threshold=good_parallax_limit,
@@ -190,14 +190,14 @@ def scienceRadarBatch(
     ]
     summary.append(
         metrics.PercentileMetric(
-            percentile=95, metricName="95th Percentile Parallax Error"
+            percentile=95, metricName="95th Percentile Parallax Uncert"
         )
     )
     summary.extend(standardSummary())
     for rmag, plotmax in zip(rmags_para, plotmaxVals):
         plotDict = {"xMin": 0, "xMax": plotmax, "colorMin": 0, "colorMax": plotmax}
         metric = metrics.ParallaxMetric(
-            metricName="Parallax Error @ %.1f" % (rmag),
+            metricName="Parallax Uncert @ %.1f" % (rmag),
             rmag=rmag,
             normalize=False,
         )
@@ -281,17 +281,17 @@ def scienceRadarBatch(
             area=18000,
             reduce_func=np.median,
             decreasing=False,
-            metricName="Median Proper Motion Error (18k)",
+            metricName="Median Proper Motion Uncert (18k)",
         )
     ]
     summary.append(
-        metrics.PercentileMetric(metricName="95th Percentile Proper Motion Error")
+        metrics.PercentileMetric(metricName="95th Percentile Proper Motion Uncert")
     )
     summary.extend(standardSummary())
     for rmag, plotmax in zip(rmags_pm, plotmaxVals):
         plotDict = {"xMin": 0, "xMax": plotmax, "colorMin": 0, "colorMax": plotmax}
         metric = metrics.ProperMotionMetric(
-            metricName="Proper Motion Error @ %.1f" % rmag,
+            metricName="Proper Motion Uncert @ %.1f" % rmag,
             rmag=rmag,
             normalize=False,
         )
@@ -755,15 +755,15 @@ def scienceRadarBatch(
     summaryMetrics = extendedSummary()
     summaryMetrics += [metrics.AreaThresholdMetric(upper_threshold=threshold)]
     for f in filterlist:
-        m = metrics.SFErrorMetric(
+        m = metrics.SFUncertMetric(
             mag=agn_m5[f],
-            metricName="AGN SF_error",
+            metricName="AGN SF_uncert",
         )
         plotDict = {"color": colors[f]}
         displayDict["order"] = filterorders[f]
-        displayDict["subgroup"] = "SFError"
+        displayDict["subgroup"] = "SFUncert"
         displayDict["caption"] = (
-            "Expected AGN structure function errors, based on observations in "
+            "Expected AGN structure function uncertainties, based on observations in "
             f"{f} band, for an AGN of magnitude {agn_m5[f]:.2f}"
         )
         bundleList.append(
@@ -1343,7 +1343,7 @@ def scienceRadarBatch(
         stellar_map = maps.StellarDensityMap(filtername=f)
         displayDict["order"] = filterorders[f]
         displayDict["caption"] = (
-            "Number of stars in %s band with an measurement error due to crowding "
+            "Number of stars in %s band with an measurement uncertainty due to crowding "
             "of less than 0.2 mag" % f
         )
         # Configure the NstarsMetric - note 'filtername' refers to the filter in which to evaluate crowding
@@ -1373,7 +1373,7 @@ def scienceRadarBatch(
         stellar_map = maps.StellarDensityMap(filtername=f)
         displayDict["order"] = filterorders[f]
         displayDict["caption"] = (
-            "Number of stars in %s band with an measurement error "
+            "Number of stars in %s band with an measurement uncertainty "
             "of less than 0.2 mag, not considering crowding" % f
         )
         # Configure the NstarsMetric - note 'filtername' refers to the filter in which to evaluate crowding

--- a/rubin_sim/maf/metrics/agnstructure.py
+++ b/rubin_sim/maf/metrics/agnstructure.py
@@ -6,10 +6,10 @@ import warnings
 from rubin_sim.photUtils import Dust_values
 
 
-__all__ = ["SFErrorMetric"]
+__all__ = ["SFUncertMetric"]
 
 
-class SFErrorMetric(BaseMetric):
+class SFUncertMetric(BaseMetric):
     """Structure Function (SF) Uncertainty Metric. Developed on top of LogTGaps
 
     Adapted from Weixiang Yu & Gordon Richards at:
@@ -47,7 +47,7 @@ class SFErrorMetric(BaseMetric):
         units="mag",
         bins=np.logspace(0, np.log10(3650), 11),
         weight=np.full(10, 0.1),
-        metricName="Structure Function Error",
+        metricName="Structure Function Uncert",
         snr_cut=5,
         filterCol="filter",
         dust=True,
@@ -66,7 +66,7 @@ class SFErrorMetric(BaseMetric):
         self.dust = dust
 
         maps = ["DustMap"]
-        super(SFErrorMetric, self).__init__(
+        super(SFUncertMetric, self).__init__(
             col=[self.timesCol, m5Col, filterCol],
             metricName=self.metricName,
             units=units,


### PR DESCRIPTION
Remove "Error" from metric names because it makes it hard to grep log files for actual errors. 