### PR TITLE
Update LST in Conditions when necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ version.py
 
 # pycharm files
 .idea/
+
+# vscode files
+.vscode/

--- a/rubin_sim/scheduler/features/conditions.py
+++ b/rubin_sim/scheduler/features/conditions.py
@@ -16,6 +16,7 @@ from rubin_sim.scheduler.utils import (
     season_calc,
     smallest_signed_angle,
 )
+from rubin_sim.utils import calc_lmst_last
 
 __all__ = ["Conditions"]
 
@@ -288,6 +289,9 @@ class Conditions(object):
 
     @property
     def lmst(self):
+        if self._lmst is None:
+            self._lmst = calc_lmst_last(self.mjd, self.site.longitude_rad)[0]
+
         return self._lmst
 
     @lmst.setter
@@ -302,7 +306,7 @@ class Conditions(object):
         return self._HA
 
     def calc_ha(self):
-        self._HA = np.radians(self._lmst * 360.0 / 24.0) - self.ra
+        self._HA = np.radians(self.lmst * 360.0 / 24.0) - self.ra
         self._HA[np.where(self._HA < 0)] += 2.0 * np.pi
 
     @property

--- a/rubin_sim/scheduler/schedulers/core_scheduler.py
+++ b/rubin_sim/scheduler/schedulers/core_scheduler.py
@@ -402,14 +402,17 @@ class CoreScheduler(object):
 
         print("", file=output)
         print("## Queue", file=output)
-        print(
-            pd.concat(pd.DataFrame(q) for q in self.queue)[
-                ["ID", "flush_by_mjd", "RA", "dec", "filter", "exptime", "note"]
-            ]
-            .set_index("ID")
-            .to_markdown(),
-            file=output,
-        )
+        if len(self.queue) > 0:
+            print(
+                pd.concat(pd.DataFrame(q) for q in self.queue)[
+                    ["ID", "flush_by_mjd", "RA", "dec", "filter", "exptime", "note"]
+                ]
+                .set_index("ID")
+                .to_markdown(),
+                file=output,
+            )
+        else:
+            print("Queue is empty.")
 
         result = output.getvalue()
         return result
@@ -437,10 +440,17 @@ class CoreScheduler(object):
         surveys = []
         survey_list = self.survey_lists[tier]
         for survey_list_elem, survey in enumerate(survey_list):
-            reward = np.max(survey.reward) if tier <= self.survey_index[0] else None
-            chosen = (tier == self.survey_index[0]) and (
-                survey_list_elem == self.survey_index[1]
-            )
+            try:
+                reward = np.max(survey.reward) if tier <= self.survey_index[0] else None
+            except TypeError:
+                reward = None
+
+            try:
+                chosen = (tier == self.survey_index[0]) and (
+                    survey_list_elem == self.survey_index[1]
+                )
+            except:
+                chosen = False
             surveys.append({"survey": str(survey), "reward": reward, "chosen": chosen})
 
         df = pd.DataFrame(surveys).set_index("survey")

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -40,6 +40,18 @@ class TestFeatures(unittest.TestCase):
         self.assertIsInstance(repr(conditions), str)
         self.assertIsInstance(str(conditions), str)
 
+        step_days = 1.0
+
+        # Number of sidereal days in a standard day
+        sidereal_hours_per_day = 24 * (24.0 / 23.9344696)
+        initial_lmst = float(conditions.lmst)
+        conditions.mjd = conditions.mjd + step_days
+        new_lmst = float(conditions.lmst)
+        self.assertAlmostEqual(
+            new_lmst,
+            (initial_lmst + step_days * sidereal_hours_per_day) % 24,
+        )
+
     def test_note_last_observed(self):
 
         note_last_observed = features.NoteLastObserved(note="test")


### PR DESCRIPTION
When the MJD for a conditions object is assigned, _lmst in set to None because the old value is on longer valid. Have the getter compute it anew when needed, rather than returning None.