### PR TITLE
Move reading of throughputs out of init

### DIFF
--- a/rubin_sim/maf/stackers/general_stackers.py
+++ b/rubin_sim/maf/stackers/general_stackers.py
@@ -69,15 +69,15 @@ class SaturationStacker(BaseStacker):
         self.airmass_col = airmass_col
         self.saturation_e = saturation_e
         self.pixscale = pixscale
-        if zeropoints is None:
-            zp_inst, k_atm = load_inst_zeropoints()
-            self.zeropoints = zp_inst
-            self.km = k_atm
-        else:
-            self.zeropoints = zeropoints
-            self.km = km
+        self.zeropoints = zeropoints
+        self.km = km
 
     def _run(self, sim_data, cols_present=False):
+        if self.zeropoints is None:
+            zp_inst, k_atm = load_inst_zeropoints()
+            self.zeropoints = zp_inst
+        if self.km is None:
+            self.km = k_atm
         for filtername in np.unique(sim_data[self.filter_col]):
             in_filt = np.where(sim_data[self.filter_col] == filtername)[0]
             # Calculate the length of the on-sky time per EXPOSURE


### PR DESCRIPTION
If `load_inst_zeropoints` is called from the `init` method, then when the stacker is instantiated in other metrics or batches, then the actual read of the data will happen immediately -- and this causes even the import of maf to fail if rubin_sim_data/throughputs is not available. 
Moving the call to load_inst_zeropoints to the 'run' method (which is only called when the code is actually run) means that the import can proceed even if the data is not available. 
