### PR TITLE
U/lynnej/ddf metric names

### DIFF
--- a/rubin_sim/maf/batches/scienceRadarBatch.py
+++ b/rubin_sim/maf/batches/scienceRadarBatch.py
@@ -19,7 +19,7 @@ def scienceRadarBatch(
     benchmarkArea=18000,
     benchmarkNvisits=825,
     minNvisits=750,
-    long_microlensing=False,
+    long_microlensing=True,
     srd_only=False,
 ):
     """A batch of metrics for looking at survey performance relative to the SRD and the main
@@ -27,8 +27,8 @@ def scienceRadarBatch(
 
     Parameters
     ----------
-    long_microlensing : `bool` (False)
-        Add the longer running microlensing metrics to the batch
+    long_microlensing : `bool` (True)
+        Add the longer running microlensing metrics to the batch (subset of crossing times only)
     srd_only : `bool` (False)
         Only return the SRD metrics
     """
@@ -1145,6 +1145,14 @@ def scienceRadarBatch(
         )
 
     if long_microlensing:
+        n_events = 10000
+        # Let's evaluate a subset of the crossing times for these
+        crossing_times = [
+            [10, 20],
+            [20, 30],
+            [30, 60],
+            [200, 500],
+        ]
         metric_Npts = maf.MicrolensingMetric(metricCalc="Npts")
         summaryMetrics = maf.batches.microlensingSummary(metricType="Npts")
         order = 0

--- a/rubin_sim/maf/batches/timeBatch.py
+++ b/rubin_sim/maf/batches/timeBatch.py
@@ -62,7 +62,6 @@ def intraNight(
 
     bundleList = []
     standardStats = standardSummary()
-    subsetPlots = [plots.HealpixSkyMap(), plots.HealpixHistogram()]
 
     if slicer is None:
         slicer = slicers.HealpixSlicer(
@@ -103,7 +102,6 @@ def intraNight(
         sql,
         info_label=md,
         summaryMetrics=standardStats,
-        plotFuncs=subsetPlots,
         displayDict=displayDict,
     )
     bundleList.append(bundle)
@@ -128,7 +126,6 @@ def intraNight(
         sql,
         info_label=md,
         summaryMetrics=standardStats,
-        plotFuncs=subsetPlots,
         displayDict=displayDict,
     )
     bundleList.append(bundle)
@@ -157,7 +154,6 @@ def intraNight(
         sql,
         info_label=md,
         summaryMetrics=standardStats,
-        plotFuncs=subsetPlots,
         displayDict=displayDict,
     )
     bundleList.append(bundle)
@@ -181,7 +177,6 @@ def intraNight(
         extraSql,
         info_label=info_label,
         displayDict=displayDict,
-        plotFuncs=subsetPlots,
         plotDict=plotDict,
         summaryMetrics=standardStats,
     )
@@ -213,7 +208,6 @@ def intraNight(
             sqls[f],
             info_label=info_labels[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -254,7 +248,6 @@ def intraNight(
             sql,
             info_label=info,
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -359,7 +352,7 @@ def interNight(
     """
 
     if colmap is None:
-        colmap = ColMapDict("opsimV4")
+        colmap = ColMapDict("FBS")
 
     bundleList = []
 
@@ -410,7 +403,6 @@ def interNight(
     bundleList.append(bundle)
 
     standardStats = standardSummary()
-    subsetPlots = [plots.HealpixSkyMap(), plots.HealpixHistogram()]
 
     # Look at the total number of unique nights with visits
     metric = metrics.CountUniqueMetric(
@@ -423,7 +415,6 @@ def interNight(
         sqls["all"],
         info_label=info_label["all"],
         displayDict=displayDict,
-        plotFuncs=subsetPlots,
         plotDict={"colorMin": 0, "colorMax": 500},
         summaryMetrics=standardStats,
     )
@@ -445,7 +436,6 @@ def interNight(
             sqls[f],
             info_label=info_label[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -472,7 +462,6 @@ def interNight(
             sqls[f],
             info_label=info_label[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -494,7 +483,6 @@ def interNight(
             sqls[f],
             info_label=info_label[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -707,7 +695,6 @@ def seasons(
     }
 
     standardStats = standardSummary()
-    subsetPlots = [plots.HealpixSkyMap(), plots.HealpixHistogram()]
 
     metric = metrics.SeasonLengthMetric(
         metricName="Median Season Length", mjdCol=colmap["mjd"], reduceFunc=np.median
@@ -733,7 +720,6 @@ def seasons(
             sqls[f],
             info_label=info_label[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -769,7 +755,6 @@ def seasons(
             sqls[f],
             info_label=info_label[f],
             displayDict=displayDict,
-            plotFuncs=subsetPlots,
             plotDict=plotDict,
             summaryMetrics=standardStats,
         )
@@ -791,7 +776,6 @@ def seasons(
         sqls["all"],
         info_label=info_label["all"],
         displayDict=displayDict,
-        plotFuncs=subsetPlots,
         plotDict=plotDict,
         summaryMetrics=standardStats,
     )

--- a/rubin_sim/maf/metrics/simpleMetrics.py
+++ b/rubin_sim/maf/metrics/simpleMetrics.py
@@ -210,7 +210,7 @@ class CountExplimMetric(BaseMetric):
 class CountRatioMetric(BaseMetric):
     """Count the length of a simData column slice, then divide by 'normVal'."""
 
-    def __init__(self, col=None, normVal=1.0, metricName=None, **kwargs):
+    def __init__(self, col=None, normVal=1.0, metricName=None, units="", **kwargs):
         self.normVal = float(normVal)
         if metricName is None:
             metricName = "CountRatio %s div %.1f" % (col, normVal)


### PR DESCRIPTION
Updates the DDF metric batch to add 
* number of sequences per DDF
* histogram of gaps between DDF sequences
* histogram of season lengths per DDF
* preemptively updated parameters for SN in DDFs to require 4 pre / 10 post peak detections
* reorganize metric names -- each DDF metric should now be identifiable by "DD:<fieldname>" in the metric name, and the names more generally match the names for the general WFD equivalent metric (this should make it easier to find DDF versions of similar metrics, etc.)

Also updated science radar a bit to
* run long microlensing metrics by default BUT, only a subset of crossing times. This should add ~1 hr of processing time due to Npts/Fisher matrix calculations for microlensing. Likely could cut that down a bit further by excluding the 10-20 day crossing times. 