### PR TITLE
Add area and accum area to reward table

### DIFF
--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -1,0 +1,35 @@
+import os
+import numpy as np
+import pandas as pd
+import unittest
+from rubin_sim.data import get_data_dir
+import rubin_sim.scheduler.basis_functions as basis_functions
+import rubin_sim.scheduler.surveys as surveys
+from rubin_sim.scheduler.model_observatory import ModelObservatory
+
+
+class TestSurveys(unittest.TestCase):
+    def test_field_survey(self):
+        nside = 32
+
+        bfs = []
+        bfs.append(basis_functions.M5DiffBasisFunction(nside=nside))
+        survey = surveys.FieldSurvey(bfs, RA=90.0, dec=-30.0, reward_value=1)
+
+        observatory = ModelObservatory(
+            seeing_db=os.path.join(get_data_dir(), "tests", "seeing.db"),
+        )
+
+        # Check dunder methods
+        self.assertIsInstance(repr(survey), str)
+        self.assertIsInstance(str(survey), str)
+
+        # Check survey access methods
+        conditions = observatory.return_conditions()
+        reward_df = survey.reward_changes(conditions)
+        reward_df = survey.make_reward_df(conditions)
+        self.assertIsInstance(reward_df, pd.DataFrame)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expands methods that produce DataFrames of rewards to include unmasked area, where applicable.  I expect to make further modifications to refine the contents of this DataFrame, but what is here now should get merged now so it doesn't stop progress on moving visualization elements from schedview to rubin_sim (and it doesn't actually make anything worse than it already is).