### PR TITLE
U/yoachim/sched array restore

### DIFF
--- a/rubin_sim/scheduler/basis_functions/basis_functions.py
+++ b/rubin_sim/scheduler/basis_functions/basis_functions.py
@@ -82,7 +82,17 @@ class BaseBasisFunction(object):
         self.filtername = filtername
 
     def add_observations_array(self, observations_array, observations_hpid):
-        """Like add_observation, but for loading a whole array of observations at a time"""
+        """Like add_observation, but for loading a whole array of observations at a time
+
+        Parameters
+        ----------
+        observations_array_in : np.array
+            An array of completed observations (with columns like rubin_sim.scheduler.utils.empty_observation).
+            Should be sorted by MJD.
+        observations_hpid_in : np.array
+            Same as observations_array_in, but larger and with an additional column for HEALpix id. Each
+            observation is listed mulitple times, once for every HEALpix it overlaps.
+        """
 
         for feature in self.survey_features:
             self.survey_features[feature].add_observations_array(

--- a/rubin_sim/scheduler/basis_functions/basis_functions.py
+++ b/rubin_sim/scheduler/basis_functions/basis_functions.py
@@ -81,6 +81,16 @@ class BaseBasisFunction(object):
 
         self.filtername = filtername
 
+    def add_observations_array(self, observations_array, observations_hpid):
+        """Like add_observation, but for loading a whole array of observations at a time"""
+
+        for feature in self.survey_features:
+            self.survey_features[feature].add_observations_array(
+                observations_array, observations_hpid
+            )
+        if self.update_on_newobs:
+            self.recalc = True
+
     def add_observation(self, observation, indx=None):
         """
         Parameters

--- a/rubin_sim/scheduler/detailers/detailer.py
+++ b/rubin_sim/scheduler/detailers/detailer.py
@@ -38,6 +38,14 @@ class BaseDetailer(object):
         self.survey_features = {}
         self.nside = nside
 
+    def add_observations_array(self, observations_array, observations_hpid):
+        """Like add_observation, but for loading a whole array of observations at a time"""
+
+        for feature in self.survey_features:
+            self.survey_features[feature].add_observations_array(
+                observations_array, observations_hpid
+            )
+
     def add_observation(self, observation, indx=None):
         """
         Parameters

--- a/rubin_sim/scheduler/features/features.py
+++ b/rubin_sim/scheduler/features/features.py
@@ -319,10 +319,11 @@ class NObservations(BaseSurveyFeature):
             tmp = [name in self.survey_name for name in observations_hpid["note"]]
             valid_indx = valid_indx * np.array(tmp)
         data = observations_hpid[valid_indx]
-        result, _be, _bn = binned_statistic(
-            data["hpid"], np.ones(data.size), statistic="sum", bins=self.bins
-        )
-        self.feature += result
+        if np.size(data) > 0:
+            result, _be, _bn = binned_statistic(
+                data["hpid"], np.ones(data.size), statistic=np.sum, bins=self.bins
+            )
+            self.feature += result
 
     def add_observation(self, observation, indx=None):
         """
@@ -430,13 +431,14 @@ class LastNObsTimes(BaseSurveyFeature):
             ] = False
         data = observations_hpid[valid_indx]
 
-        for i in range(1, self.n_obs + 1):
-            func = LargestN(i)
-            result, _be, _bn = binned_statistic(
-                data["hpid"], data["mjd"], statistic=func, bins=self.bins
-            )
-            # some_vals = np.where(np.sum(result, axis=1) > 0)[0]
-            self.feature[-i, :] = result
+        if np.size(data) > 0:
+            for i in range(1, self.n_obs + 1):
+                func = LargestN(i)
+                result, _be, _bn = binned_statistic(
+                    data["hpid"], data["mjd"], statistic=func, bins=self.bins
+                )
+                # some_vals = np.where(np.sum(result, axis=1) > 0)[0]
+                self.feature[-i, :] = result
 
     def add_observation(self, observation, indx=None):
         if self.filtername is None or observation["filter"][0] in self.filtername:
@@ -600,11 +602,12 @@ class LastObserved(BaseSurveyFeature):
             ] = False
         data = observations_hpid[valid_indx]
 
-        result, _be, _bn = binned_statistic(
-            data["hpid"], data["mjd"], statistic=np.max, bins=self.bins
-        )
-        good = np.where(result > 0)
-        self.feature[good] = result[good]
+        if np.size(data) > 0:
+            result, _be, _bn = binned_statistic(
+                data["hpid"], data["mjd"], statistic=np.max, bins=self.bins
+            )
+            good = np.where(result > 0)
+            self.feature[good] = result[good]
 
     def add_observation(self, observation, indx=None):
         if self.filtername is None:

--- a/rubin_sim/scheduler/schedulers/core_scheduler.py
+++ b/rubin_sim/scheduler/schedulers/core_scheduler.py
@@ -91,16 +91,22 @@ class CoreScheduler(object):
         self.rotator_limits = np.sort(np.radians(rotator_limits))
 
     def flush_queue(self):
-        """ "
-        Like it sounds, clear any currently queued desired observations.
-        """
+        """Like it sounds, clear any currently queued desired observations."""
         self.queue = []
         self.survey_index = [None, None]
 
     def add_observations_array(self, obs):
-        lol_hpids = self.pointing2hpindx(obs['RA'], obs['dec'])
+        """Like add_observation, but for passing many observations at once.
+
+        Assigns overlapping HEALpix IDs to each observation, then passes
+        the observation array and constructed observations + healpix id to each survey.
+        """
+        obs.sort(order="mjd")
+        # Generate list-of-lists for HEALPix IDs for each pointing
+        lol_hpids = self.pointing2hpindx(obs["RA"], obs["dec"])
         hpids = []
         big_array_indx = []
+        # Unravel the list-of-lists
         for i, indxs in enumerate(lol_hpids):
             for indx in indxs:
                 hpids.append(indx)
@@ -110,7 +116,7 @@ class CoreScheduler(object):
         types = [obs[name].dtype for name in names]
 
         names.append(hpids.dtype.names[0])
-        types.append(hpids['hpid'].dtype)
+        types.append(hpids["hpid"].dtype)
         ndt = list(zip(names, types))
 
         obs_array_hpid = np.empty(hpids.size, dtype=ndt)

--- a/rubin_sim/scheduler/schedulers/core_scheduler.py
+++ b/rubin_sim/scheduler/schedulers/core_scheduler.py
@@ -97,6 +97,30 @@ class CoreScheduler(object):
         self.queue = []
         self.survey_index = [None, None]
 
+    def add_observations_array(self, obs):
+        lol_hpids = self.pointing2hpindx(obs['RA'], obs['dec'])
+        hpids = []
+        big_array_indx = []
+        for i, indxs in enumerate(lol_hpids):
+            for indx in indxs:
+                hpids.append(indx)
+                big_array_indx.append(i)
+        hpids = np.array(hpids, dtype=[("hpid", int)])
+        names = list(obs.dtype.names)
+        types = [obs[name].dtype for name in names]
+
+        names.append(hpids.dtype.names[0])
+        types.append(hpids['hpid'].dtype)
+        ndt = list(zip(names, types))
+
+        obs_array_hpid = np.empty(hpids.size, dtype=ndt)
+        obs_array_hpid[list(obs.dtype.names)] = obs[big_array_indx]
+        obs_array_hpid[hpids.dtype.names[0]] = hpids
+
+        for surveys in self.survey_lists:
+            for survey in surveys:
+                survey.add_observations_array(obs, obs_array_hpid)
+
     def add_observation(self, observation):
         """
         Record a completed observation and update features accordingly.

--- a/rubin_sim/scheduler/surveys/base_survey.py
+++ b/rubin_sim/scheduler/surveys/base_survey.py
@@ -93,6 +93,29 @@ class BaseSurvey(object):
     def get_scheduled_obs(self):
         return self.scheduled_obs
 
+    def add_observations_array(self, observations_array_in, observations_hpid_in):
+        """Add an array of observations rather than one at a time"""
+
+        to_ignore = np.in1d(observations_array_in["note"], self.ignore_obs)
+        observations_array = observations_array_in[~to_ignore]
+
+        good = np.in1d(observations_hpid_in["ID"], observations_array["ID"])
+        observations_hpid = observations_hpid_in[good]
+
+        for feature in self.extra_features:
+            self.extra_features[feature].add_observations_array(
+                observations_array, observations_hpid
+            )
+        for bf in self.extra_basis_functions:
+            self.extra_basis_functions[bf].add_observations_array(
+                observations_array, observations_hpid
+            )
+        for bf in self.basis_functions:
+            bf.add_observations_array(observations_array, observations_hpid)
+        for detailer in self.detailers:
+            detailer.add_observations_array(observations_array, observations_hpid)
+        self.reward_checked = False
+
     def add_observation(self, observation, **kwargs):
         # Check each posible ignore string
         checks = [io not in str(observation["note"]) for io in self.ignore_obs]

--- a/rubin_sim/scheduler/surveys/base_survey.py
+++ b/rubin_sim/scheduler/surveys/base_survey.py
@@ -94,13 +94,25 @@ class BaseSurvey(object):
         return self.scheduled_obs
 
     def add_observations_array(self, observations_array_in, observations_hpid_in):
-        """Add an array of observations rather than one at a time"""
+        """Add an array of observations rather than one at a time
+
+        Parameters
+        ----------
+        observations_array_in : np.array
+            An array of completed observations (with columns like rubin_sim.scheduler.utils.empty_observation).
+        observations_hpid_in : np.array
+            Same as observations_array_in, but larger and with an additional column for HEALpix id. Each
+            observation is listed mulitple times, once for every HEALpix it overlaps."""
+
+        # Just to be sure things are sorted
+        observations_array_in.sort(order="mjd")
+        observations_hpid_in.sort(order="mjd")
 
         to_ignore = np.in1d(observations_array_in["note"], self.ignore_obs)
         observations_array = observations_array_in[~to_ignore]
 
-        good = np.in1d(observations_hpid_in["ID"], observations_array["ID"])
-        observations_hpid = observations_hpid_in[good]
+        to_ignore = np.in1d(observations_hpid_in["note"], self.ignore_obs)
+        observations_hpid = observations_hpid_in[~to_ignore]
 
         for feature in self.extra_features:
             self.extra_features[feature].add_observations_array(

--- a/rubin_sim/scheduler/surveys/long_gap_survey.py
+++ b/rubin_sim/scheduler/surveys/long_gap_survey.py
@@ -85,6 +85,14 @@ class LongGapSurvey(BaseSurvey):
         self.avoid_zenith = avoid_zenith
         self.mjd_step = hour_step / 24.0
 
+    def add_observations_array(self, observations_array_in, observations_hpid_in):
+        self.blob_survey.add_observations_array(
+            observations_array_in, observations_hpid_in
+        )
+        self.scripted_survey.add_observations_array(
+            observations_array_in, observations_hpid_in
+        )
+
     def add_observation(self, observation, **kwargs):
         self.blob_survey.add_observation(observation, **kwargs)
         self.scripted_survey.add_observation(observation, **kwargs)

--- a/rubin_sim/scheduler/surveys/scripted_surveys.py
+++ b/rubin_sim/scheduler/surveys/scripted_surveys.py
@@ -76,10 +76,15 @@ class ScriptedSurvey(BaseSurvey):
                 detailer.add_observations_array(observations_array, observations_hpid)
 
             # If scripted_id, note, and filter match, then consider the observation completed.
-            completed = np.char.add(observations_array["scripted_id"].astype(str), observations_array["note"])
+            completed = np.char.add(
+                observations_array["scripted_id"].astype(str),
+                observations_array["note"],
+            )
             completed = np.char.add(completed, observations_array["filter"])
 
-            wanted = np.char.add(self.obs_wanted["scripted_id"].astype(str), self.obs_wanted["note"])
+            wanted = np.char.add(
+                self.obs_wanted["scripted_id"].astype(str), self.obs_wanted["note"]
+            )
             wanted = np.char.add(wanted, self.obs_wanted["filter"])
 
             indx = np.in1d(wanted, completed)

--- a/rubin_sim/scheduler/utils/utils.py
+++ b/rubin_sim/scheduler/utils/utils.py
@@ -136,7 +136,7 @@ def set_default_nside(nside=None):
 
 
 def restore_scheduler(
-    observation_id, scheduler, observatory, in_obs, filter_sched=None
+    observation_id, scheduler, observatory, in_obs, filter_sched=None, fast=True
 ):
     """Put the scheduler and observatory in the state they were in. Handy for checking reward fucnction
 
@@ -167,12 +167,19 @@ def restore_scheduler(
     # replay the observations back into the scheduler
     # In the future, may be able to replace this with a
     # faster .add_observations_array method.
-    for obs in observations:
-        scheduler.add_observation(obs)
-        if filter_sched is not None:
-            filter_sched.add_observation(obs)
+
+    if fast:
+        scheduler.add_observations_array(observations)
+        obs = in_obs[-1]
+    else:
+        for obs in observations:
+            scheduler.add_observation(obs)
 
     if filter_sched is not None:
+        # We've assumed the filter scheduler doesn't have any filters
+        # May need to call the add_observation method on it if that
+        # changes.
+
         # Make sure we have mounted the right filters for the night
         # XXX--note, this might not be exact, but should work most of the time.
         mjd_start_night = np.min(

--- a/rubin_sim/scheduler/utils/utils.py
+++ b/rubin_sim/scheduler/utils/utils.py
@@ -154,6 +154,9 @@ def restore_scheduler(
     filter_sched : rubin_sim.scheduler.scheduler object
         The filter scheduler. Note that we don't look up the official end of the previous night,
         so there is potential for the loaded filters to not match.
+    fast : bool (True)
+        If True, loads observations and passes them as an array to the `add_observations_array`
+        method. If False, passes observations individually with `add_observation` method.
     """
     if type(in_obs) == str:
         sc = SchemaConverter()

--- a/rubin_sim/scheduler/utils/utils.py
+++ b/rubin_sim/scheduler/utils/utils.py
@@ -170,7 +170,7 @@ def restore_scheduler(
 
     if fast:
         scheduler.add_observations_array(observations)
-        obs = in_obs[-1]
+        obs = observations[-1]
     else:
         for obs in observations:
             scheduler.add_observation(obs)


### PR DESCRIPTION
Introduce the new method `add_observations_array` throughout the code so surveys and features can be updated with arrays rather than requiring looping over observations individually. Results in ~50x speedup in restoring scheduler states.

Also expanded the example scheduler so it can be easily run from the command line to generate an example survey.