### PR TITLE
update phot_utils to be able to read throughput files

### DIFF
--- a/rubin_sim/phot_utils/bandpass.py
+++ b/rubin_sim/phot_utils/bandpass.py
@@ -27,16 +27,12 @@ Class data:
 wavelen (nm)
 sb  (Transmission, 0-1)
 phi (Normalized system response)
-wavelen/sb are guaranteed gridded.
 phi will be None until specifically needed; any updates to wavelen/sb within class will reset phi to None.
 the name of the bandpass file
 
-Note that Bandpass objects are required to maintain a uniform grid in wavelength, rather than
-being allowed to have variable wavelength bins. This is because of the method used in 'Sed' to
-calculate magnitudes, but is simpler to enforce here.
 
 Methods:
-* __init__ : pass wavelen/sb arrays and set values (on grid) OR set data to None's
+* __init__ : pass wavelen/sb arrays and set values  OR set data to None's
 * setWavelenLimits / getWavelenLimits: set or get the wavelength limits of bandpass
 * setBandpass: set bandpass using wavelen/sb input values
 * getBandpass: return copies of wavelen/sb values
@@ -49,7 +45,7 @@ the individual throughputs
 (grid is specified by min/max/step size)
 * sb_tophi : calculate phi from sb - needed for calculating magnitudes
 * multiply_throughputs : multiply self.wavelen/sb by given wavelen/sb and return
-new wavelen/sb arrays (gridded like self)
+new wavelen/sb arrays (wavelength sampled like self)
 * calc_zp_t : calculate instrumental zeropoint for this bandpass
 * calc_eff_wavelen: calculate the effective wavelength (using both Sb and Phi) for this bandpass
 * writeThroughput : utility to write bandpass information to file
