### PR TITLE
U/lynnej/update season calc

### DIFF
--- a/rubin_sim/maf/metrics/seasonMetrics.py
+++ b/rubin_sim/maf/metrics/seasonMetrics.py
@@ -57,7 +57,7 @@ class SeasonLengthMetric(BaseMetric):
         self,
         mjdCol="observationStartMJD",
         expTimeCol="visitExposureTime",
-        minExpTime=20,
+        minExpTime=16,
         reduceFunc=np.median,
         metricName="SeasonLength",
         **kwargs

--- a/rubin_sim/utils/season_utils.py
+++ b/rubin_sim/utils/season_utils.py
@@ -4,42 +4,45 @@ __all__ = ["calcSeason"]
 
 
 def calcSeason(ra, time):
-    """Calculate the 'season' in the survey for a series of ra/dec/time values of an observation.
-    Based only on the RA of the point on the sky, it calculates the 'season' based on when this
-    point would be overhead. To convert to an integer season label, take np.floor of the returned
-    float season values.
+    """Calculate the 'season' in the survey for a series of ra/time values of an observation.
+    Based only on the RA of the point on the sky, it calculates the 'season' based on when the sun
+    passes through this RA (this marks the start of a 'season').
 
-    Note that seasons should be calculated for a fixed point on the sky, not for each pointing that
-    overlaps a point on the sky.  For example, bad things might happen if you compute the season
-    for observations that overlap RA=0, but were centered on RA=359.
+    Note that seasons should be calculated using the RA of a fixed point on the sky, such as
+    the slicePoint['ra'] if calculating season values for a series of opsim pointings on the sky.
+    To convert to integer seasons, use np.floor(seasons)
 
     Parameters
     ----------
-    ra : float
+    ra : `float`
         The RA (in degrees) of the point on the sky
-    time : np.ndarray
-        The times of the observations, in MJD
+    time : `np.ndarray`
+        The times of the observations, in MJD days
 
     Returns
     -------
-    np.ndarray
-        The season values
+    seasons : `np.array`
+        The season values, as floats.
     """
-    # A reference RA and equinox to anchor ra/season calculation - RA = 0 is overhead at this (local) time.
+    # A reference time and sun RA location to anchor the location of the Sun
     # This time was chosen as it is close to the expected start of the survey.
-    # Generally speaking, this is the equinox (RA=0 is overhead at midnight)
-    Equinox = 60208.00106863426
-    # convert ra into 'days'
-    dayRA = ra / 360 * 365.25
-    firstSeasonBegan = Equinox + dayRA - 0.5 * 365.25
-    seasons = (time - firstSeasonBegan) / 365.25
-    # Set first season to 0
+    refTime = 60575.0
+    refSunRA = 179.20796047239727
+    # Calculate the fraction of the sphere/"year" for this location
+    offset = (ra - refSunRA) / 360 * 365.25
+    # Calculate when the seasons should begin
+    seasonBegan = refTime + offset
+    # Calculate the season value for each point.
+    seasons = (time - seasonBegan) / 365.25
+    # (usually) Set first season at this point to 0
     seasons = seasons - np.floor(np.min(seasons))
     return seasons
-
-    # The value for the equinox above was calculated as follows:
+    # The reference values can be evaluated using:
     # from astropy.time import Time
+    # from astropy.coordinates import get_sun
     # from astropy.coordinates import EarthLocation
     # loc = EarthLocation.of_site('Cerro Pachon')
-    # t = Time('2023-09-21T00:01:32.33', format='isot', scale='utc', location=loc)
-    # print(t.sidereal_time('apparent') - loc.lon, t.utc.mjd)
+    # t = Time('2024-09-22T00:00:00.00', format='isot', scale='utc', location=loc)
+    # print('Ref time', t.utc.mjd)
+    # print('Ref sun RA', get_sun(t).ra.deg, t.utc.mjd)
+    # print('local sidereal time at season start', t.sidereal_time('apparent').deg)


### PR DESCRIPTION
I went through and tested this more carefully, looked at many examples. 
Current "season" calculations based on gaps in the nights between visits are likely to fail, based on this examination (there can be gaps of 150 nights or so in infrequently visited portions of the sky). The new, more precise numbers for the season calculation no longer assign visits into the wrong season (this sometimes happened at the end of seasons, and likely at preferential RA values, as essentially the time of the sync-up of the seasons was slightly wrong). 
Notebook demonstration at https://github.com/lsst/rubin_sim_notebooks/blob/main/maf/science/Test%20Seasons.ipynb