### PR TITLE
bug fix Sed.readSED_fnu

### DIFF
--- a/rubin_sim/photUtils/Sed.py
+++ b/rubin_sim/photUtils/Sed.py
@@ -671,11 +671,11 @@ class Sed(object):
             sourcewavelen.append(float(values[0]))
             sourcefnu.append(float(values[1]))
         f.close()
-        # Convert to numpy arrays.
-        sourcewavelen = numpy.array(sourcewavelen)
-        sourcefnu = numpy.array(sourcefnu)
-        # Convert fnu to flambda
-        self.fnuToflambda(sourcewavelen, sourcefnu)
+        # Convert to numpy arrays and set members
+        self.wavelen = numpy.array(sourcewavelen)
+        self.fnu = numpy.array(sourcefnu)
+        # convert fnu to flambda
+        self.fnuToflambda()
         if name is None:
             self.name = filename
         else:


### PR DESCRIPTION
This commit fixes a bug in `Sed.readSED_fnu`.

Since `self.fnuToflambda` is called with the 2 arrays as arguments, the object members are not updated.

I propose to just set the `wavelen` and `fnu` members from what is read, and then call `self.fnuToflambda` with no argument so that `flambda` be set correctly.

I do not provide a unit test, but here are a few lines of code:
```
import rubin_sim.photUtils.Sed as Sed
lambda_fnu_file = 'sed_lambdaFnu.txt'
my_sed = Sed()
my_sed.readSED_fnu(lambda_fnu_file)
print('Check that Fnu is filled')
print(my_sed.getSED_flambda()[:10])
print('Check that Flambda is filled')
print(my_sed.getSED_flambda()[:10])
```

and data:
```
> head sed_lambdaFnu.txt
# lambda(nm)   Fnu(Jy)
200.0	0.000046
201.0	0.000047
202.0	0.000047
203.0	0.000047
204.0	0.000047
205.0	0.000048
206.0	0.000048
207.0	0.000048
208.0	0.000048
(...)
```
that can be downloaded at:
https://box.in2p3.fr/index.php/s/jHDHY6c5T6CyLgg