### PR TITLE
Make env a global variable

### DIFF
--- a/rubin_sim/maf/show_maf.py
+++ b/rubin_sim/maf/show_maf.py
@@ -202,6 +202,7 @@ def showMaf():
     faviconPath = os.path.join(mafDir, "web/")
     global jsPath
     jsPath = os.path.join(mafDir, "web/")
+    global env
     env = Environment(loader=FileSystemLoader(templateDir))
     # Add 'zip' to jinja templates.
     env.globals.update(zip=zip)


### PR DESCRIPTION
Showmaf wasn't working .. now it is.
This  fix however, does feel like a bit of a hack. 
Making a bunch of variables 'global' (note that it's not just `env` .. I just added `env` to the set of things which were defined as global variables) seems like not the optimal approach, although it works. 
