### PR TITLE
Add option to record rewards during simulation

### DIFF
--- a/rubin_sim/scheduler/surveys/long_gap_survey.py
+++ b/rubin_sim/scheduler/surveys/long_gap_survey.py
@@ -218,13 +218,15 @@ class LongGapSurvey(BaseSurvey):
 
         return observations
 
-    def make_reward_df(self, conditions):
+    def make_reward_df(self, conditions, accum=True):
         """Create a pandas.DataFrame describing the reward from the survey.
 
         Parameters
         ----------
         conditions : `rubin_sim.scheduler.features.Conditions`
             Conditions for which rewards are to be returned
+        accum : `bool`
+            Include accumulated rewards
 
         Returns
         -------
@@ -238,14 +240,27 @@ class LongGapSurvey(BaseSurvey):
             test_survey._check_feasibility(conditions) and reward > np.finfo(reward).min
         )
 
-        reward_df = pd.DataFrame(
-            {
-                "basis_function": ["None"],
-                "feasible": [feasible],
-                "max_basis_reward": [reward],
-                "basis_area": [0],
-                "max_accum_reward": [reward],
-                "accum_area": [0],
-            }
-        )
+        if accum:
+            reward_df = pd.DataFrame(
+                {
+                    "basis_function": ["None"],
+                    "feasible": [feasible],
+                    "max_basis_reward": [reward],
+                    "basis_area": [0],
+                    "basis_weight": [1],
+                    "max_accum_reward": [reward],
+                    "accum_area": [0],
+                }
+            )
+        else:
+            reward_df = pd.DataFrame(
+                {
+                    "basis_function": ["None"],
+                    "feasible": [feasible],
+                    "max_basis_reward": [reward],
+                    "basis_area": [0],
+                    "basis_weight": [1],
+                }
+            )
+
         return reward_df

--- a/tests/scheduler/test_coresched.py
+++ b/tests/scheduler/test_coresched.py
@@ -51,10 +51,20 @@ class TestCoreSched(unittest.TestCase):
         # Check survey access methods
         reward_df = scheduler.make_reward_df(observatory.return_conditions())
         self.assertIsInstance(reward_df, pd.DataFrame)
+        reward_df = scheduler.make_reward_df(
+            observatory.return_conditions(), accum=False
+        )
+        self.assertIsInstance(reward_df, pd.DataFrame)
 
         obs = scheduler.request_observation()
         surveys_df = scheduler.surveys_df(0)
         self.assertIsInstance(surveys_df, pd.DataFrame)
+
+        # Test we can record basis function values when requested
+        recording_scheduler = CoreScheduler([survey], keep_rewards=True)
+        recording_scheduler.update_conditions(observatory.return_conditions())
+        obs = recording_scheduler.request_observation()
+        self.assertIsInstance(recording_scheduler.queue_reward_df, pd.DataFrame)
 
 
 if __name__ == "__main__":

--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -31,6 +31,7 @@ class TestSurveys(unittest.TestCase):
         reward_df = survey.reward_changes(conditions)
         reward_df = survey.make_reward_df(conditions)
         self.assertIsInstance(reward_df, pd.DataFrame)
+        reward_df = survey.make_reward_df(conditions, accum=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I added options to record basis functions and rewards during a simulation, so that they can then be plotted in dashboards.
What is here may eventually need to be supplemented so that there is a direct way to figure out where long gap observations came from.

I really only intend for this to be used in simulations of a few nights or less, although I suppose we could try with a full simulation to see if it is practical in practice.

Note that the "accum" options was added so that it can be turned off, because it increases the time of simulation by more than a factor of 6, and is generally not necessary. If we really wanted it, some optimization could be done by caching basis function values, but at this point I don't think it worth the added work and code complexity.