### PR TITLE
Verify JSON output works with python 3

### DIFF
--- a/rubin_sim/maf/slicers/baseSlicer.py
+++ b/rubin_sim/maf/slicers/baseSlicer.py
@@ -276,7 +276,7 @@ class BaseSlicer(with_metaclass(SlicerRegistry, object)):
         if "title" in plotDict:
             header["title"] = plotDict["title"]
         else:
-            header["title"] = "%s %s: %s" % (simDataName, metadata, metricName)
+            header["title"] = "%s %s: %s" % (simDataName, info_label, metricName)
         if "xlabel" in plotDict:
             header["xlabel"] = plotDict["xlabel"]
         else:

--- a/tests/maf/test_JSON.py
+++ b/tests/maf/test_JSON.py
@@ -95,9 +95,6 @@ class TestJSONoutUniSlicer(unittest.TestCase):
     def tearDown(self):
         del self.testslicer
 
-    @unittest.skip(
-        "13 March 2017--Skipping to clear python 3 update. Probably string unicode issues."
-    )
     def test(self):
         metricVal = makeMetricData(self.testslicer, "float", seed=88102231)
         io = self.testslicer.outputJSON(
@@ -127,9 +124,6 @@ class TestJSONoutOneDSlicer2(unittest.TestCase):
     def tearDown(self):
         del self.testslicer
 
-    @unittest.skip(
-        "13 March 2017--Skipping to clear python 3 update. Probably string unicode issues."
-    )
     def test(self):
         metricVal = makeMetricData(self.testslicer, "float", seed=18)
         io = self.testslicer.outputJSON(metricVal)
@@ -154,9 +148,6 @@ class TestJSONoutHealpixSlicer(unittest.TestCase):
     def tearDown(self):
         del self.testslicer
 
-    @unittest.skip(
-        "13 March 2017--Skipping to clear python 3 update. Probably string unicode issues."
-    )
     def test(self):
         metricVal = makeMetricData(self.testslicer, "float", seed=452)
         io = self.testslicer.outputJSON(metricVal)


### PR DESCRIPTION
JSON output now works again in python 3. 

```
from io import StringIO
import rubin_sim.maf as maf

b = maf.MetricBundle.load(<some metric file>)
strio  = b.outputJSON()
header, [list of slice points and metric values] = json.loads(strio.getvalue())
```
Note that this output does not currently include masked values. 
It's possible that for work such as @ehneilsen does with schedview, that outputting masked values from the metric with a defined masked value would be more useful than the current approach (which outputs the 'bin' plus the metric value, so skipped binned = masked). 
