### PR TITLE
Simplify some slew time issues

### DIFF
--- a/rubin_sim/scheduler/basis_functions/basis_functions.py
+++ b/rubin_sim/scheduler/basis_functions/basis_functions.py
@@ -1213,7 +1213,6 @@ class SlewtimeBasisFunction(BaseBasisFunction):
         self.maxtime = max_time
         self.nside = nside
         self.filtername = filtername
-        self.result = np.zeros(hp.nside2npix(nside), dtype=float)
 
     def add_observation(self, observation, indx=None):
         # No tracking of observations in this basis function. Purely based on conditions.
@@ -1226,9 +1225,12 @@ class SlewtimeBasisFunction(BaseBasisFunction):
         else:
             # Need to make sure smaller slewtime is larger reward.
             if np.size(conditions.slewtime) > 1:
-                result = self.result.copy()
-                good = ~np.isnan(conditions.slewtime)
-                result[good] = -conditions.slewtime[good] / self.maxtime
+                # Slewtime map can contain nans and/or infs - mask these with nans
+                result = np.where(
+                    np.isfinite(conditions.slewtime),
+                    -conditions.slewtime / self.maxtime,
+                    np.nan,
+                )
             else:
                 result = -conditions.slewtime / self.maxtime
         return result

--- a/rubin_sim/scheduler/model_observatory/kinem_model.py
+++ b/rubin_sim/scheduler/model_observatory/kinem_model.py
@@ -456,13 +456,13 @@ class KinemModel(object):
         )[0]
         delta_az_long[oob] = np.inf
 
-        # Taking minimum of abs, so only possible azimuths slews should show up.
-        # And delta_az is signed properly.
-        stacked_az = np.vstack([delta_az_short, delta_az_long])
-        indx = np.argmin(np.abs(stacked_az), axis=0)
-        delta_aztel = np.take_along_axis(
-            stacked_az, np.expand_dims(indx, axis=0), axis=0
-        ).squeeze(axis=0)
+        # Find minimum azimuth slew out of long/short direction (use absolute, because these can be negative)
+        # Note that with an impaired telescope with az range<180, infinite slewtimes can propagate
+        delta_aztel = np.where(
+            np.abs(delta_az_short) < np.abs(delta_az_long),
+            delta_az_short,
+            delta_az_long,
+        )
 
         # Calculate how long the telescope will take to slew to this position.
         tel_alt_slew_time = self._uam_slew_time(

--- a/rubin_sim/scheduler/surveys/base_survey.py
+++ b/rubin_sim/scheduler/surveys/base_survey.py
@@ -444,7 +444,7 @@ class BaseMarkovSurvey(BaseSurvey):
                 return False
         return result
 
-    def _hp2fieldsetup(self, ra, dec, leafsize=100):
+    def _hp2fieldsetup(self, ra, dec):
         """Map each healpixel to nearest field. This will only work if healpix
         resolution is higher than field resolution.
         """
@@ -525,9 +525,6 @@ class BaseMarkovSurvey(BaseSurvey):
             for bf, weight in zip(self.basis_functions, self.basis_weights):
                 basis_value = bf(conditions, indx=indx)
                 self.reward += basis_value * weight
-
-            if np.any(np.isinf(self.reward)):
-                self.reward = np.inf
         else:
             # If not feasable, negative infinity reward
             self.reward = -np.inf


### PR DESCRIPTION
Simply slew time calculation, modify slew time basis function so it returns Nans for unreachable areas, and stop replacement of array reward with a scalar (in cases with infinite values in reward) in BaseMarkovSurvey 