### PR TITLE
support field surveys with rewards for scalar basis functions

### DIFF
--- a/rubin_sim/scheduler/features/conditions.py
+++ b/rubin_sim/scheduler/features/conditions.py
@@ -496,6 +496,11 @@ class Conditions(object):
         except ImportError:
             return repr(self)
 
+        if self.mjd is None:
+            # Many elements of the pretty str representation rely on
+            # the time beging set. If it is not, just return the ugly form.
+            return repr(self)
+
         output = StringIO()
         print(f"{self.__class__.__qualname__} at {hex(id(self))}", file=output)
         print("============================", file=output)

--- a/rubin_sim/scheduler/surveys/field_survey.py
+++ b/rubin_sim/scheduler/surveys/field_survey.py
@@ -59,10 +59,11 @@ class FieldSurvey(DeepDrillingSurvey):
                 basis_value = bf(conditions, indx=indx)
                 self.reward += basis_value * weight
 
-            self.reward = np.sum(self.reward[indx])
+            if not np.isscalar(self.reward):
+                self.reward = np.sum(self.reward[indx])
 
-            if np.any(np.isinf(self.reward)):
-                self.reward = np.inf
+                if np.any(np.isinf(self.reward)):
+                    self.reward = np.inf
         else:
             # If not feasable, negative infinity reward
             self.reward = -np.inf

--- a/tests/scheduler/test_features.py
+++ b/tests/scheduler/test_features.py
@@ -34,7 +34,7 @@ class TestFeatures(unittest.TestCase):
 
     def test_conditions(self):
         observatory = ModelObservatory(
-            seeing_db=os.path.join(get_data_dir(), "tests", "seeing.db"),
+            seeing_db=os.path.join(get_data_dir(), "tests", "seeing.db")
         )
         conditions = observatory.return_conditions()
         self.assertIsInstance(repr(conditions), str)

--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -26,6 +26,8 @@ class TestSurveys(unittest.TestCase):
 
         # Check survey access methods
         conditions = observatory.return_conditions()
+        reward = survey.calc_reward_function(conditions)
+        self.assertIsInstance(reward, float)
         reward_df = survey.reward_changes(conditions)
         reward_df = survey.make_reward_df(conditions)
         self.assertIsInstance(reward_df, pd.DataFrame)


### PR DESCRIPTION
Auxtel users encountered a problem in schedview caused by scalar basis functions in the field surveys. This fix lets then use either scalar or array basis functions.