### PR TITLE
Add unique readable names for surveys and basis functions to the data…

### DIFF
--- a/rubin_sim/scheduler/basis_functions/basis_functions.py
+++ b/rubin_sim/scheduler/basis_functions/basis_functions.py
@@ -164,7 +164,7 @@ class BaseBasisFunction(object):
         label : `str`
             A string suitable for labeling the basis function in a plot or table.
         """
-        label = self.__class__.__name__.replace("_basis_function", "")
+        label = self.__class__.__name__.replace("BasisFunction", "")
 
         if self.filtername is not None:
             label += f" {self.filtername}"


### PR DESCRIPTION
…frame of basis function values recorded in rubin_sim

This will make it easier for use by schedview, or anything else that wants to look at the same data.

The code that actually creates the labels here may need to be updated at the conclusion of [RFC-913](https://jira.lsstcorp.org/browse/RFC-913),  but given the interface here, schedview shouldn't care how its implemented, and whatever changes will be needed should be easy.