### PR TITLE
OPSIM-1069: fix m5 diff basis function

### DIFF
--- a/rubin_sim/scheduler/features/features.py
+++ b/rubin_sim/scheduler/features/features.py
@@ -127,7 +127,7 @@ class NObsCount(BaseSurveyFeature):
         if self.filtername is None:
             self.feature += np.size(observations_array)
         else:
-            in_filt = np.where(observations_array["filter"] == self.filter)[0]
+            in_filt = np.where(observations_array["filter"] == self.filtername)[0]
             self.feature += np.size(in_filt)
 
     def add_observation(self, observation, indx=None):

--- a/rubin_sim/scheduler/model_observatory/model_observatory.py
+++ b/rubin_sim/scheduler/model_observatory/model_observatory.py
@@ -1,5 +1,6 @@
 __all__ = ("ModelObservatory", "NoClouds", "NominalSeeing")
 
+
 import healpy as hp
 import numpy as np
 from astropy.coordinates import EarthLocation
@@ -215,11 +216,12 @@ class ModelObservatory:
         sun_moon_info = self.almanac.get_sun_moon_positions(self.mjd)
         season_offset = create_season_offset(self.nside, sun_moon_info["sun_RA"])
         self.sun_ra_start = sun_moon_info["sun_RA"] + 0
+        self.season_offset = season_offset
         # Conditions object to update and return on request
         self.conditions = Conditions(
             nside=self.nside,
-            mjd_start=mjd_start,
-            season_offset=season_offset,
+            mjd_start=self.mjd_start,
+            season_offset=self.season_offset,
             sun_ra_start=self.sun_ra_start,
         )
 
@@ -246,8 +248,13 @@ class ModelObservatory:
         -------
         rubin_sim.scheduler.features.conditions object
         """
-
-        self.conditions.mjd = self.mjd
+        self.conditions = Conditions(
+            nside=self.nside,
+            mjd_start=self.mjd_start,
+            season_offset=self.season_offset,
+            sun_ra_start=self.sun_ra_start,
+            mjd=self.mjd,
+        )
 
         self.conditions.night = int(self.night)
         # Current time as astropy time


### PR DESCRIPTION
Fix bug where M5Diff was using the dark sky brightness rather than the best possible 5-sigma limiting depth. Also update model observatory to create fresh Conditions objects to prevent excessive warnings.