@@ -112,7 +108,7 @@ class Bandpass(object):
         """
         Populate bandpass data with wavelen/sb arrays.
 
-        Sets self.wavelen/sb on a grid of wavelen_min/max/step. Phi set to None.
+        Phi set to None.
         """
         # Check data type.
         if (isinstance(wavelen, numpy.ndarray) == False) or (
@@ -155,9 +151,9 @@ class Bandpass(object):
 
     def read_throughput(self, filename):
         """
-        Populate bandpass data with data (wavelen/sb) read from file, resample onto grid.
+        Populate bandpass data with data (wavelen/sb) read from file.
 
-        Sets wavelen/sb, with grid min/max/step as Parameters. Does NOT set phi.
+        Sets wavelen/sb. Does NOT set phi.
         """
         # Set self values to None in case of file read error.
         self.wavelen = None
@@ -354,7 +350,7 @@ class Bandpass(object):
         This function only pdates self.phi.
         """
         # The definition of phi = (Sb/wavelength)/\int(Sb/wavelength)dlambda.
-        # Due to definition of class, self.sb and self.wavelen are guaranteed equal-gridded.
+        # XXX--might want to test here what happens if un-equal grid
         dlambda = self.wavelen[1] - self.wavelen[0]
         self.phi = self.sb / self.wavelen
         # Normalize phi so that the integral of phi is 1.

--- a/rubin_sim/phot_utils/bandpass.py
+++ b/rubin_sim/phot_utils/bandpass.py
@@ -256,6 +256,11 @@ class Bandpass(object):
         for component in component_list:
             # Read data from file.
             tempbandpass.read_throughput(os.path.join(root_dir, component))
+            tempbandpass.resample_bandpass(
+                wavelen_min=wavelen_min,
+                wavelen_max=wavelen_max,
+                wavelen_step=wavelen_step,
+            )
             # Multiply self by new sb values.
             self.sb = self.sb * tempbandpass.sb
         self.bandpassname = "".join(component_list)
@@ -368,9 +373,13 @@ class Bandpass(object):
         This method does not affect self.
         """
         # Resample wavelen_other/sb_other to match this bandpass.
-        if self.need_resample(wavelen=wavelen_other):
+        if not numpy.all(self.wavelen == wavelen_other):
             wavelen_other, sb_other = self.resample_bandpass(
-                wavelen=wavelen_other, sb=sb_other
+                wavelen=wavelen_other,
+                sb=sb_other,
+                wavelen_min=self.wavelen.min(),
+                wavelen_max=self.wavelen.max(),
+                wavelen_step=self.wavelen[1] - self.wavelen[0],
             )
         # Make new memory copy of wavelen.
         wavelen_new = numpy.copy(self.wavelen)

--- a/rubin_sim/phot_utils/bandpass.py
+++ b/rubin_sim/phot_utils/bandpass.py
@@ -347,17 +347,12 @@ class Bandpass(object):
         """
         Calculate and set phi - the normalized system response.
 
-        This function only pdates self.phi.
+        This function only updates self.phi.
         """
         # The definition of phi = (Sb/wavelength)/\int(Sb/wavelength)dlambda.
-        # XXX--might want to test here what happens if un-equal grid
-        dlambda = self.wavelen[1] - self.wavelen[0]
         self.phi = self.sb / self.wavelen
         # Normalize phi so that the integral of phi is 1.
-        phisum = self.phi.sum()
-        if phisum < 1e-300:
-            raise Exception("Phi is poorly defined (nearly 0) over bandpass range.")
-        norm = phisum * dlambda
+        norm = numpy.trapz(self.phi, x=self.wavelen)
         self.phi = self.phi / norm
         return
 

--- a/rubin_sim/phot_utils/physical_parameters.py
+++ b/rubin_sim/phot_utils/physical_parameters.py
@@ -8,48 +8,10 @@ class PhysicalParameters(object):
     """
 
     def __init__(self):
-        # the quantities below are in nanometers
-        self._minwavelen = 300.0
-        self._maxwavelen = 1150.0
-        self._wavelenstep = 0.1
-
         self._lightspeed = 299792458.0  # speed of light, = 2.9979e8 m/s
         self._planck = 6.626068e-27  # planck's constant, = 6.626068e-27 ergs*seconds
         self._nm2m = 1.00e-9  # nanometers to meters conversion = 1e-9 m/nm
         self._ergsetc2jansky = 1.00e23  # erg/cm2/s/Hz to Jansky units (fnu)
-
-    @property
-    def minwavelen(self):
-        """
-        minimum wavelength in nanometers
-        """
-        return self._minwavelen
-
-    @minwavelen.setter
-    def minwavelen(self, value):
-        raise RuntimeError("Cannot change the value of minwavelen")
-
-    @property
-    def maxwavelen(self):
-        """
-        maximum wavelength in nanometers
-        """
-        return self._maxwavelen
-
-    @maxwavelen.setter
-    def maxwavelen(self, value):
-        raise RuntimeError("Cannot change the value of maxwavelen")
-
-    @property
-    def wavelenstep(self):
-        """
-        wavelength step in nanometers
-        """
-        return self._wavelenstep
-
-    @wavelenstep.setter
-    def wavelenstep(self, value):
-        raise RuntimeError("Cannot change the value of wavelenstep")
 
     @property
     def lightspeed(self):

--- a/rubin_sim/phot_utils/sed.py
+++ b/rubin_sim/phot_utils/sed.py
@@ -1428,8 +1428,7 @@ class Sed(object):
         if bandpass.phi is None:
             bandpass.sb_tophi()
         # Calculate flux in bandpass and return this value.
-        dlambda = wavelen[1] - wavelen[0]
-        flux = (fnu * bandpass.phi).sum() * dlambda
+        flux = numpy.trapz(fnu * bandpass.phi, x=wavelen)
         return flux
 
     def calc_mag(self, bandpass, wavelen=None, fnu=None):

--- a/rubin_sim/phot_utils/sed.py
+++ b/rubin_sim/phot_utils/sed.py
@@ -537,19 +537,11 @@ class Sed(object):
         return
 
     def set_flat_sed(
-        self, wavelen_min=None, wavelen_max=None, wavelen_step=None, name="Flat"
+        self, wavelen_min=300.0, wavelen_max=1150.0, wavelen_step=0.1, name="Flat"
     ):
         """
         Populate the wavelength/flambda/fnu fields in sed according to a flat fnu source.
         """
-        if wavelen_min is None:
-            wavelen_min = self._phys_params.minwavelen
-
-        if wavelen_max is None:
-            wavelen_max = self._phys_params.maxwavelen
-
-        if wavelen_step is None:
-            wavelen_step = self._phys_params.wavelenstep
 
         self.wavelen = numpy.arange(
             wavelen_min, wavelen_max + wavelen_step, wavelen_step, dtype="float"
@@ -1703,11 +1695,17 @@ class Sed(object):
         """
         # Calculate dlambda for phi array.
         wavelen_step = bandpasslist[0].wavelen[1] - bandpasslist[0].wavelen[0]
-        wavelen_min = bandpasslist[0].wavelen[0]
-        wavelen_max = bandpasslist[0].wavelen[len(bandpasslist[0].wavelen) - 1]
+        wavelen_min = numpy.min([bandpass.wavelen[0] for bandpass in bandpasslist])
+        wavelen_max = numpy.max([bandpass.wavelen[-1] for bandpass in bandpasslist])
         # Set up
         phiarray = numpy.empty(
-            (len(bandpasslist), len(bandpasslist[0].wavelen)), dtype="float"
+            (
+                len(bandpasslist),
+                numpy.size(
+                    numpy.arange(wavelen_min, wavelen_max + wavelen_step, wavelen_step)
+                ),
+            ),
+            dtype="float",
         )
         # Check phis calculated and on same wavelength grid.
         i = 0

--- a/tests/phot_utils/test_photometricparameters.py
+++ b/tests/phot_utils/test_photometricparameters.py
@@ -251,27 +251,6 @@ class PhysicalParametersUnitTest(unittest.TestCase):
         msg = ""
 
         try:
-            pp.minwavelen = 2.0
-            success += 1
-            msg += "was able to assign minwavelen; "
-        except:
-            self.assertEqual(pp.minwavelen, control.minwavelen)
-
-        try:
-            pp.maxwavelen = 2.0
-            success += 1
-            msg += "was able to assign maxwavelen; "
-        except:
-            self.assertEqual(pp.maxwavelen, control.maxwavelen)
-
-        try:
-            pp.wavelenstep = 2.0
-            success += 1
-            msg += "was able to assign wavelenstep; "
-        except:
-            self.assertEqual(pp.wavelenstep, control.wavelenstep)
-
-        try:
             pp.lightspeed = 2.0
             success += 1
             msg += "was able to assign lightspeed; "

--- a/tests/phot_utils/test_read_bandpasses.py
+++ b/tests/phot_utils/test_read_bandpasses.py
@@ -1,0 +1,27 @@
+import os
+import unittest
+from rubin_sim.phot_utils import Bandpass
+from rubin_sim.data import get_data_dir
+
+
+class ReadBandPassTest(unittest.TestCase):
+    """
+    Tests for reading in bandpasses
+    """
+
+    def test_read(self):
+        """
+        Check that we can read things stored in the throughputs directory easily
+        """
+        throughputs_dir = os.path.join(get_data_dir(), "throughputs")
+
+        # select files to try and read
+        files = [
+            "2MASS/2MASS_Ks.dat",
+            "WISE/WISE_w1.dat",
+            "johnson/johnson_U.dat",
+            "sdss/sdss_r.dat",
+        ]
+        for filename in files:
+            bp = Bandpass()
+            bp.read_throughput(os.path.join(throughputs_dir, filename))


### PR DESCRIPTION
The `Bandpass` class was setting wavelength parameters on instantiation that then prevented it from being able to read/set filters outside that range (e.g., 2MASS filters). Refactored so `Bandpass` only uses a `wavelen` attribute and no longer uses `self.wavelen_min` etc.