### PR TITLE
Update to sim_baseline v2.1

### DIFF
--- a/.github/workflows/python-all-tests.yml
+++ b/.github/workflows/python-all-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo `pwd`
           ls ${{ github.workspace }}
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       - name: download rubin_sim_data components needed for unit tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/python-docs-only.yml
+++ b/.github/workflows/python-docs-only.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo `pwd`
           ls ${{ github.workspace }}
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       - name: download rubin_sim_data components needed to set up metrics for metricList
         shell: bash -l {0}
         run: |

--- a/.github/workflows/python-tests-doc.yml
+++ b/.github/workflows/python-tests-doc.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo `pwd`
           ls ${{ github.workspace }}
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       - name: download rubin_sim_data components needed for unit tests
         shell: bash -l {0}
         run: |
@@ -83,7 +83,7 @@ jobs:
         run: |
           echo `pwd`
           ls ${{ github.workspace }}
-          python -m pip install . --use-feature=in-tree-build
+          python -m pip install .
       - name: download rubin_sim_data components needed to set up metrics for metricList
         shell: bash -l {0}
         run: |

--- a/bin/rs_download_data
+++ b/bin/rs_download_data
@@ -18,7 +18,7 @@ def data_dict():
         "maps": "maps_2022_2_28.tgz",
         "movingObjects": "movingObjects_oct_2021.tgz",
         "orbits": "orbits_2022_3_1.tgz",
-        "sim_baseline": "sim_baseline_nov_2021.tgz",
+        "sim_baseline": "sim_baseline_2022_5_18.tgz",
         "site_models": "site_models_may_2021.tgz",
         "skybrightness": "skybrightness_may_2021.tgz",
         "skybrightness_pre": "skybrightness_pre_may_2021.tgz",


### PR DESCRIPTION
Use sim_baseline_2022_5_18.tgz (v2.1) instead of the sim_baseline_nov_2021 (v2.0)
