### PR TITLE
Let 'baseline_run' be multiple runs

### DIFF
--- a/rubin_sim/maf/run_comparison/summary_plots.py
+++ b/rubin_sim/maf/run_comparison/summary_plots.py
@@ -91,7 +91,7 @@ def normalize_metric_summaries(
     while baseline_comparison in summary.index:
         baseline_comparison += "b"
 
-    if not isinstance(baseline_run, str):
+    if isinstance(summary.loc[baseline_run], pd.DataFrame):
         summary.loc[baseline_comparison] = summary.loc[baseline_run].median(axis="rows")
     else:
         summary.loc[baseline_comparison] = summary.loc[baseline_run]


### PR DESCRIPTION
Letting the baseline_run be a list allows normalization of the summary metrics to the median value across that list. 
Specifying the list is better than just using all the values in the summary, as perhaps only some of the contents of the summary set should be used for the normalization, while others should just be normalized in the same way for plotting purposes. I.e. : send metrics for a set of weather/clouds + new test runs, but normalize only based on the weather/clouds runs while still normalizing the test runs on the same scale. 

