### PR TITLE
replace .asscalar with cast to float

### DIFF
--- a/rubin_sim/scheduler/features/conditions.py
+++ b/rubin_sim/scheduler/features/conditions.py
@@ -551,8 +551,8 @@ class Conditions(object):
             positions.append(
                 {
                     "name": planet_name,
-                    "RA": np.asscalar(self.planet_positions[planet_name + "_RA"]),
-                    "decl": np.asscalar(self.planet_positions[planet_name + "_dec"]),
+                    "RA": float(self.planet_positions[planet_name + "_RA"]),
+                    "decl": float(self.planet_positions[planet_name + "_dec"]),
                 }
             )
         positions.append(


### PR DESCRIPTION
The rubin_sim Conditions._str_ implementation currently uses the .asscalar method of numpy array, which has been dropped in newer versions of numpy. Replace this call so that it works with more recent versions of numpy.