### PR TITLE
swap unit test to numpy allclose

### DIFF
--- a/tests/maf/test_summary_plots.py
+++ b/tests/maf/test_summary_plots.py
@@ -3,7 +3,7 @@ import unittest
 from numpy.random import default_rng
 import pandas as pd
 import matplotlib.pyplot as plt
-
+import numpy as np
 from rubin_sim import maf
 
 # constants
@@ -59,7 +59,7 @@ class TestSummaryPlots(unittest.TestCase):
             mag_cols=self.mag_metrics,
         )
 
-        self.assertTrue(norm_values.equals(ref_norm_values))
+        np.testing.assert_allclose(norm_values.values, ref_norm_values.values)
 
     def test_plot_run_metric(self):
         fig, ax = maf.plot_run_metric(self.metric_values)


### PR DESCRIPTION
Looks like there can be a slight difference in floating point values on different hardware. 

`(Pdb) norm_values["metric2"]["run9"]`
`-0.49167052452560656`
`(Pdb) ref_norm_values["metric2"]["run9"]`
`-0.49167052452560667`

Swapping to use numpy allclose so this passes.