### PR TITLE
U/lynnej/run galactic plane metrics

### DIFF
--- a/bin/maf/metadata_dir
+++ b/bin/maf/metadata_dir
@@ -36,6 +36,12 @@ if __name__ == "__main__":
         help="Threshold number of visits per pointing to use to define the WFD footprint."
         "Default value of 750 corresponds to the minimum median value per pointing from the SRD.",
     )
+    parser.add_argument(
+        "--no_clobber",
+        dest="no_clobber",
+        action="store_false",
+        help="Do not remove existing directory outputs",
+    )
     args = parser.parse_args()
 
     # If runNames not given, scan for opsim databases in current directory and use those
@@ -70,10 +76,10 @@ if __name__ == "__main__":
         colmap = batches.ColMapDict()
 
         # Set and create if needed the output directory
-        # I guess 'meta' really means to be more like 'conditions' of visits here.
         outDir = opsim + "_meta"
-        if os.path.isdir(outDir):
-            shutil.rmtree(outDir)
+        if not args.no_clobber:
+            if os.path.isdir(outDir):
+                shutil.rmtree(outDir)
 
         # Find the 'wfd' footprint
         m = CountExplimMetric(col="observationStartMJD")
@@ -173,7 +179,7 @@ if __name__ == "__main__":
             opsimRun=opsim,
             opsimVersion=None,
             opsimDate=None,
-            mafComment="Metadata",
+            mafComment="Simple",
             mafVersion=mafVersion,
             mafDate=mafDate,
             mafDir=outDir,

