### PR TITLE
In rubin_sim/scheduler/detailers/dither_detailer.py fix bug in offset…

### DIFF
--- a/rubin_sim/scheduler/detailers/dither_detailer.py
+++ b/rubin_sim/scheduler/detailers/dither_detailer.py
@@ -52,6 +52,7 @@ class DitherDetailer(BaseDetailer):
                 self.offset = np.array([radius * np.cos(angle), radius * np.sin(angle)])
             offsets = np.tile(self.offset, (n_offsets, 1))
         else:
+            self.rng = np.random.default_rng()
             angle = self.rng.random(n_offsets) * 2 * np.pi
             radius = self.max_dither * np.sqrt(self.rng.random(n_offsets))
             offsets = np.array([radius * np.cos(angle), radius * np.sin(angle)]).T
@@ -232,6 +233,7 @@ class CameraRotDetailer(BaseDetailer):
                 self.offset = self.offsets[night] * self.range + self.min_rot
             offsets = np.ones(n_offsets) * self.offset
         else:
+            self.rng = np.random.default_rng()
             offsets = self.rng.random(n_offsets) * self.range + self.min_rot
 
         offsets = offsets % (2.0 * np.pi)

--- a/rubin_sim/scheduler/detailers/dither_detailer.py
+++ b/rubin_sim/scheduler/detailers/dither_detailer.py
@@ -54,7 +54,7 @@ class DitherDetailer(BaseDetailer):
         else:
             angle = self.rng.random(n_offsets) * 2 * np.pi
             radius = self.max_dither * np.sqrt(self.rng.random(n_offsets))
-            offsets = np.array([radius * np.cos(angle), radius * np.sin(angle)])
+            offsets = np.array([radius * np.cos(angle), radius * np.sin(angle)]).T
 
         return offsets
 


### PR DESCRIPTION
…s array shape.

This PR is to fix a bug in the offsets shape passed by the DitherDetailer when the per_night option is set to False. Below is the traceback from the local simulation before the patch on this branch was included. The proposed fix was validated by removing the rng from the calculated offset and comparing the offsets with per_night=True and per_night=False. 

`ValueError                                Traceback (most recent call last)
Cell In[6], line 1
----> 1 modelObservatory, scheduler, observations = sim_runner(modelObservatory,scheduler,survey_length=2.5,
      2                                                  verbose=True,filename='./2023-03-14_spec_survey.db')

File ~/repos/rubin_sim/rubin_sim/scheduler/sim_runner.py:71, in sim_runner(observatory, scheduler, filter_scheduler, mjd_start, survey_length, filename, delete_past, n_visit_limit, step_none, verbose, extra_info, event_table)
     69 if not scheduler._check_queue_mjd_only(observatory.mjd):
     70     scheduler.update_conditions(observatory.return_conditions())
---> 71 desired_obs = scheduler.request_observation(mjd=observatory.mjd)
     72 if desired_obs is None:
     73     # No observation. Just step into the future and try again.
     74     warnings.warn("No observation. Step into the future and trying again.")

File ~/repos/rubin_sim/rubin_sim/scheduler/schedulers/core_scheduler.py:184, in CoreScheduler.request_observation(self, mjd)
    182     mjd = self.conditions.mjd
    183 if len(self.queue) == 0:
--> 184     self._fill_queue()
    186 if len(self.queue) == 0:
    187     return None

File ~/repos/rubin_sim/rubin_sim/scheduler/schedulers/core_scheduler.py:252, in CoreScheduler._fill_queue(self)
    248     self.survey_index[1] = np.min(np.where(rewards == np.nanmax(rewards)))
    249     # Survey return list of observations
    250     result = self.survey_lists[self.survey_index[0]][
    251         self.survey_index[1]
--> 252     ].generate_observations(self.conditions)
    254     self.queue = result
    256 if len(self.queue) == 0:

File ~/repos/rubin_sim/rubin_sim/scheduler/surveys/base_survey.py:160, in BaseSurvey.generate_observations(self, conditions)
    158 observations = self.generate_observations_rough(conditions)
    159 for detailer in self.detailers:
--> 160     observations = detailer(observations, conditions)
    161 return observations

File ~/repos/rubin_sim/rubin_sim/scheduler/detailers/dither_detailer.py:66, in DitherDetailer.__call__(self, observation_list, conditions)
     63 offsets = self._generate_offsets(len(observation_list), conditions.night)
     65 obs_array = np.concatenate(observation_list)
---> 66 new_ra, new_dec = gnomonic_project_tosky(
     67     offsets[:, 0], offsets[:, 1], obs_array["RA"], obs_array["dec"]
     68 )
     69 for i, obs in enumerate(observation_list):
     70     observation_list[i]["RA"] = new_ra[i]

File ~/repos/rubin_sim/rubin_sim/utils/projections.py:24, in gnomonic_project_tosky(x, y, r_acen, deccen)
     21 def gnomonic_project_tosky(x, y, r_acen, deccen):
     22     """Calculate RA/dec on sky of object with x/y and RA/Cen of field of view.
     23     Returns Ra/dec in radians."""
---> 24     denom = np.cos(deccen) - y * np.sin(deccen)
     25     RA = r_acen + np.arctan2(x, denom)
     26     dec = np.arctan2(
     27         np.sin(deccen) + y * np.cos(deccen), np.sqrt(x * x + denom * denom)
     28     )

ValueError: operands could not be broadcast together with shapes (2,) (3,) 
`