### PR TITLE
add sun alt limit to scheduled observations

### DIFF
--- a/rubin_sim/scheduler/surveys/ddf_presched.py
+++ b/rubin_sim/scheduler/surveys/ddf_presched.py
@@ -262,6 +262,7 @@ def generate_ddf_scheduled_obs(
     alt_max=85,
     HA_min=21.0,
     HA_max=3.0,
+    sun_alt_max=-18,
     dist_tol=3.0,
     season_unobs_frac=0.1,
     nvis_master=[8, 10, 20, 20, 24, 18],
@@ -310,6 +311,7 @@ def generate_ddf_scheduled_obs(
     alt_min = np.radians(alt_min)
     alt_max = np.radians(alt_max)
     dist_tol = np.radians(dist_tol)
+    sun_alt_max = np.radians(sun_alt_max)
 
     ddfs = ddf_locations()
     ddf_data = np.load(data_file)
@@ -348,6 +350,7 @@ def generate_ddf_scheduled_obs(
                     obs["HA_max"] = HA_max
                     obs["alt_min"] = alt_min
                     obs["alt_max"] = alt_max
+                    obs["sun_alt_max"] = sun_alt_max
                     all_scheduled_obs.append(obs)
 
                     obs = scheduled_observation(n=int(nvis / 2))
@@ -367,6 +370,7 @@ def generate_ddf_scheduled_obs(
                     obs["HA_max"] = HA_max
                     obs["alt_min"] = alt_min
                     obs["alt_max"] = alt_max
+                    obs["sun_alt_max"] = sun_alt_max
                     all_scheduled_obs.append(obs)
 
                 else:
@@ -387,6 +391,7 @@ def generate_ddf_scheduled_obs(
                     obs["HA_max"] = HA_max
                     obs["alt_min"] = alt_min
                     obs["alt_max"] = alt_max
+                    obs["sun_alt_max"] = sun_alt_max
                     all_scheduled_obs.append(obs)
 
     result = np.concatenate(all_scheduled_obs)

--- a/rubin_sim/scheduler/surveys/scripted_surveys.py
+++ b/rubin_sim/scheduler/surveys/scripted_surveys.py
@@ -31,7 +31,7 @@ class ScriptedSurvey(BaseSurvey):
         nside=None,
         detailers=None,
         id_start=1,
-        return_n_limit=100,
+        return_n_limit=10,
         survey_name="",
     ):
         """"""
@@ -175,6 +175,7 @@ class ScriptedSurvey(BaseSurvey):
             (alt < observation["alt_max"])
             & (alt > observation["alt_min"])
             & ((HA > observation["HA_max"]) | (HA < observation["HA_min"]))
+            & (conditions.sun_alt < observation["sun_alt_max"])
         )[0]
         return in_range
 

--- a/rubin_sim/scheduler/utils/utils.py
+++ b/rubin_sim/scheduler/utils/utils.py
@@ -620,6 +620,8 @@ def scheduled_observation(n=1):
         Hour angle limit. Constraint is such that for hour angle running from 0 to 24 hours,
         the target RA,Dec must be greather than HA_max and less than HA_min. Set HA_min to 24 for
         no limit. (hours)
+    sun_alt_max : float
+        The sun must be below sun_alt_max to execute. (radians)
     observed : `bool`
         If set to True, scheduler will probably consider this a completed observation an never attempt it.
 
@@ -663,10 +665,11 @@ def scheduled_observation(n=1):
         "alt_max",
         "HA_max",
         "HA_min",
+        "sun_alt_max",
         "observed",
         "scripted_id",
     ]
-    types += [float, float, float, float, float, float, bool, int]
+    types += [float, float, float, float, float, float, float, bool, int]
     result = np.zeros(n, dtype=list(zip(names, types)))
     return result
 


### PR DESCRIPTION
Update scheduled observations so a sun altitude limit can be set. Also decrease the default number of observations `ScriptedSurvey` returns to prevent DDF observations running into twilight time.