--- a/rubin_sim/maf/batches/movingObjectsBatch.py
+++ b/rubin_sim/maf/batches/movingObjectsBatch.py
@@ -221,6 +221,9 @@ def quickDiscoveryBatch(
         parentBundle.childBundles["N_Chances"].setDisplayDict(dispDict)
         return
 
+    tMin = 5.0 / 60.0 / 24.0
+    tMax = 90.0 / 60.0 / 24.0
+
     # 3 pairs in 15
     md = info_label + " 3 pairs in 15 nights" + detectionLosses
     # Set up plot dict.
@@ -228,8 +231,8 @@ def quickDiscoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=15,
         **colkwargs,
@@ -256,8 +259,8 @@ def quickDiscoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=30,
         **colkwargs,
@@ -366,6 +369,9 @@ def discoveryBatch(
         }
         parentBundle.childBundles["N_Chances"].setDisplayDict(dispDict)
 
+    tMin = 5.0 / 60.0 / 24.0
+    tMax = 90.0 / 60.0 / 24.0
+
     # 3 pairs in 15 and 3 pairs in 30 done in 'quickDiscoveryBatch' (with vis).
 
     # 4 pairs in 20
@@ -374,8 +380,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=4,
         tWindow=20,
         **colkwargs,
@@ -402,7 +408,7 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=3,
-        tMin=0,
+        tMin=tMin,
         tMax=120.0 / 60.0 / 24.0,
         nNightsPerWindow=3,
         tWindow=30,
@@ -430,7 +436,7 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=4,
-        tMin=0,
+        tMin=tMin,
         tMax=150.0 / 60.0 / 24.0,
         nNightsPerWindow=1,
         tWindow=2,
@@ -461,8 +467,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=15,
         snrLimit=5,
@@ -490,8 +496,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=15,
         snrLimit=4,
@@ -519,8 +525,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=15,
         snrLimit=3,
@@ -549,8 +555,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=3,
         tWindow=15,
         snrLimit=0,
@@ -579,8 +585,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=1,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=1,
         tWindow=5,
         **colkwargs,
@@ -607,8 +613,8 @@ def discoveryBatch(
     plotDict.update(basicPlotDict)
     metric = metrics.DiscoveryMetric(
         nObsPerNight=2,
-        tMin=0,
-        tMax=90.0 / 60.0 / 24.0,
+        tMin=tMin,
+        tMax=tMax,
         nNightsPerWindow=1,
         tWindow=5,
         **colkwargs,

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -43,6 +43,7 @@ def scienceRadarBatch(
     healslicer = slicers.HealpixSlicer(nside=nside)
     subsetPlots = [plots.HealpixSkyMap(), plots.HealpixHistogram()]
 
+    """
     #########################
     #########################
     # SRD, DM, etc
@@ -1256,7 +1257,7 @@ def scienceRadarBatch(
             displayDict=displayDict,
         )
     )
-
+    """
     #########################
     #########################
     # Galactic Plane - TVS/MW
@@ -1351,8 +1352,8 @@ def scienceRadarBatch(
         )
 
     bundleList += list(bundles.values())
-    tmpBundleList = list(bundles.values())
 
+    """
     #########################
     #########################
     # Milky Way
@@ -1517,9 +1518,8 @@ def scienceRadarBatch(
         displayDict=displayDict,
     )
     bundleList.append(bundle)
-
+    """
     # Set the runName for all bundles and return the bundleDict.
-    bundleList = tmpBundleList
     for b in bundleList:
         b.setRunName(runName)
     bundleDict = mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -1262,6 +1262,9 @@ def scienceRadarBatch(
     # Galactic Plane - TVS/MW
     #########################
     #########################
+
+    displayDict = {"group": "Galactic Plane", "subgroup": ""}
+
     footprint_summaries = [metrics.SumMetric()]
     footprint_plotDicts = {"percentileClip": 95}
     filter_summaries = [
@@ -1289,6 +1292,10 @@ def scienceRadarBatch(
     sql = None
     bundles = {}
     for m in science_maps:
+        displayDict["subgroup"] = m
+        displayDict[
+            "caption"
+        ] = f"Footprint relevant for {m} galactic plane science case."
         footprintmetric = metrics.GalPlaneFootprintMetric(science_map=m)
         bundles[f"{m} footprint"] = mb.MetricBundle(
             footprintmetric,
@@ -1297,7 +1304,11 @@ def scienceRadarBatch(
             plotDict=footprint_plotDicts,
             runName=runName,
             summaryMetrics=footprint_summaries,
+            displayDict=displayDict,
         )
+        displayDict[
+            "caption"
+        ] = f"Filter balance in region of {m}  galactic plane science case."
         filtermetric = metrics.GalPlaneTimePerFilterMetric(science_map=m)
         bundles[f"{m} filter"] = mb.MetricBundle(
             filtermetric,
@@ -1306,7 +1317,11 @@ def scienceRadarBatch(
             plotDict=filter_plotdicts,
             runName=runName,
             summaryMetrics=filter_summaries,
+            displayDict=displayDict,
         )
+        displayDict[
+            "caption"
+        ] = f"Timescale intervals in region of {m} galactic plane science case."
         visit_timescalesmetric = metrics.GalPlaneVisitIntervalsTimescaleMetric(
             science_map=m
         )
@@ -1317,7 +1332,11 @@ def scienceRadarBatch(
             plotDict=timescale_plotdicts,
             runName=runName,
             summaryMetrics=timescale_summaries,
+            displayDict=displayDict,
         )
+        displayDict[
+            "caption"
+        ] = f"Seasonal coverage in region of {m} galactic plane science case."
         season_timescalemetric = metrics.GalPlaneSeasonGapsTimescaleMetric(
             science_map=m
         )
@@ -1328,7 +1347,11 @@ def scienceRadarBatch(
             plotDict=timescale_plotdicts,
             runName=runName,
             summaryMetrics=timescale_summaries,
+            displayDict=displayDict,
         )
+
+    bundleList += list(bundles.values())
+    tmpBundleList = list(bundles.values())
 
     #########################
     #########################
@@ -1496,6 +1519,7 @@ def scienceRadarBatch(
     bundleList.append(bundle)
 
     # Set the runName for all bundles and return the bundleDict.
+    bundleList = tmpBundleList
     for b in bundleList:
         b.setRunName(runName)
     bundleDict = mb.makeBundlesDictFromList(bundleList)

--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -43,7 +43,6 @@ def scienceRadarBatch(
     healslicer = slicers.HealpixSlicer(nside=nside)
     subsetPlots = [plots.HealpixSkyMap(), plots.HealpixHistogram()]
 
-    """
     #########################
     #########################
     # SRD, DM, etc
@@ -221,7 +220,7 @@ def scienceRadarBatch(
     # This separates the effect of cadence from depth.
     for rmag in rmags_para:
         metric = metrics.ParallaxMetric(
-            metricName="Normalized Parallax @ %.1f" % (rmag),
+            metricName="Normalized Parallax Uncert @ %.1f" % (rmag),
             rmag=rmag,
             normalize=True,
         )
@@ -312,7 +311,7 @@ def scienceRadarBatch(
     # Normalized proper motion.
     for rmag in rmags_pm:
         metric = metrics.ProperMotionMetric(
-            metricName="Normalized Proper Motion @ %.1f" % rmag,
+            metricName="Normalized Proper Motion Uncert @ %.1f" % rmag,
             rmag=rmag,
             normalize=True,
         )
@@ -1257,7 +1256,7 @@ def scienceRadarBatch(
             displayDict=displayDict,
         )
     )
-    """
+
     #########################
     #########################
     # Galactic Plane - TVS/MW
@@ -1353,7 +1352,6 @@ def scienceRadarBatch(
 
     bundleList += list(bundles.values())
 
-    """
     #########################
     #########################
     # Milky Way
@@ -1518,7 +1516,7 @@ def scienceRadarBatch(
         displayDict=displayDict,
     )
     bundleList.append(bundle)
-    """
+
     # Set the runName for all bundles and return the bundleDict.
     for b in bundleList:
         b.setRunName(runName)

--- a/rubin_sim/maf/batches/srdBatch.py
+++ b/rubin_sim/maf/batches/srdBatch.py
@@ -248,7 +248,7 @@ def astrometryBatch(
             area=18000,
             reduce_func=np.median,
             decreasing=False,
-            metricName="Median Parallax Error (18k)",
+            metricName="Median Parallax Uncert (18k)",
         ),
         metrics.AreaThresholdMetric(
             upper_threshold=good_parallax_limit,
@@ -257,14 +257,14 @@ def astrometryBatch(
     ]
     summary.append(
         metrics.PercentileMetric(
-            percentile=95, metricName="95th Percentile Parallax Error"
+            percentile=95, metricName="95th Percentile Parallax Uncert"
         )
     )
     summary.extend(standardSummary())
     for rmag, plotmax in zip(rmags_para, plotmaxVals):
         plotDict = {"xMin": 0, "xMax": plotmax, "colorMin": 0, "colorMax": plotmax}
         metric = metrics.ParallaxMetric(
-            metricName="Parallax Error @ %.1f" % (rmag),
+            metricName="Parallax Uncert @ %.1f" % (rmag),
             rmag=rmag,
             seeingCol=colmap["seeingGeom"],
             filterCol=colmap["filter"],
@@ -289,7 +289,7 @@ def astrometryBatch(
     # This separates the effect of cadence from depth.
     for rmag in rmags_para:
         metric = metrics.ParallaxMetric(
-            metricName="Normalized Parallax @ %.1f" % (rmag),
+            metricName="Normalized Parallax Uncert @ %.1f" % (rmag),
             rmag=rmag,
             seeingCol=colmap["seeingGeom"],
             filterCol=colmap["filter"],
@@ -371,17 +371,17 @@ def astrometryBatch(
             area=18000,
             reduce_func=np.median,
             decreasing=False,
-            metricName="Median Proper Motion Error (18k)",
+            metricName="Median Proper Motion Uncert (18k)",
         )
     ]
     summary.append(
-        metrics.PercentileMetric(metricName="95th Percentile Proper Motion Error")
+        metrics.PercentileMetric(metricName="95th Percentile Proper Motion Uncert")
     )
     summary.extend(standardSummary())
     for rmag, plotmax in zip(rmags_pm, plotmaxVals):
         plotDict = {"xMin": 0, "xMax": plotmax, "colorMin": 0, "colorMax": plotmax}
         metric = metrics.ProperMotionMetric(
-            metricName="Proper Motion Error @ %.1f" % rmag,
+            metricName="Proper Motion Uncert @ %.1f" % rmag,
             rmag=rmag,
             m5Col=colmap["fiveSigmaDepth"],
             mjdCol=colmap["mjd"],
@@ -404,7 +404,7 @@ def astrometryBatch(
     # Normalized proper motion.
     for rmag in rmags_pm:
         metric = metrics.ProperMotionMetric(
-            metricName="Normalized Proper Motion @ %.1f" % rmag,
+            metricName="Normalized Proper Motion Uncert @ %.1f" % rmag,
             rmag=rmag,
             m5Col=colmap["fiveSigmaDepth"],
             mjdCol=colmap["mjd"],

--- a/rubin_sim/maf/metrics/galplaneTimeSamplingMetrics.py
+++ b/rubin_sim/maf/metrics/galplaneTimeSamplingMetrics.py
@@ -219,5 +219,5 @@ class GalPlaneSeasonGapsTimescaleMetric(BaseMetric):
             # if the season gap is shorter than the expected season gap, count this as 'good'
             good_season_gaps = np.where(season_gaps <= self.expected_season_gap)
             metric_data[tau][good_season_gaps] = 1
-            metric_data[tau] /= len(season_gaps)
+            metric_data[tau] = metric_data[tau].sum() / len(season_gaps)
         return metric_data


### PR DESCRIPTION
Modifies the minimum time interval for solar system metrics (per Mario's request). 
THIS IS IMPORTANT -- the previous solar system metrics on disk and in the summary files, do not use this same minimum time and so will not be directly comparable. It's possible that I should not merge this until we re-run the metrics with this update ..). 

Mostly, it adds a new metric to the metadata for the timespan in a single night, and makes sure to *actually* run the galactic plane metrics in the science bundle. 