### PR TITLE
Update YoungStellarObjectsMetric.py

### DIFF
--- a/rubin_sim/maf/mafContrib/YoungStellarObjectsMetric.py
+++ b/rubin_sim/maf/mafContrib/YoungStellarObjectsMetric.py
@@ -79,7 +79,7 @@ class NYoungStarsMetric(BaseMetric):
         m5Col="fiveSigmaDepth",
         filterCol="filter",
         badval=0,
-        mags={"g": 10.32, "r": 9.28, "i": 7.37},
+        mags={"g": 10.32, "r": 9.28, "i": 7.97},
         galb_limit=90.0,
         snrs={"g": 5.0, "r": 5.0, "i": 5.0},
         nside=64,


### PR DESCRIPTION
I found a small error at line 82. i=7.97 is the correct value. The value 7.37 was referred to mag z that is not used in this metrics