### PR TITLE
OPSIM-1063: Ensure MAF imports without data and that all stackers run

### DIFF
--- a/rubin_sim/maf/batches/altaz_batch.py
+++ b/rubin_sim/maf/batches/altaz_batch.py
@@ -11,7 +11,7 @@ from .common import filter_list
 
 def basicSetup(metric_name, colmap=None, nside=64):
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     slicer = slicers.HealpixSlicer(
         nside=nside,

--- a/rubin_sim/maf/batches/common.py
+++ b/rubin_sim/maf/batches/common.py
@@ -1,7 +1,6 @@
 __all__ = (
     "combine_info_labels",
     "filter_list",
-    "radec_cols",
     "standard_summary",
     "extended_summary",
     "standard_metrics",
@@ -17,7 +16,6 @@ __all__ = (
 import inspect
 
 import rubin_sim.maf.metrics as metrics
-import rubin_sim.maf.stackers as stackers
 
 
 def combine_info_labels(info1, info2):
@@ -84,39 +82,6 @@ def filter_list(all=True, extra_sql=None, extra_info_label=None):
             else:
                 sqls[s] = "(%s) and (%s)" % (extra_sql, sqls[s])
     return filterlist, colors, orders, sqls, info_labels
-
-
-def radec_cols(dither_stacker, colmap, ditherkwargs=None):
-    degrees = colmap["raDecDeg"]
-    if dither_stacker is None:
-        raCol = colmap["ra"]
-        decCol = colmap["dec"]
-        stacker = None
-        ditherInfoLabel = None
-    else:
-        if isinstance(dither_stacker, stackers.BaseDitherStacker):
-            stacker = dither_stacker
-        else:
-            s = stackers.BaseStacker().registry[dither_stacker]
-            args = [f for f in inspect.getfullargspec(s).args if f.endswith("Col")]
-            # Set up default dither kwargs.
-            kwargs = {}
-            for a in args:
-                colmapCol = a.replace("Col", "")
-                if colmapCol in colmap:
-                    kwargs[a] = colmap[colmapCol]
-            # Update with passed values, if any.
-            if ditherkwargs is not None:
-                kwargs.update(ditherkwargs)
-            stacker = s(degrees=degrees, **kwargs)
-        raCol = stacker.colsAdded[0]
-        decCol = stacker.colsAdded[1]
-        # Send back some info_label information.
-        ditherInfoLabel = stacker.__class__.__name__.replace("Stacker", "")
-        if ditherkwargs is not None:
-            for k, v in ditherkwargs.items():
-                ditherInfoLabel += " " + "%s:%s" % (k, v)
-    return raCol, decCol, degrees, stacker, ditherInfoLabel
 
 
 def standard_summary(withCount=True):

--- a/rubin_sim/maf/batches/filterchange_batch.py
+++ b/rubin_sim/maf/batches/filterchange_batch.py
@@ -80,7 +80,7 @@ def filtersPerNight(colmap=None, runName="opsim", nights=1, extraSql=None, extra
     """
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     # Set up sql and info_label, if passed any additional information.
@@ -144,7 +144,7 @@ def filtersWholeSurvey(colmap=None, runName="opsim", extraSql=None, extraInfoLab
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     # Set up sql and info_label, if passed any additional information.

--- a/rubin_sim/maf/batches/glance_batch.py
+++ b/rubin_sim/maf/batches/glance_batch.py
@@ -58,7 +58,7 @@ def glanceBatch(
         raise ValueError("colmap must be a dictionary, not a string")
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     bundle_list = []
 

--- a/rubin_sim/maf/batches/hourglass_batch.py
+++ b/rubin_sim/maf/batches/hourglass_batch.py
@@ -26,7 +26,7 @@ def hourglassPlots(colmap=None, runName="opsim", nyears=10, extraSql=None, extra
         Add an extra piece of info_label before running metrics. Default None.
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     sql = ""

--- a/rubin_sim/maf/batches/info_batch.py
+++ b/rubin_sim/maf/batches/info_batch.py
@@ -5,7 +5,7 @@ import numpy as np
 import rubin_sim.maf.batches as batches
 
 
-def metadata_bundle_dicts(allsky_slicer, wfd_slicer, opsim="opsim", colmap=batches.col_map_dict("FBS")):
+def metadata_bundle_dicts(allsky_slicer, wfd_slicer, opsim="opsim", colmap=batches.col_map_dict()):
     # Set up the bundle dicts
     # Some of these metrics are reproduced in other scripts - srd and cadence
     bdict = {}

--- a/rubin_sim/maf/batches/metadata_batch.py
+++ b/rubin_sim/maf/batches/metadata_batch.py
@@ -10,7 +10,6 @@ __all__ = (
 
 import rubin_sim.maf.metric_bundles as mb
 import rubin_sim.maf.metrics as metrics
-import rubin_sim.maf.plots as plots
 import rubin_sim.maf.slicers as slicers
 import rubin_sim.maf.stackers as stackers
 
@@ -19,7 +18,6 @@ from .common import (
     combine_info_labels,
     extended_metrics,
     filter_list,
-    radec_cols,
     standard_angle_metrics,
     standard_summary,
 )
@@ -69,7 +67,7 @@ def metadataBasics(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("fbs")
+        colmap = col_map_dict()
     bundleList = []
 
     if valueName is None:
@@ -87,8 +85,10 @@ def metadataBasics(
 
     displayDict = {"group": groupName, "subgroup": subgroup}
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    extraInfoLabel = combine_info_labels(extraInfoLabel, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
+
     # Set up basic all and per filter sql constraints.
     filterlist, colors, orders, sqls, info_label = filter_list(
         all=True, extra_sql=extraSql, extra_info_label=extraInfoLabel
@@ -217,7 +217,7 @@ def metadataBasicsAngle(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     if valueName is None:
@@ -235,8 +235,9 @@ def metadataBasicsAngle(
 
     displayDict = {"group": groupName, "subgroup": subgroup}
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    extraInfoLabel = combine_info_labels(extraInfoLabel, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
     # Set up basic all and per filter sql constraints.
     filterlist, colors, orders, sqls, info_label = filter_list(
         all=True, extra_sql=extraSql, extra_info_label=extraInfoLabel
@@ -336,7 +337,7 @@ def allMetadata(colmap=None, runName="opsim", extraSql=None, extraInfoLabel=None
     """
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     bdict = {}
 
@@ -413,7 +414,7 @@ def metadataMaps(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     if valueName is None:
@@ -431,8 +432,9 @@ def metadataMaps(
 
     displayDict = {"group": groupName, "subgroup": subgroup}
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    extraInfoLabel = combine_info_labels(extraInfoLabel, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
     # Set up basic all and per filter sql constraints.
     filterlist, colors, orders, sqls, info_label = filter_list(
         all=True, extra_sql=extraSql, extra_info_label=extraInfoLabel
@@ -506,7 +508,7 @@ def firstYearMetadata(colmap=None, runName="opsim", extraSql=None, extraInfoLabe
     """
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     bdict = {}
 

--- a/rubin_sim/maf/batches/moving_objects_batch.py
+++ b/rubin_sim/maf/batches/moving_objects_batch.py
@@ -136,7 +136,7 @@ def quick_discovery_batch(
     magtype="asteroid",
 ):
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     basicPlotDict = {
@@ -277,7 +277,7 @@ def discovery_batch(
     magtype="asteroid",
 ):
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     basicPlotDict = {
@@ -906,7 +906,7 @@ def characterization_inner_batch(
 ):
     """Characterization metrics for inner solar system objects."""
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     # Set up a dictionary to pass to each metric for the column names.
@@ -1103,7 +1103,7 @@ def characterization_outer_batch(
 ):
     """Characterization metrics for outer solar system objects."""
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     # Set up a dictionary to pass to each metric for the column names.

--- a/rubin_sim/maf/batches/openshutter_batch.py
+++ b/rubin_sim/maf/batches/openshutter_batch.py
@@ -26,7 +26,7 @@ def openshutterFractions(colmap=None, runName="opsim", extraSql=None, extraInfoL
         Additional info_label to add before any below (i.e. "WFD").  Default is None.
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     group = "Open Shutter Fraction"

--- a/rubin_sim/maf/batches/science_radar_batch.py
+++ b/rubin_sim/maf/batches/science_radar_batch.py
@@ -658,6 +658,7 @@ def science_radar_batch(
 
     # Do the weak lensing per year
     for year in np.arange(1, 10):
+        displayDict["order"] = year
         sqlconstraint = (
             'note not like "DD%"'
             + ' and (filter="g" or filter="r" or filter="i") and night < %i' % (year * 365.25)

--- a/rubin_sim/maf/batches/skycoverage.py
+++ b/rubin_sim/maf/batches/skycoverage.py
@@ -27,7 +27,7 @@ def meanRADec(colmap=None, runName="opsim", extraSql=None, extraInfoLabel=None):
         Additional info_label to add before any below (i.e. "WFD").  Default is None.
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     group = "RA Dec coverage"
@@ -90,7 +90,7 @@ def eastWestBias(colmap=None, runName="opsim", extraSql=None, extraInfoLabel=Non
         Additional info_label to add before any below (i.e. "WFD").  Default is None.
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     group = "East vs West"

--- a/rubin_sim/maf/batches/slew_batch.py
+++ b/rubin_sim/maf/batches/slew_batch.py
@@ -1,8 +1,6 @@
 """Sets of slew metrics.
 """
-__all__ = ("slewBasics", "slewAngles", "slewSpeeds", "slewActivities")
-
-import warnings
+__all__ = ("slewBasics",)
 
 import numpy as np
 
@@ -11,7 +9,7 @@ import rubin_sim.maf.metrics as metrics
 import rubin_sim.maf.slicers as slicers
 
 from .col_map_dict import col_map_dict
-from .common import combine_info_labels, standard_metrics
+from .common import standard_metrics
 
 
 def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
@@ -33,7 +31,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
     """
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     bundleList = []
 
@@ -144,269 +142,6 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
         bundleList.append(bundle)
 
     # Set the run_name for all bundles and return the bundleDict.
-    for b in bundleList:
-        b.set_run_name(runName)
-    return mb.make_bundles_dict_from_list(bundleList)
-
-
-def slewAngles(colmap=None, runName="opsim", sqlConstraint=None):
-    """Generate a set of slew statistics focused on the angles of each component (dome and telescope).
-    These slew statistics must be run on the SlewFinalState or SlewInitialState table in opsimv4,
-    and on the SlewState table in opsimv3.
-
-    Parameters
-    ----------
-    colmap : dict or None, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
-    runName : str, optional
-        The name of the simulated survey. Default is "opsim".
-    sqlConstraint : str or None, optional
-        SQL constraint to apply to metrics. Note this runs on Slew*State table, so constraints
-        should generally be based on slew_slewCount.
-
-    Returns
-    -------
-    metric_bundleDict
-    """
-    if colmap is None:
-        colmap = col_map_dict("opsimV4")
-    bundleList = []
-
-    # All of these metrics are run with a unislicer.
-    slicer = slicers.UniSlicer()
-
-    # For each angle, we will compute mean/median/min/max and rms.
-    # Note that these angles can range over more than 360 degrees, because of cable wrap.
-    # This is why we're not using the Angle metrics - here 380 degrees is NOT the same as 20 deg.
-    # Stats for angle:
-    angles = ["Tel Alt", "Tel Az", "Rot Tel Pos"]
-
-    displayDict = {
-        "group": "Slew",
-        "subgroup": "Slew Angles",
-        "order": -1,
-        "caption": None,
-    }
-    for angle in angles:
-        info_label = combine_info_labels(angle, sqlConstraint)
-        metriclist = standard_metrics(colmap[angle], replace_colname="")
-        metriclist += [metrics.RmsMetric(colmap[angle], metric_name="RMS")]
-        for metric in metriclist:
-            displayDict["caption"] = "%s %s" % (metric.name, angle)
-            displayDict["order"] += 1
-            bundle = mb.MetricBundle(
-                metric,
-                slicer,
-                sqlConstraint,
-                display_dict=displayDict,
-                info_label=info_label,
-            )
-            bundleList.append(bundle)
-
-    for b in bundleList:
-        b.set_run_name(runName)
-    return mb.make_bundles_dict_from_list(bundleList)
-
-
-def slewSpeeds(colmap=None, runName="opsim", sqlConstraint=None):
-    """Generate a set of slew statistics focused on the speeds of each component (dome and telescope).
-    These slew statistics must be run on the SlewMaxSpeeds table in opsimv4 and opsimv3.
-
-    Parameters
-    ----------
-    colmap : dict or None, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
-        Note that for these metrics, the column names are distinctly different in v3/v4.
-    runName : str, optional
-        The name of the simulated survey. Default is "opsim".
-    sqlConstraint : str or None, optional
-        SQL constraint to apply to metrics. Note this runs on Slew*State table, so constraints
-        should generally be based on slew_slewCount.
-
-    Returns
-    -------
-    metric_bundleDict
-    """
-    if colmap is None:
-        colmap = col_map_dict("opsimV4")
-    bundleList = []
-
-    # All of these metrics run with a unislicer, on all the slew data.
-    slicer = slicers.UniSlicer()
-
-    speeds = [
-        "Dome Alt Speed",
-        "Dome Az Speed",
-        "Tel Alt Speed",
-        "Tel Az Speed",
-        "Rotator Speed",
-    ]
-
-    displayDict = {
-        "group": "Slew",
-        "subgroup": "Slew Speeds",
-        "order": -1,
-        "caption": None,
-    }
-    for speed in speeds:
-        info_label = combine_info_labels(speed, sqlConstraint)
-        metric = metrics.AbsMaxMetric(col=colmap[speed], metric_name="Max (Abs)")
-        displayDict["caption"] = "Maximum absolute value of %s." % speed
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(
-            metric,
-            slicer,
-            sqlConstraint,
-            display_dict=displayDict,
-            info_label=info_label,
-        )
-        bundleList.append(bundle)
-
-        metric = metrics.AbsMeanMetric(col=colmap[speed], metric_name="Mean (Abs)")
-        displayDict["caption"] = "Mean absolute value of %s." % speed
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(
-            metric,
-            slicer,
-            sqlConstraint,
-            display_dict=displayDict,
-            info_label=info_label,
-        )
-        bundleList.append(bundle)
-
-        metric = metrics.AbsMaxPercentMetric(col=colmap[speed], metric_name="% @ Max")
-        displayDict["caption"] = "Percent of slews at the maximum %s (absolute value)." % speed
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(
-            metric,
-            slicer,
-            sqlConstraint,
-            display_dict=displayDict,
-            info_label=info_label,
-        )
-        bundleList.append(bundle)
-
-    for b in bundleList:
-        b.set_run_name(runName)
-
-    return mb.make_bundles_dict_from_list(bundleList)
-
-
-def slewActivities(colmap=None, runName="opsim", totalSlewN=1, sqlConstraint=None):
-    """Generate a set of slew statistics focused on finding the contributions to the overall slew time.
-    These slew statistics must be run on the SlewActivities table in opsimv4 and opsimv3.
-
-    Note that the type of activities listed are different between v3 and v4.
-
-    Parameters
-    ----------
-    colmap : dict or None, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
-    runName : str, optional
-        The name of the simulated survey. Default is "opsim".
-    totalSlewN : int, optional
-        The total number of slews in the simulated survey.
-        Used to calculate % of slew activities for each component.
-        Default is 1.
-    sqlConstraint : str or None, optional
-        SQL constraint to apply to metrics. Note this runs on Slew*State table, so constraints
-        should generally be based on slew_slewCount.
-
-
-    Returns
-    -------
-    metric_bundleDict
-    """
-    if totalSlewN == 1:
-        warnings.warn("TotalSlewN should be set (using 1). Percents from activities may be incorrect.")
-
-    if colmap is None:
-        colmap = col_map_dict("opsimV4")
-    bundleList = []
-
-    # All of these metrics run with a unislicer, on all the slew data.
-    slicer = slicers.UniSlicer()
-
-    if "slewactivities" not in colmap:
-        raise ValueError("List of slewactivities not in colmap! Will not create slewActivities bundles.")
-
-    slewTypeDict = colmap["slewactivities"]
-
-    displayDict = {
-        "group": "Slew",
-        "subgroup": "Slew Activities",
-        "order": -1,
-        "caption": None,
-    }
-
-    for slewType in slewTypeDict:
-        info_label = combine_info_labels(slewType, sqlConstraint)
-        tableValue = slewTypeDict[slewType]
-
-        # Metrics for all activities of this type.
-        sql = 'activityDelay>0 and activity="%s"' % tableValue
-        if sqlConstraint is not None:
-            sql = "(%s) and (%s)" % (sql, sqlConstraint)
-
-        # Percent of slews which include this activity.
-        metric = metrics.CountRatioMetric(
-            col="activityDelay", norm_val=totalSlewN / 100.0, metric_name="ActivePerc"
-        )
-        displayDict["caption"] = "Percent of total slews which include %s movement." % slewType
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
-        # Mean time for this activity, in all slews.
-        metric = metrics.MeanMetric(col="activityDelay", metric_name="Ave T(s)")
-        displayDict["caption"] = "Mean amount of time (in seconds) for %s movements." % (slewType)
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
-        # Maximum time for this activity, in all slews.
-        metric = metrics.MaxMetric(col="activityDelay", metric_name="Max T(s)")
-        displayDict["caption"] = "Max amount of time (in seconds) for %s movement." % (slewType)
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
-        # Metrics for activities of this type which are in the critical path.
-        sql = 'activityDelay>0 and inCriticalPath="True" and activity="%s"' % tableValue
-        if sqlConstraint is not None:
-            sql = "(%s) and (%s)" % (sql, sqlConstraint)
-
-        # Percent of slews which include this activity in the critical path.
-        metric = metrics.CountRatioMetric(
-            col="activityDelay",
-            norm_val=totalSlewN / 100.0,
-            metric_name="ActivePerc in crit",
-        )
-        displayDict[
-            "caption"
-        ] = "Percent of total slew which include %s movement, " "and are in critical path." % (slewType)
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
-        # Mean time for slews which include this activity, in the critical path.
-        metric = metrics.MeanMetric(col="activityDelay", metric_name="Ave T(s) in crit")
-        displayDict["caption"] = "Mean time (in seconds) for %s movements, " "when in critical path." % (
-            slewType
-        )
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
-        # Total time that this activity was in the critical path.
-        metric = metrics.SumMetric(col="activityDelay", metric_name="Total T(s) in crit")
-        displayDict["caption"] = "Total time (in seconds) for %s movements, " "when in critical path." % (
-            slewType
-        )
-        displayDict["order"] += 1
-        bundle = mb.MetricBundle(metric, slicer, sql, display_dict=displayDict, info_label=info_label)
-        bundleList.append(bundle)
-
     for b in bundleList:
         b.set_run_name(runName)
     return mb.make_bundles_dict_from_list(bundleList)

--- a/rubin_sim/maf/batches/srd_batch.py
+++ b/rubin_sim/maf/batches/srd_batch.py
@@ -15,7 +15,7 @@ import rubin_sim.maf.slicers as slicers
 import rubin_sim.maf.stackers as stackers
 
 from .col_map_dict import col_map_dict
-from .common import combine_info_labels, radec_cols, standard_summary
+from .common import standard_summary
 
 
 def fOBatch(
@@ -49,7 +49,7 @@ def fOBatch(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("fbs")
+        colmap = col_map_dict()
 
     bundleList = []
 
@@ -66,10 +66,9 @@ def fOBatch(
 
     subgroup = info_label
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    # Don't want dither info in subgroup (too long), but do want it in bundle name.
-    info_label = combine_info_labels(info_label, ditherMeta)
-
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
     # Set up fO metric.
     if slicer is None:
         nside = 64
@@ -145,7 +144,6 @@ def fOBatch(
         slicer,
         sql,
         plot_dict=plotDict,
-        stacker_list=[ditherStacker],
         display_dict=displayDict,
         summary_metrics=summaryMetrics,
         plot_funcs=[plots.FOPlot()],
@@ -185,7 +183,7 @@ def astrometryBatch(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("fbs")
+        colmap = col_map_dict()
     bundleList = []
 
     sql = ""
@@ -442,7 +440,7 @@ def rapidRevisitBatch(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("fbs")
+        colmap = col_map_dict()
     bundleList = []
 
     sql = ""

--- a/rubin_sim/maf/batches/time_sci_batch.py
+++ b/rubin_sim/maf/batches/time_sci_batch.py
@@ -2,15 +2,13 @@
 """
 __all__ = ("phaseGap",)
 
-import numpy as np
-
 import rubin_sim.maf.metric_bundles as mb
 import rubin_sim.maf.metrics as metrics
 import rubin_sim.maf.plots as plots
 import rubin_sim.maf.slicers as slicers
 
 from .col_map_dict import col_map_dict
-from .common import combine_info_labels, filter_list, radec_cols, standard_summary
+from .common import combine_info_labels, standard_summary
 
 
 def phaseGap(
@@ -19,8 +17,6 @@ def phaseGap(
     nside=64,
     extraSql=None,
     extraInfoLabel=None,
-    ditherStacker=None,
-    ditherkwargs=None,
 ):
     """Generate a set of statistics about the pair/triplet/etc. rate within a night.
 
@@ -36,10 +32,6 @@ def phaseGap(
         Additional sql constraint to apply to all metrics.
     extraInfoLabel : str or None, optional
         Additional info_label to apply to all results.
-    ditherStacker: str or rubin_sim.maf.stackers.BaseDitherStacker
-        Optional dither stacker to use to define ra/dec columns.
-    ditherkwargs: dict or None, optional
-        Optional dictionary of kwargs for the dither stacker.
 
     Returns
     -------
@@ -47,15 +39,16 @@ def phaseGap(
     """
 
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
 
     info_label = extraInfoLabel
     if extraSql is not None and len(extraSql) > 0:
         if info_label is None:
             info_label = extraSql
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(ditherStacker, colmap, ditherkwargs)
-    info_label = combine_info_labels(info_label, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
 
     bundleList = []
     standardStats = standard_summary()

--- a/rubin_sim/maf/batches/visitdepth_batch.py
+++ b/rubin_sim/maf/batches/visitdepth_batch.py
@@ -13,7 +13,7 @@ import rubin_sim.maf.stackers as stackers
 import rubin_sim.maf.utils as mafUtils
 
 from .col_map_dict import col_map_dict, get_col_map
-from .common import combine_info_labels, filter_list, radec_cols, standard_summary
+from .common import filter_list, standard_summary
 
 
 def nvisitsM5Maps(
@@ -49,15 +49,16 @@ def nvisitsM5Maps(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     subgroup = extraInfoLabel
     if subgroup is None:
         subgroup = "All visits"
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    extraInfoLabel = combine_info_labels(extraInfoLabel, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
     # Set up basic all and per filter sql constraints.
     filterlist, colors, orders, sqls, info_label = filter_list(
         all=True, extra_sql=extraSql, extra_info_label=extraInfoLabel
@@ -107,7 +108,7 @@ def nvisitsM5Maps(
 
     for f in filterlist:
         sql = sqls[f]
-        displayDict["caption"] = "Number of visits per healpix in %s." % info_label[f]
+        displayDict["caption"] = f"Number of visits per healpix in {info_label[f]}."
         displayDict["order"] = orders[f]
         bin_size = 2
         if f == "all":
@@ -125,7 +126,6 @@ def nvisitsM5Maps(
             slicer,
             sql,
             info_label=info_label[f],
-            stacker_list=ditherStacker,
             display_dict=displayDict,
             plot_dict=plotDict,
             summary_metrics=standard_summary(),
@@ -142,22 +142,10 @@ def nvisitsM5Maps(
             continue
         mag_zp = benchmarkVals["coaddedDepth"][f]
         sql = sqls[f]
-        displayDict[
-            "caption"
-        ] = "Coadded depth per healpix, with %s benchmark value subtracted (%.1f) " "in %s." % (
-            f,
-            mag_zp,
-            info_label[f],
-        )
+        displayDict["caption"] = f"Coadded depth per healpix in {info_label[f]}."
         displayDict["caption"] += " More positive numbers indicate fainter limiting magnitudes."
         displayDict["order"] = orders[f]
         plotDict = {
-            # "zp": mag_zp,
-            # "x_min": -0.6,
-            # "x_max": 0.6,
-            # "xlabel": "coadded m5 - %.1f" % mag_zp,
-            # "color_min": -0.6,
-            # "color_max": 0.6,
             "percentile_clip": 98,
             "color": colors[f],
         }
@@ -166,7 +154,6 @@ def nvisitsM5Maps(
             slicer,
             sql,
             info_label=info_label[f],
-            stacker_list=ditherStacker,
             display_dict=displayDict,
             plot_dict=plotDict,
             summary_metrics=standard_summary(),
@@ -186,19 +173,12 @@ def nvisitsM5Maps(
         displayDict["caption"] = (
             "Coadded depth per healpix for extragalactic purposes "
             "(i.e. combined with dust extinction maps), "
-            "with %s benchmark value subtracted (%.1f) "
-            "in %s." % (f, mag_zp, info_label[f])
+            f"in {info_label[f]}."
         )
         displayDict["caption"] += " More positive numbers indicate fainter limiting magnitudes."
         displayDict["order"] = orders[f]
         plotDict = {
-            # "zp": mag_zp,
-            # "x_min": -0.6,
-            # "x_max": 0.6,
-            # "xlabel": "coadded m5 - %.1f" % mag_zp,
-            # "color_min": -0.6,
-            # "color_max": 0.6,
-            "percentile_clip": 98,
+            "percentile_clip": 93,
             "color": colors[f],
         }
         bundle = mb.MetricBundle(
@@ -206,7 +186,6 @@ def nvisitsM5Maps(
             slicerDust,
             sql,
             info_label=info_label[f],
-            stacker_list=ditherStacker,
             display_dict=displayDict,
             plot_dict=plotDict,
             summary_metrics=standard_summary(),
@@ -247,15 +226,16 @@ def tEffMetrics(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("opsimV4")
+        colmap = col_map_dict()
     bundleList = []
 
     subgroup = extraInfoLabel
     if subgroup is None:
         subgroup = "All visits"
 
-    raCol, decCol, degrees, ditherStacker, ditherMeta = radec_cols(None, colmap, None)
-    extraInfoLabel = combine_info_labels(extraInfoLabel, ditherMeta)
+    raCol = colmap["ra"]
+    decCol = colmap["dec"]
+    degrees = colmap["raDecDeg"]
 
     if slicer is not None:
         skyslicer = slicer
@@ -309,9 +289,6 @@ def tEffMetrics(
 
     # Generate Teff maps in all and per filters
     displayDict = {"group": "T_eff Maps", "subgroup": subgroup}
-    if ditherMeta is not None:
-        for m in info_label:
-            info_label[m] = combine_info_labels(info_label[m], ditherMeta)
 
     metric = metrics.TeffMetric(
         m5_col=colmap["fiveSigmaDepth"],
@@ -328,7 +305,6 @@ def tEffMetrics(
             skyslicer,
             sqls[f],
             info_label=info_label[f],
-            stacker_list=ditherStacker,
             display_dict=displayDict,
             plot_dict=plotDict,
             summary_metrics=standard_summary(),
@@ -372,7 +348,7 @@ def nvisitsPerNight(
     metric_bundleDict
     """
     if colmap is None:
-        colmap = col_map_dict("FBS")
+        colmap = col_map_dict()
 
     subgroup = subgroup
     if subgroup is None:

--- a/rubin_sim/maf/maf_contrib/lss_obs_strategy/__init__.py
+++ b/rubin_sim/maf/maf_contrib/lss_obs_strategy/__init__.py
@@ -5,7 +5,5 @@ from .constants_for_pipeline import *
 from .galaxy_counts_metric_extended import *
 from .galaxy_counts_with_pixel_calibration import *
 from .masking_algorithm_generalized import *
-from .new_dither_stackers import *
-from .num_obs_metric import *
 from .os_bias_analysis import *
 from .save_bundle_data_npz_format import *

--- a/rubin_sim/maf/maf_contrib/lss_obs_strategy/artificial_structure_calculation.py
+++ b/rubin_sim/maf/maf_contrib/lss_obs_strategy/artificial_structure_calculation.py
@@ -67,7 +67,7 @@ from rubin_sim.maf.maf_contrib.lss_obs_strategy.galaxy_counts_with_pixel_calibra
 from rubin_sim.maf.maf_contrib.lss_obs_strategy.masking_algorithm_generalized import (
     masking_algorithm_generalized,
 )
-from rubin_sim.maf.maf_contrib.lss_obs_strategy.num_obs_metric import NumObsMetric
+from rubin_sim.maf.metrics import CountMetric as NumObsMetric
 from rubin_sim.maf.maf_contrib.lss_obs_strategy.save_bundle_data_npz_format import save_bundle_data_npz_format
 
 

--- a/rubin_sim/maf/maf_contrib/lss_obs_strategy/new_dither_stackers.py
+++ b/rubin_sim/maf/maf_contrib/lss_obs_strategy/new_dither_stackers.py
@@ -11,17 +11,19 @@
 # Last updated: 06/11/16
 ###############################################################################################################
 __all__ = (
-    "RepulsiveRandomDitherFieldPerVisitStacker",
-    "RepulsiveRandomDitherFieldPerNightStacker",
     "RepulsiveRandomDitherPerNightStacker",
-    "FermatSpiralDitherFieldPerVisitStacker",
-    "FermatSpiralDitherFieldPerNightStacker",
     "FermatSpiralDitherPerNightStacker",
-    "PentagonDiamondDitherFieldPerSeasonStacker",
     "PentagonDitherPerSeasonStacker",
     "PentagonDiamondDitherPerSeasonStacker",
     "SpiralDitherPerSeasonStacker",
 )
+
+# deprecated
+#  "RepulsiveRandomDitherFieldPerVisitStacker",
+#  "FermatSpiralDitherFieldPerVisitStacker",
+# "RepulsiveRandomDitherFieldPerNightStacker",
+# "FermatSpiralDitherFieldPerNightStacker",
+#  "PentagonDiamondDitherFieldPerSeasonStacker",
 
 import numpy as np
 
@@ -220,7 +222,7 @@ class RepulsiveRandomDitherFieldPerVisitStacker(BaseStacker):
         self.x_off = x_off
         self.y_off = y_off
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate random numbers for dither, using defined seed value if desired.
         if self.random_seed is not None:
             np.random.seed(self.random_seed)
@@ -307,7 +309,7 @@ class RepulsiveRandomDitherFieldPerNightStacker(RepulsiveRandomDitherFieldPerVis
         # Values required for framework operation: this specifies the data columns required from the database.
         self.cols_req.append(self.night_col)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate random numbers for dither, using defined seed value if desired.
         if self.random_seed is not None:
             np.random.seed(self.random_seed)
@@ -394,7 +396,7 @@ class RepulsiveRandomDitherPerNightStacker(RepulsiveRandomDitherFieldPerVisitSta
         # Values required for framework operation: this specifies the data columns required from the database.
         self.cols_req.append(self.night_col)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate random numbers for dither, using defined seed value if desired.
         if self.random_seed is not None:
             np.random.seed(self.random_seed)
@@ -428,7 +430,7 @@ class FermatSpiralDitherFieldPerVisitStacker(BaseStacker):
     Offset along a Fermat's spiral with num_points, out to a maximum radius of max_dither.
     Sequential offset for each visit to a field.
 
-    Note: dithers are confined to the hexagon inscribed in the circle with with radius max_dither
+    Note: dithers are confined to the hexagon inscribed in the circle with radius max_dither
     Note: Fermat's spiral is defined by r= c*sqrt(n), theta= n*angle, n= integer
 
     Parameters
@@ -487,7 +489,7 @@ class FermatSpiralDitherFieldPerVisitStacker(BaseStacker):
         self.x_off = r * np.cos(theta)
         self.y_off = r * np.sin(theta)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate the spiral offset vertices.
         self._generate_fermat_spiral_offsets()
         # Now apply to observations.
@@ -566,7 +568,7 @@ class FermatSpiralDitherFieldPerNightStacker(FermatSpiralDitherFieldPerVisitStac
         # Values required for framework operation: this specifies the data columns required from the database.
         self.cols_req.append(self.night_col)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate the spiral offset vertices.
         self._generate_fermat_spiral_offsets()
         # Now apply to observations.
@@ -648,7 +650,7 @@ class FermatSpiralDitherPerNightStacker(FermatSpiralDitherFieldPerVisitStacker):
         # Values required for framework operation: this specifies the data columns required from the database.
         self.cols_req.append(self.night_col)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # Generate the spiral offset vertices.
         self._generate_fermat_spiral_offsets()
 
@@ -667,10 +669,7 @@ class FermatSpiralDitherPerNightStacker(FermatSpiralDitherFieldPerVisitStacker):
             vertex_id += 1
 
         # Wrap into expected range.
-        (
-            sim_data["fermatSpiralDitherPerNightRa"],
-            sim_data["fermatSpiralDitherPerNightDec"],
-        ) = wrap_ra_dec(
+        (sim_data["fermatSpiralDitherPerNightRa"], sim_data["fermatSpiralDitherPerNightDec"],) = wrap_ra_dec(
             sim_data["fermatSpiralDitherPerNightRa"],
             sim_data["fermatSpiralDitherPerNightDec"],
         )
@@ -740,7 +739,7 @@ class PentagonDitherFieldPerSeasonStacker(BaseStacker):
         self.x_off = np.concatenate((zip(*inner)[0], zip(*outer)[0]), axis=0)
         self.y_off = np.concatenate((zip(*inner)[1], zip(*outer)[1]), axis=0)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # find the seasons associated with each visit.
         seasons = calc_season(sim_data[self.ra_col], simdata[self.exp_mjd_col])
         # check how many entries in the >10 season
@@ -840,7 +839,7 @@ class PentagonDiamondDitherFieldPerSeasonStacker(BaseStacker):
         self.x_off = np.concatenate(([0], zip(*diamond_coord)[0], zip(*pent_coord)[0]), axis=0)
         self.y_off = np.concatenate(([0], zip(*diamond_coord)[1], zip(*pent_coord)[1]), axis=0)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # find the seasons associated with each visit.
         seasons = calc_season(sim_data[self.ra_col], sim_data[self.exp_mjd_col])
 
@@ -926,7 +925,7 @@ class PentagonDitherPerSeasonStacker(PentagonDitherFieldPerSeasonStacker):
         # Values required for framework operation: this specifies the names of the new columns.
         self.cols_added = ["pentagonDitherPerSeasonRa", "pentagonDitherPerSeasonDec"]
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # find the seasons associated with each visit.
         seasons = calc_season(sim_data[self.ra_col], sim_data[self.exp_mjd_col])
         years = sim_data[self.nightCol] % 365.25
@@ -981,10 +980,7 @@ class PentagonDitherPerSeasonStacker(PentagonDitherFieldPerSeasonStacker):
             vertex_id += 1
 
         # Wrap into expected range.
-        (
-            sim_data["pentagonDitherPerSeasonRa"],
-            sim_data["pentagonDitherPerSeasonDec"],
-        ) = wrap_ra_dec(
+        (sim_data["pentagonDitherPerSeasonRa"], sim_data["pentagonDitherPerSeasonDec"],) = wrap_ra_dec(
             sim_data["pentagonDitherPerSeasonRa"],
             sim_data["pentagonDitherPerSeasonDec"],
         )
@@ -1037,7 +1033,7 @@ class PentagonDiamondDitherPerSeasonStacker(PentagonDiamondDitherFieldPerSeasonS
             "pentagonDiamondDitherPerSeasonDec",
         ]
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # find the seasons associated with each visit.
         seasons = calc_season(sim_data[self.ra_col], sim_data[self.exp_mjd_col])
 
@@ -1129,7 +1125,7 @@ class SpiralDitherPerSeasonStacker(SpiralDitherFieldPerVisitStacker):
         self.cols_added = ["spiralDitherPerSeasonRa", "spiralDitherPerSeasonDec"]
         self.cols_req.append(self.exp_mjd_col)
 
-    def _run(self, sim_data):
+    def _run(self, sim_data, cols_present=False):
         # find the seasons associated with each visit.
         seasons = calc_season(sim_data[self.raCol], sim_data[self.exp_mjd_col])
 

--- a/rubin_sim/maf/maf_contrib/lss_obs_strategy/new_dither_stackers.py
+++ b/rubin_sim/maf/maf_contrib/lss_obs_strategy/new_dither_stackers.py
@@ -669,7 +669,10 @@ class FermatSpiralDitherPerNightStacker(FermatSpiralDitherFieldPerVisitStacker):
             vertex_id += 1
 
         # Wrap into expected range.
-        (sim_data["fermatSpiralDitherPerNightRa"], sim_data["fermatSpiralDitherPerNightDec"],) = wrap_ra_dec(
+        (
+            sim_data["fermatSpiralDitherPerNightRa"],
+            sim_data["fermatSpiralDitherPerNightDec"],
+        ) = wrap_ra_dec(
             sim_data["fermatSpiralDitherPerNightRa"],
             sim_data["fermatSpiralDitherPerNightDec"],
         )
@@ -980,7 +983,10 @@ class PentagonDitherPerSeasonStacker(PentagonDitherFieldPerSeasonStacker):
             vertex_id += 1
 
         # Wrap into expected range.
-        (sim_data["pentagonDitherPerSeasonRa"], sim_data["pentagonDitherPerSeasonDec"],) = wrap_ra_dec(
+        (
+            sim_data["pentagonDitherPerSeasonRa"],
+            sim_data["pentagonDitherPerSeasonDec"],
+        ) = wrap_ra_dec(
             sim_data["pentagonDitherPerSeasonRa"],
             sim_data["pentagonDitherPerSeasonDec"],
         )

--- a/rubin_sim/maf/metric_bundles/metric_bundle_group.py
+++ b/rubin_sim/maf/metric_bundles/metric_bundle_group.py
@@ -11,10 +11,8 @@ import numpy.ma as ma
 import tqdm
 
 import rubin_sim.maf.db as db
-import rubin_sim.maf.maps as maps
 import rubin_sim.maf.utils as utils
 from rubin_sim.maf.plots import PlotHandler
-from rubin_sim.maf.stackers import BaseDitherStacker
 
 from .metric_bundle import MetricBundle, create_empty_metric_bundle
 
@@ -397,16 +395,6 @@ class MetricBundleGroup:
                 uniq_maps.append(m)
 
         # Run stackers.
-        # Run dither stackers first. (this is a bit of a hack -- we should probably figure out
-        # proper hierarchy and DAG so that stackers run in the order they need to. This will catch 90%).
-        dither_stackers = []
-        for s in uniq_stackers:
-            if isinstance(s, BaseDitherStacker):
-                dither_stackers.append(s)
-        for stacker in dither_stackers:
-            self.sim_data = stacker.run(self.sim_data, override=True)
-            uniq_stackers.remove(stacker)
-
         for stacker in uniq_stackers:
             # Note that stackers will clobber previously existing rows with the same name.
             self.sim_data = stacker.run(self.sim_data, override=True)

--- a/rubin_sim/maf/run_comparison/archive.py
+++ b/rubin_sim/maf/run_comparison/archive.py
@@ -362,7 +362,11 @@ def get_metric_summaries(
     if isinstance(summary_source, pd.DataFrame):
         all_summaries = summary_source
     else:
-        all_summaries = pd.read_csv(summary_source, index_col=0, low_memory=False)
+        try:
+            all_summaries = pd.read_csv(summary_source, index_col=0, low_memory=False)
+        except UnicodeDecodeError:
+            # then this was probably the h5 file instead
+            all_summaries = pd.read_hdf(summary_source)
         all_summaries.index.name = "OpsimRun"
 
     if len(run_families) > 0:

--- a/rubin_sim/maf/stackers/__init__.py
+++ b/rubin_sim/maf/stackers/__init__.py
@@ -1,6 +1,5 @@
 from .base_stacker import *
 from .coord_stackers import *
-from .dither_stackers import *
 from .general_stackers import *
 from .get_col_info import *
 from .label_stackers import *

--- a/rubin_sim/maf/stackers/dither_stackers.py
+++ b/rubin_sim/maf/stackers/dither_stackers.py
@@ -310,7 +310,10 @@ class RandomDitherFieldPerVisitStacker(BaseDitherStacker):
         sim_data["randomDitherFieldPerVisitRa"] = ra + self.x_off / np.cos(dec)
         sim_data["randomDitherFieldPerVisitDec"] = dec + self.y_off
         # Wrap back into expected range.
-        (sim_data["randomDitherFieldPerVisitRa"], sim_data["randomDitherFieldPerVisitDec"],) = wrap_ra_dec(
+        (
+            sim_data["randomDitherFieldPerVisitRa"],
+            sim_data["randomDitherFieldPerVisitDec"],
+        ) = wrap_ra_dec(
             sim_data["randomDitherFieldPerVisitRa"],
             sim_data["randomDitherFieldPerVisitDec"],
         )
@@ -423,7 +426,10 @@ class RandomDitherFieldPerNightStacker(RandomDitherFieldPerVisitStacker):
             )
             sim_data["randomDitherFieldPerNightDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (sim_data["randomDitherFieldPerNightRa"], sim_data["randomDitherFieldPerNightDec"],) = wrap_ra_dec(
+        (
+            sim_data["randomDitherFieldPerNightRa"],
+            sim_data["randomDitherFieldPerNightDec"],
+        ) = wrap_ra_dec(
             sim_data["randomDitherFieldPerNightRa"],
             sim_data["randomDitherFieldPerNightDec"],
         )
@@ -638,7 +644,10 @@ class SpiralDitherFieldPerVisitStacker(BaseDitherStacker):
             )
             sim_data["spiralDitherFieldPerVisitDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (sim_data["spiralDitherFieldPerVisitRa"], sim_data["spiralDitherFieldPerVisitDec"],) = wrap_ra_dec(
+        (
+            sim_data["spiralDitherFieldPerVisitRa"],
+            sim_data["spiralDitherFieldPerVisitDec"],
+        ) = wrap_ra_dec(
             sim_data["spiralDitherFieldPerVisitRa"],
             sim_data["spiralDitherFieldPerVisitDec"],
         )
@@ -739,7 +748,10 @@ class SpiralDitherFieldPerNightStacker(SpiralDitherFieldPerVisitStacker):
             )
             sim_data["spiralDitherFieldPerNightDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (sim_data["spiralDitherFieldPerNightRa"], sim_data["spiralDitherFieldPerNightDec"],) = wrap_ra_dec(
+        (
+            sim_data["spiralDitherFieldPerNightRa"],
+            sim_data["spiralDitherFieldPerNightDec"],
+        ) = wrap_ra_dec(
             sim_data["spiralDitherFieldPerNightRa"],
             sim_data["spiralDitherFieldPerNightDec"],
         )

--- a/rubin_sim/maf/stackers/dither_stackers.py
+++ b/rubin_sim/maf/stackers/dither_stackers.py
@@ -7,15 +7,16 @@ __all__ = (
     "BaseDitherStacker",
     "RandomDitherFieldPerVisitStacker",
     "RandomDitherFieldPerNightStacker",
-    "RandomDitherPerNightStacker",
     "SpiralDitherFieldPerVisitStacker",
     "SpiralDitherFieldPerNightStacker",
-    "SpiralDitherPerNightStacker",
     "HexDitherFieldPerVisitStacker",
     "HexDitherFieldPerNightStacker",
+    "RandomDitherPerNightStacker",
+    "SpiralDitherPerNightStacker",
     "HexDitherPerNightStacker",
     "RandomRotDitherPerFilterChangeStacker",
 )
+
 
 import warnings
 

--- a/rubin_sim/maf/stackers/dither_stackers.py
+++ b/rubin_sim/maf/stackers/dither_stackers.py
@@ -309,10 +309,7 @@ class RandomDitherFieldPerVisitStacker(BaseDitherStacker):
         sim_data["randomDitherFieldPerVisitRa"] = ra + self.x_off / np.cos(dec)
         sim_data["randomDitherFieldPerVisitDec"] = dec + self.y_off
         # Wrap back into expected range.
-        (
-            sim_data["randomDitherFieldPerVisitRa"],
-            sim_data["randomDitherFieldPerVisitDec"],
-        ) = wrap_ra_dec(
+        (sim_data["randomDitherFieldPerVisitRa"], sim_data["randomDitherFieldPerVisitDec"],) = wrap_ra_dec(
             sim_data["randomDitherFieldPerVisitRa"],
             sim_data["randomDitherFieldPerVisitDec"],
         )
@@ -425,10 +422,7 @@ class RandomDitherFieldPerNightStacker(RandomDitherFieldPerVisitStacker):
             )
             sim_data["randomDitherFieldPerNightDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (
-            sim_data["randomDitherFieldPerNightRa"],
-            sim_data["randomDitherFieldPerNightDec"],
-        ) = wrap_ra_dec(
+        (sim_data["randomDitherFieldPerNightRa"], sim_data["randomDitherFieldPerNightDec"],) = wrap_ra_dec(
             sim_data["randomDitherFieldPerNightRa"],
             sim_data["randomDitherFieldPerNightDec"],
         )
@@ -614,7 +608,7 @@ class SpiralDitherFieldPerVisitStacker(BaseDitherStacker):
         thetapts = np.zeros(self.num_points, float)
         for i, ap in enumerate(arcpts):
             diff = np.abs(arc - ap)
-            match = np.where(diff == diff.min())[0]
+            match = np.where(diff == diff.min())[0][0]
             rpts[i] = r[match]
             thetapts[i] = theta[match]
         # Translate these r/theta points into x/y (ra/dec) offsets.
@@ -643,10 +637,7 @@ class SpiralDitherFieldPerVisitStacker(BaseDitherStacker):
             )
             sim_data["spiralDitherFieldPerVisitDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (
-            sim_data["spiralDitherFieldPerVisitRa"],
-            sim_data["spiralDitherFieldPerVisitDec"],
-        ) = wrap_ra_dec(
+        (sim_data["spiralDitherFieldPerVisitRa"], sim_data["spiralDitherFieldPerVisitDec"],) = wrap_ra_dec(
             sim_data["spiralDitherFieldPerVisitRa"],
             sim_data["spiralDitherFieldPerVisitDec"],
         )
@@ -747,10 +738,7 @@ class SpiralDitherFieldPerNightStacker(SpiralDitherFieldPerVisitStacker):
             )
             sim_data["spiralDitherFieldPerNightDec"][match] = dec[match] + self.y_off[vertex_idxs]
         # Wrap into expected range.
-        (
-            sim_data["spiralDitherFieldPerNightRa"],
-            sim_data["spiralDitherFieldPerNightDec"],
-        ) = wrap_ra_dec(
+        (sim_data["spiralDitherFieldPerNightRa"], sim_data["spiralDitherFieldPerNightDec"],) = wrap_ra_dec(
             sim_data["spiralDitherFieldPerNightRa"],
             sim_data["spiralDitherFieldPerNightDec"],
         )

--- a/rubin_sim/maf/stackers/general_stackers.py
+++ b/rubin_sim/maf/stackers/general_stackers.py
@@ -69,15 +69,15 @@ class SaturationStacker(BaseStacker):
         self.airmass_col = airmass_col
         self.saturation_e = saturation_e
         self.pixscale = pixscale
+        self.zeropoints = zeropoints
+        self.km = km
+
+    def _run(self, sim_data, cols_present=False):
         if zeropoints is None:
             zp_inst, k_atm = load_inst_zeropoints()
             self.zeropoints = zp_inst
+        if self.km is None:
             self.km = k_atm
-        else:
-            self.zeropoints = zeropoints
-            self.km = km
-
-    def _run(self, sim_data, cols_present=False):
         for filtername in np.unique(sim_data[self.filter_col]):
             in_filt = np.where(sim_data[self.filter_col] == filtername)[0]
             # Calculate the length of the on-sky time per EXPOSURE

--- a/rubin_sim/maf/stackers/general_stackers.py
+++ b/rubin_sim/maf/stackers/general_stackers.py
@@ -73,7 +73,7 @@ class SaturationStacker(BaseStacker):
         self.km = km
 
     def _run(self, sim_data, cols_present=False):
-        if zeropoints is None:
+        if self.zeropoints is None:
             zp_inst, k_atm = load_inst_zeropoints()
             self.zeropoints = zp_inst
         if self.km is None:
@@ -143,7 +143,7 @@ class FiveSigmaStacker(BaseStacker):
 
     def _run(self, sim_data, cols_present=False):
         if cols_present:
-            # Column already present in data; assume it needs updating and recalculate.
+            # Column already present in data; assume it is fine.
             return sim_data
         filts = np.unique(sim_data[self.filter_col])
         for filtername in filts:

--- a/rubin_sim/maf/stackers/m5_optimal_stacker.py
+++ b/rubin_sim/maf/stackers/m5_optimal_stacker.py
@@ -66,7 +66,7 @@ class M5OptimalStacker(BaseStacker):
         been if the observation had been taken on the meridian.
     """
 
-    cols_added = ["m5Optimal"]
+    cols_added = ["m5_optimal"]
 
     def __init__(
         self,
@@ -74,6 +74,7 @@ class M5OptimalStacker(BaseStacker):
         dec_col="fieldDec",
         sky_bright_col="skyBrightness",
         seeing_col="seeingFwhmEff",
+        m5_col="fiveSigmaDepth",
         filter_col="filter",
         moon_alt_col="moonAlt",
         sun_alt_col="sunAlt",
@@ -88,8 +89,7 @@ class M5OptimalStacker(BaseStacker):
         self.filter_col = filter_col
         self.moon_alt_col = moon_alt_col
         self.sun_alt_col = sun_alt_col
-        self.m5_stacker = FiveSigmaStacker()
-        self.m5_col = self.m5_stacker.cols_added[0]
+        self.m5_col = m5_col
         self.cols_req = [
             airmass_col,
             dec_col,
@@ -99,12 +99,9 @@ class M5OptimalStacker(BaseStacker):
             moon_alt_col,
             sun_alt_col,
         ]
-        self.cols_req.extend(self.m5_stacker.cols_req)
         self.cols_req = list(set(self.cols_req))
 
     def _run(self, sim_data, cols_present=False):
-        sim_data, m5col_present = self.m5_stacker._add_stacker_cols(sim_data)
-        sim_data = self.m5_stacker._run(sim_data, m5col_present)
         # k_atm values from rubin_sim.operations gen_output.py
         k_atm = {"u": 0.50, "g": 0.21, "r": 0.13, "i": 0.10, "z": 0.07, "y": 0.18}
         # Linear fits to sky brightness change, no moon, twilight, or zodiacal components

--- a/rubin_sim/maf/stackers/sn_stacker.py
+++ b/rubin_sim/maf/stackers/sn_stacker.py
@@ -136,7 +136,10 @@ class CoaddStacker(BaseStacker):
                 if colname == "coadd":
                     r.append(1)
                 else:
-                    r.append(np.median(tab[colname]))
+                    if tab[colname].dtype == "object":
+                        r.append(tab[colname][0])
+                    else:
+                        r.append(np.median(tab[colname]))
             if colname == self.m5_col:
                 r.append(self.m5_coadd(tab[self.m5_col]))
             if colname in [
@@ -166,10 +169,4 @@ class CoaddStacker(BaseStacker):
         -----------
         "coadded" m5 value
         """
-
-        fluxes = 10 ** (-0.4 * m5)
-        sigmas = fluxes / 5.0
-        sigma_tot = 1.0 / np.sqrt(np.sum(1.0 / sigmas**2))
-        flux_tot = 5.0 * sigma_tot
-
-        return -2.5 * np.log10(flux_tot)
+        return 1.25 * np.log10(np.sum(10.0 ** (0.8 * m5)))

--- a/rubin_sim/maf/stackers/sn_stacker.py
+++ b/rubin_sim/maf/stackers/sn_stacker.py
@@ -12,10 +12,24 @@ class CoaddStacker(BaseStacker):
 
     Parameters
     ----------
-    list : str, optional
-        Name of the columns used.
-        Default : 'observationStartMJD', 'fieldRA', 'fieldDec','filter','fiveSigmaDepth','visitExposureTime','night','observationId', 'numExposures','visitTime'
-
+    mjd_col : `str`, optional
+        Name of the MJD column
+    ra_col : `str`, optional
+        Name of the RA column
+    dec_col : `str`, optional
+        Name of the Dec column
+    m5_col : `str`, optional
+        Name of the m5 column
+    filter_col : `str`, optional
+        Name of the filter column
+    night_col : `str`, optional
+        Name of the night column
+    num_exposures_col : `str`, optional
+        Name of the number of exposures per visit column
+    visit_time_col : `str`, optional
+        Name of the total visit time column
+    visit_exposure_time_col : `str`, optional
+        Name of the on-sky exposure time column
     """
 
     cols_added = ["coadd"]
@@ -26,7 +40,6 @@ class CoaddStacker(BaseStacker):
         ra_col="fieldRA",
         dec_col="fieldDec",
         m5_col="fiveSigmaDepth",
-        nightcol="night",
         filter_col="filter",
         night_col="night",
         num_exposures_col="numExposures",
@@ -57,14 +70,13 @@ class CoaddStacker(BaseStacker):
 
     def _run(self, sim_data, cols_present=False):
         """
-
         Parameters
-        ---------------
+        ------------
         sim_data : simulation data
         cols_present: to check whether the field has already been estimated
 
         Returns
-        -----------
+        --------
         numpy array of initial fields plus modified fields:
         - m5Col: "coadded" m5
         - numExposuresCol: sum of  numExposuresCol

--- a/rubin_sim/phot_utils/bandpass.py
+++ b/rubin_sim/phot_utils/bandpass.py
@@ -220,7 +220,9 @@ class Bandpass:
         tempbandpass = Bandpass()
         for component in component_list:
             # Read data from file.
-            tempbandpass.read_throughput(os.path.join(root_dir, component))
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                tempbandpass.read_throughput(os.path.join(root_dir, component))
             tempbandpass.resample_bandpass(
                 wavelen_min=wavelen_min,
                 wavelen_max=wavelen_max,

--- a/tests/maf/test_metricbundle.py
+++ b/tests/maf/test_metricbundle.py
@@ -36,7 +36,7 @@ class TestMetricBundle(unittest.TestCase):
         slicer = slicers.HealpixSlicer(nside=nside, camera_footprint_file=self.camera_footprint_file)
         metric = metrics.MeanMetric(col="airmass")
         sql = 'filter="r"'
-        stacker1 = stackers.RandomDitherFieldPerVisitStacker()
+        stacker1 = stackers.HourAngleStacker()
         stacker2 = stackers.GalacticStacker()
         map = maps.GalCoordsMap()
 

--- a/tests/maf/test_stackers.py
+++ b/tests/maf/test_stackers.py
@@ -33,12 +33,11 @@ class TestStackerClasses(unittest.TestCase):
             stacker_name = stacker.__class__.__name__.lower()
             if stacker_name.startswith("sdss"):
                 continue
+            if isinstance(stacker, stackers.BaseMoStacker):
+                continue
             try:
                 stacker.run(self.test_data)
             except NotImplementedError:
-                pass
-            except TypeError:
-                # moving object stacker, needs different data
                 pass
             except:
                 print(f"Failed at stacker {stacker.__class__.__name__}")
@@ -68,10 +67,6 @@ class TestStackerClasses(unittest.TestCase):
         s2 = stackers.ParallaxFactorStacker()
         assert s1 == s2
 
-        s1 = stackers.RandomDitherFieldPerVisitStacker()
-        s2 = stackers.RandomDitherFieldPerVisitStacker()
-        assert s1 == s2
-
         # Test if they have numpy array atributes
         s1.ack = np.arange(10)
         s2.ack = np.arange(10)
@@ -81,7 +76,7 @@ class TestStackerClasses(unittest.TestCase):
         s1.ack += 1
         assert s1 != s2
 
-        s2 = stackers.RandomDitherFieldPerVisitStacker(dec_col="blah")
+        s2 = stackers.NormAirmassStacker()
         assert s1 != s2
 
     def test_norm_airmass(self):
@@ -150,6 +145,7 @@ class TestStackerClasses(unittest.TestCase):
             self.assertAlmostEqual(dra_on_night.max(), 0)
             self.assertAlmostEqual(ddec_on_night.max(), 0)
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_setup_dither_stackers(self):
         # Test that we get no stacker when using default columns.
         ra_col = "fieldRA"
@@ -167,6 +163,7 @@ class TestStackerClasses(unittest.TestCase):
         stackerlist = stackers.setup_dither_stackers(ra_col, dec_col, degrees, max_dither=0.5)
         self.assertEqual(stackerlist[0].max_dither, np.radians(0.5))
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_base_dither_stacker(self):
         # Test that the base dither stacker matches the type of a stacker.
         s = stackers.HexDitherFieldPerNightStacker()
@@ -174,6 +171,7 @@ class TestStackerClasses(unittest.TestCase):
         s = stackers.ParallaxFactorStacker()
         self.assertFalse(isinstance(s, stackers.BaseDitherStacker))
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_random_dither(self):
         """
         Test the random dither pattern.
@@ -195,6 +193,7 @@ class TestStackerClasses(unittest.TestCase):
         # Check dithers within expected range.
         self._t_dither_range(diffsra, diffsdec, data["fieldRA"], data["fieldDec"], max_dither)
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_random_dither_per_night(self):
         """
         Test the per-night random dither pattern.
@@ -227,6 +226,7 @@ class TestStackerClasses(unittest.TestCase):
         # Check that dithers on the same night are the same.
         self._t_dither_per_night(diffsra, diffsdec, data["fieldRA"], data["fieldDec"], data["night"])
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_spiral_dither_per_night(self):
         """
         Test the per-night spiral dither pattern.
@@ -259,6 +259,7 @@ class TestStackerClasses(unittest.TestCase):
         # Check that dithers on the same night are the same.
         self._t_dither_per_night(diffsra, diffsdec, data["fieldRA"], data["fieldDec"], data["night"])
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_hex_dither_per_night(self):
         """
         Test the per-night hex dither pattern.
@@ -289,6 +290,7 @@ class TestStackerClasses(unittest.TestCase):
         # Check that dithers on the same night are the same.
         self._t_dither_per_night(diffsra, diffsdec, data["fieldRA"], data["fieldDec"], data["night"])
 
+    @unittest.skip("Dither Stackers deprecated")
     def test_random_rot_dither_per_filter_change_stacker(self):
         """
         Test the rotational dither stacker.

--- a/tests/maf/test_stackers.py
+++ b/tests/maf/test_stackers.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 import warnings
 
 import matplotlib
@@ -12,11 +13,34 @@ from rubin_sim.utils import (
     _galactic_from_equatorial,
     calc_lmst_last,
 )
+from rubin_sim.data import get_data_dir
+from rubin_sim.maf import get_sim_data
 
 matplotlib.use("Agg")
 
 
 class TestStackerClasses(unittest.TestCase):
+    def setUp(self):
+        # get some of the test data
+        test_db = os.path.join(get_data_dir(), "tests", "example_dbv1.7_0yrs.db")
+        query = "select * from observations limit 1000"
+        self.test_data = get_sim_data(test_db, None, [], full_sql_query=query)
+
+    def test_stackers_run(self):
+        """Just run all of the stackers with our example data."""
+        for stacker_class in stackers.BaseStacker.registry.values():
+            stacker = stacker_class()
+            try:
+                stacker.run(self.test_data)
+            except NotImplementedError:
+                pass
+            except TypeError:
+                # moving object stacker, needs different data
+                pass
+            except:
+                print(f"Failed at stacker {stacker.__class__.__name__}")
+                raise
+
     def test_add_cols(self):
         """Test that we can add columns as expected."""
         data = np.zeros(90, dtype=list(zip(["alt"], [float])))

--- a/tests/maf/test_stackers.py
+++ b/tests/maf/test_stackers.py
@@ -30,6 +30,9 @@ class TestStackerClasses(unittest.TestCase):
         """Just run all of the stackers with our example data."""
         for stacker_class in stackers.BaseStacker.registry.values():
             stacker = stacker_class()
+            stacker_name = stacker.__class__.__name__.lower()
+            if stacker_name.startswith("sdss"):
+                continue
             try:
                 stacker.run(self.test_data)
             except NotImplementedError:


### PR DESCRIPTION
If load_inst_zeropoints is in init method, then the actual throughput files are attempted to be read as soon as the stacker is instantiated (as in the batches or sometimes in metrics init methods). 
Moving the call to load_inst_zeropoints to the `run` method lets rubin_sim import even without data being available, instead of failing to import in that case. 