### PR TITLE
OPSIM:1050 Update m52snr and add y-band parallax metric 

### DIFF
--- a/rubin_sim/maf/batches/common.py
+++ b/rubin_sim/maf/batches/common.py
@@ -13,7 +13,6 @@ __all__ = (
     "microlensing_summary",
 )
 
-import inspect
 
 import rubin_sim.maf.metrics as metrics
 

--- a/rubin_sim/maf/batches/glance_batch.py
+++ b/rubin_sim/maf/batches/glance_batch.py
@@ -499,7 +499,7 @@ def glanceBatch(
 
     # Add basic slew stats.
     try:
-        slewDict = slewBasics(colmap=colmap, runName=run_name)
+        slewDict = slewBasics(colmap=colmap, run_name=run_name)
         bd.update(slewDict)
     except KeyError as e:
         warnings.warn("Could not add slew stats: missing required key %s from colmap" % (e))

--- a/rubin_sim/maf/batches/glance_batch.py
+++ b/rubin_sim/maf/batches/glance_batch.py
@@ -473,7 +473,7 @@ def glanceBatch(
     for filtername in filternames:
         sql = "filter='%s' and night < 365" % filtername
         metric = metrics.CountMetric(col="night", metric_name="N year 1")
-        summary_stat = metrics.FootprintFraction(
+        summary_stat = metrics.FootprintFractionMetric(
             footprint=footprints_hp_array[filtername],
             n_min=3,
         )

--- a/rubin_sim/maf/batches/moving_objects_batch.py
+++ b/rubin_sim/maf/batches/moving_objects_batch.py
@@ -183,14 +183,14 @@ def quick_discovery_batch(
     def _configure_child_bundles(parentBundle):
         dispDict = {
             "group": f"{objtype}",
-            "subgroup": f"Completeness Over Time",
+            "subgroup": "Completeness Over Time",
             "caption": "Time of discovery of objects",
             "order": 0,
         }
         parentBundle.child_bundles["Time"].set_display_dict(dispDict)
         dispDict = {
             "group": f"{objtype}",
-            "subgroup": f"N Chances",
+            "subgroup": "N Chances",
             "caption": "Number of chances for discovery of objects",
             "order": 0,
         }
@@ -326,14 +326,14 @@ def discovery_batch(
     def _configure_child_bundles(parentBundle):
         dispDict = {
             "group": f"{objtype}",
-            "subgroup": f"Completeness Over Time",
+            "subgroup": "Completeness Over Time",
             "caption": "Time of discovery of objects",
             "order": 0,
         }
         parentBundle.child_bundles["Time"].set_display_dict(dispDict)
         dispDict = {
             "group": f"{objtype}",
-            "subgroup": f"N Chances",
+            "subgroup": "N Chances",
             "caption": "Number of chances for discovery of objects",
             "order": 0,
         }
@@ -734,7 +734,7 @@ def run_completeness_summary(bdict, h_mark, times, out_dir, results_db):
     # Write the completeness bundles to disk, so we can re-read them later.
     # (also set the display dict properties, for the results_db output).
     for b, bundle in completeness.items():
-        bundle.display_dict["subgroup"] = f"Completeness"
+        bundle.display_dict["subgroup"] = "Completeness"
         bundle.write(out_dir=out_dir, results_db=results_db)
 
     # Calculate total number of objects - currently for NEOs and PHAs only
@@ -825,7 +825,7 @@ def plot_completeness(
     plt.grid(True, alpha=0.3)
     # Make a PlotHandler to deal with savings/results_db, etc.
     ph = plots.PlotHandler(fig_format=fig_format, results_db=results_db, out_dir=out_dir)
-    display_dict["subgroup"] = f"Completeness over time"
+    display_dict["subgroup"] = "Completeness over time"
     display_dict["caption"] = "Completeness over time, for H values indicated in legend."
     ph.save_fig(
         fig.number,
@@ -881,7 +881,7 @@ def plot_completeness(
         "legendloc": (1.01, 0.1),
         "color": None,
     }
-    display_dict["subgroup"] = f"Completeness all criteria"
+    display_dict["subgroup"] = "Completeness all criteria"
     display_dict["caption"] = "Plotting all of the cumulative completeness curves together."
     ph.plot(
         plot_func=plots.MetricVsH(),
@@ -949,7 +949,7 @@ def characterization_inner_batch(
 
     # Number of observations.
     md = info_label
-    display_dict["subgroup"] = f"N Obs"
+    display_dict["subgroup"] = "N Obs"
     plotDict = {
         "ylabel": "Number of observations (#)",
         "title": "%s: Number of observations %s" % (run_name, md),
@@ -971,7 +971,7 @@ def characterization_inner_batch(
 
     # Observational arc.
     md = info_label
-    display_dict["subgroup"] = f"Obs Arc"
+    display_dict["subgroup"] = "Obs Arc"
     plotDict = {
         "ylabel": "Observational Arc (days)",
         "title": "%s: Observational Arc Length %s" % (run_name, md),
@@ -992,7 +992,7 @@ def characterization_inner_batch(
     bundleList.append(bundle)
 
     # Activity detection.
-    display_dict["subgroup"] = f"Activity"
+    display_dict["subgroup"] = "Activity"
     for w in windows:
         md = info_label + " activity lasting %.0f days" % w
         plotDict = {
@@ -1037,7 +1037,7 @@ def characterization_inner_batch(
 
     # Lightcurve inversion.
     md = info_label
-    display_dict["subgroup"] = f"Color/Inversion"
+    display_dict["subgroup"] = "Color/Inversion"
     plotDict = {
         "y_min": 0,
         "y_max": 1,
@@ -1146,7 +1146,7 @@ def characterization_outer_batch(
 
     # Number of observations.
     md = info_label
-    display_dict["subgroup"] = f"N Obs"
+    display_dict["subgroup"] = "N Obs"
     plotDict = {
         "ylabel": "Number of observations (#)",
         "title": "%s: Number of observations %s" % (run_name, md),
@@ -1168,7 +1168,7 @@ def characterization_outer_batch(
 
     # Observational arc.
     md = info_label
-    display_dict["subgroup"] = f"Obs Arc"
+    display_dict["subgroup"] = "Obs Arc"
     plotDict = {
         "ylabel": "Observational Arc (days)",
         "title": "%s: Observational Arc Length %s" % (run_name, md),
@@ -1189,7 +1189,7 @@ def characterization_outer_batch(
     bundleList.append(bundle)
 
     # Activity detection.
-    display_dict["subgroup"] = f"Activity"
+    display_dict["subgroup"] = "Activity"
     for w in windows:
         md = info_label + " activity lasting %.0f days" % w
         plotDict = {
@@ -1234,7 +1234,7 @@ def characterization_outer_batch(
 
     # Color determination.
     md = info_label
-    display_dict["subgroup"] = f"Color/Inversion"
+    display_dict["subgroup"] = "Color/Inversion"
     plotDict = {
         "y_min": 0,
         "y_max": 1,
@@ -1375,7 +1375,7 @@ def plot_fractions(
     if figroot is None:
         figroot = run_name
     display_dict = deepcopy(first.display_dict)
-    display_dict["subgroup"] = f"Characterization Fraction"
+    display_dict["subgroup"] = "Characterization Fraction"
 
     ph = plots.PlotHandler(fig_format=fig_format, results_db=results_db, out_dir=out_dir)
     ph.set_metric_bundles(bdictFractions)

--- a/rubin_sim/maf/batches/radar_limited.py
+++ b/rubin_sim/maf/batches/radar_limited.py
@@ -568,8 +568,8 @@ def radar_limited(
     subgroupCount += 1
     displayDict["subgroup"] = f"{subgroupCount}: WL"
     displayDict["order"] = 0
-    sqlconstraint = f'note not like "DD%" and (filter="g" or filter="r" or filter="i")'
-    info_label = f"gri band non-DD"
+    sqlconstraint = 'note not like "DD%" and (filter="g" or filter="r" or filter="i")'
+    info_label = "gri band non-DD"
     minExpTime = 15
     m = metrics.WeakLensingNvisits(
         lsst_filter=bandpass,

--- a/rubin_sim/maf/batches/science_radar_batch.py
+++ b/rubin_sim/maf/batches/science_radar_batch.py
@@ -589,7 +589,7 @@ def science_radar_batch(
     plotDict = {"n_ticks": 5}
     # Have to include all filters in query, so that we check for all-band coverage.
     # Galaxy numbers calculated using 'bandpass' images only though.
-    sqlconstraint = f'note not like "DD%"'
+    sqlconstraint = 'note not like "DD%"'
     info_label = f"{bandpass} band galaxies non-DD"
     metric = maf.DepthLimitedNumGalMetric(
         nside=nside,
@@ -628,8 +628,8 @@ def science_radar_batch(
     subgroupCount += 1
     displayDict["subgroup"] = f"{subgroupCount}: WL"
     displayDict["order"] = 0
-    sqlconstraint = f'note not like "DD%" and (filter="g" or filter="r" or filter="i")'
-    info_label = f"gri band non-DD"
+    sqlconstraint = 'note not like "DD%" and (filter="g" or filter="r" or filter="i")'
+    info_label = "gri band non-DD"
     minExpTime = 15
     m = metrics.WeakLensingNvisits(
         lsst_filter=bandpass,
@@ -1457,9 +1457,9 @@ def science_radar_batch(
     plotDict = {"color_min": 0, "color_max": 1500, "x_min": 0, "x_max": 2000}
     displayDict["order"] = 0
     displayDict["caption"] = (
-        f"Evaluate the distribution of filter pairs and time gaps at each point in "
-        f"the sky. The time gaps are evaluated on a logarithmic spacing "
-        f"from 0-100 days for pairs of filters, and 0-3650 days for same filters."
+        "Evaluate the distribution of filter pairs and time gaps at each point in "
+        "the sky. The time gaps are evaluated on a logarithmic spacing "
+        "from 0-100 days for pairs of filters, and 0-3650 days for same filters."
     )
     summarystats = [
         metrics.MedianMetric(),
@@ -1881,8 +1881,8 @@ def science_radar_batch(
     # galaxy counting uses dustmap
     slicer = slicers.HealpixSlicer(nside=nside, use_cache=False)
     displayDict["caption"] = (
-        f"Approximate number of resolvable galaxies in i band, scaled by the "
-        f"coadded depth and median seeing. A dust and magnitude cut has been applied."
+        "Approximate number of resolvable galaxies in i band, scaled by the "
+        "coadded depth and median seeing. A dust and magnitude cut has been applied."
     )
     bundle = mb.MetricBundle(
         metric,
@@ -1901,9 +1901,9 @@ def science_radar_batch(
     # NlcPoints metric uses star density maps
     slicer = slicers.HealpixSlicer(nside=nside, use_cache=False)
     displayDict["caption"] = (
-        f"Approximate number of expected stellar measurements (nstars * nobs) "
-        f"in all filters, where the limiting magnitude for at least 10 visits "
-        f"is fainter than 21st magnitude, using a TRILEGAL stellar density map."
+        "Approximate number of expected stellar measurements (nstars * nobs) "
+        "in all filters, where the limiting magnitude for at least 10 visits "
+        "is fainter than 21st magnitude, using a TRILEGAL stellar density map."
     )
     bundle = mb.MetricBundle(
         metric,

--- a/rubin_sim/maf/batches/slew_batch.py
+++ b/rubin_sim/maf/batches/slew_batch.py
@@ -12,7 +12,7 @@ from .col_map_dict import col_map_dict
 from .common import standard_metrics
 
 
-def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
+def slewBasics(colmap=None, run_name="opsim", sql_constraint=None):
     """Generate a simple set of statistics about the slew times and distances.
     These slew statistics can be run on the summary or default tables.
 
@@ -39,8 +39,8 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
     slicer = slicers.UniSlicer()
 
     info_label = "All visits"
-    if sqlConstraint is not None and len(sqlConstraint) > 0:
-        info_label = "%s" % (sqlConstraint)
+    if sql_constraint is not None and len(sql_constraint) > 0:
+        info_label = "%s" % (sql_constraint)
     displayDict = {
         "group": "Slew",
         "subgroup": "Slew Basics",
@@ -51,7 +51,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
     metric = metrics.CountMetric(colmap["slewtime"], metric_name="Slew Count")
     displayDict["caption"] = "Total number of slews recorded in summary table."
     displayDict["order"] += 1
-    bundle = mb.MetricBundle(metric, slicer, sqlConstraint, info_label=info_label, display_dict=displayDict)
+    bundle = mb.MetricBundle(metric, slicer, sql_constraint, info_label=info_label, display_dict=displayDict)
     bundleList.append(bundle)
     for metric in standard_metrics(colmap["slewtime"]):
         displayDict["caption"] = "%s in seconds." % (metric.name)
@@ -59,7 +59,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
         bundle = mb.MetricBundle(
             metric,
             slicer,
-            sqlConstraint,
+            sql_constraint,
             info_label=info_label,
             display_dict=displayDict,
         )
@@ -75,7 +75,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
     bundle = mb.MetricBundle(
         metric,
         slicer,
-        sqlConstraint,
+        sql_constraint,
         info_label=info_label,
         plot_dict=plotDict,
         display_dict=displayDict,
@@ -91,7 +91,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
     bundle = mb.MetricBundle(
         metric,
         slicer,
-        sqlConstraint,
+        sql_constraint,
         info_label=info_label,
         plot_dict=plotDict,
         display_dict=displayDict,
@@ -111,7 +111,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
         bundle = mb.MetricBundle(
             metric,
             slicer,
-            sqlConstraint,
+            sql_constraint,
             info_label=info_label,
             plot_dict=plotDict,
             display_dict=displayDict,
@@ -134,7 +134,7 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
         bundle = mb.MetricBundle(
             metric,
             slicer,
-            sqlConstraint,
+            sql_constraint,
             info_label=info_label,
             plot_dict=plotDict,
             display_dict=displayDict,
@@ -143,5 +143,5 @@ def slewBasics(colmap=None, runName="opsim", sqlConstraint=None):
 
     # Set the run_name for all bundles and return the bundleDict.
     for b in bundleList:
-        b.set_run_name(runName)
+        b.set_run_name(run_name)
     return mb.make_bundles_dict_from_list(bundleList)

--- a/rubin_sim/maf/batches/visitdepth_batch.py
+++ b/rubin_sim/maf/batches/visitdepth_batch.py
@@ -24,25 +24,23 @@ def nvisitsM5Maps(
     slicer=None,
     runLength=10.0,
 ):
-    """Generate maps of the number of visits and coadded depth (with and without dust extinction)
-    in all bands and per filter.
+    """Generate maps of the number of visits and coadded depth
+    (with and without dust extinction) in all bands and per filter.
 
     Parameters
     ----------
     colmap : `dict`, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+        A dictionary with a mapping of column names.
     runName : `str`, optional
-        The name of the simulated survey. Default is "opsim".
+        The name of the simulated survey.
     extraSql : `str`, optional
-        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
-        Default None, for no additional constraints.
+        Additional constraint to add to any sql constraints.
     extraInfoLabel : `str`, optional
-        Additional info_label to add before any below (i.e. "WFD").  Default is None.
+        Additional info_label to add before any below (i.e. "WFD").
     slicer :  `rubin_sim.maf.slicer` or None, optional
         Optionally, use something other than an nside=64 healpix slicer
     runLength : `float`, optional
         Length of the simulated survey, for scaling values for the plot limits.
-        Default 10.
 
     Returns
     -------
@@ -140,7 +138,6 @@ def nvisitsM5Maps(
         # Skip "all" for coadded depth.
         if f == "all":
             continue
-        mag_zp = benchmarkVals["coaddedDepth"][f]
         sql = sqls[f]
         displayDict["caption"] = f"Coadded depth per healpix in {info_label[f]}."
         displayDict["caption"] += " More positive numbers indicate fainter limiting magnitudes."
@@ -168,7 +165,6 @@ def nvisitsM5Maps(
         # Skip "all" for coadded depth.
         if f == "all":
             continue
-        mag_zp = benchmarkVals["coaddedDepth"][f]
         sql = sqls[f]
         displayDict["caption"] = (
             "Coadded depth per healpix for extragalactic purposes "
@@ -178,7 +174,7 @@ def nvisitsM5Maps(
         displayDict["caption"] += " More positive numbers indicate fainter limiting magnitudes."
         displayDict["order"] = orders[f]
         plotDict = {
-            "percentile_clip": 93,
+            "percentile_clip": 90,
             "color": colors[f],
         }
         bundle = mb.MetricBundle(
@@ -205,19 +201,19 @@ def tEffMetrics(
     extraInfoLabel=None,
     slicer=None,
 ):
-    """Generate a series of Teff metrics. Teff total, per night, and sky maps (all and per filter).
+    """Generate a series of Teff metrics.
+    Teff total, per night, and sky maps (all and per filter).
 
     Parameters
     ----------
     colmap : `dict`, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+        A dictionary with a mapping of column names.
     runName : `str`, optional
-        The name of the simulated survey. Default is "opsim".
+        The name of the simulated survey.
     extraSql : `str`, optional
-        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
-        Default None, for no additional constraints.
+        Additional constraint to add to any sql constraints.
     extraInfoLabel : `str`, optional
-        Additional info_label to add before any below (i.e. "WFD").  Default is None.
+        Additional info_label to add before any below (i.e. "WFD").
     slicer : `rubin_sim.maf.slicer` or None, optional
         Optionally, use something other than an nside=64 healpix slicer
 
@@ -330,18 +326,17 @@ def nvisitsPerNight(
     Parameters
     ----------
     colmap : `dict` or None, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+        A dictionary with a mapping of column names.
     runName : `str`, optional
         The name of the simulated survey. Default is "opsim".
     binNights : `int`, optional
-        Number of nights to count in each bin. Default = 1, count number of visits in each night.
+        Number of nights to count in each bin.
     extraSql : `str` or None, optional
-        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
-        Default None, for no additional constraints.
+        Additional constraint to add to any sql constraints.
     extraInfoLabel : `str` or None, optional
-        Additional info_label to add before any below (i.e. "WFD").  Default is None.
+        Additional info_label to add before any below (i.e. "WFD").
     subgroup : `str` or None, optional
-        Use this for the 'subgroup' in the display_dict, instead of info_label. Default is None.
+        Use this for the 'subgroup' in the display_dict, instead of info_label.
 
     Returns
     -------
@@ -394,27 +389,29 @@ def nvisitsPerSubset(
     footprintConstraint=None,
     extraInfoLabel=None,
 ):
-    """Look at the distribution of a given sql constraint or footprint constraint's visits,
-    total number and distribution over time (# per night), if possible.
+    """Look at the distribution of a given sql constraint or
+    footprint constraint's visits, total number and distribution over time
+    (# per night), if possible.
 
     Parameters
     ----------
     opsdb : `str` or database connection
         Name of the opsim sqlite database.
     colmap : `dict` or None, optional
-        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+        A dictionary with a mapping of column names.
     runName : `str`, optional
         The name of the simulated survey. Default is "opsim".
     binNights : `int`, optional
-        Number of nights to count in each bin. Default = 1, count number of visits in each night.
+        Number of nights to count in each bin.
     constraint : `str` or None, optional
         SQL constraint to add to all metrics.
-        This would be the way to select only a given "Note" out of a simulation.
+        This would be the way to select only a given "Note".
     footprintConstraint : `np.ndarray` or None, optional
-        Footprint to look for visits within (and then identify via WFDlabelStacker).
+        Footprint to look for visits within
+        (and then identify via WFDlabelStacker).
         The footprint = a full length heapix array, filled with 0/1 values.
     extraInfoLabel : `str` or None, optional
-        Additional info_label to add before any below (i.e. "WFD").  Default is None.
+        Additional info_label to add before any below (i.e. "WFD").
 
     Returns
     -------
@@ -456,7 +453,8 @@ def nvisitsPerSubset(
         )
         bundleList.append(bundle)
 
-    # Or count the total number of visits that contribute towards a given footprint
+    # Or count the total number of visits that contribute
+    # towards a given footprint
     if footprintConstraint is not None:
         # Set up a stacker to use this footprint to label visits
         if extraInfoLabel is None:

--- a/rubin_sim/maf/metric_bundles/metric_bundle.py
+++ b/rubin_sim/maf/metric_bundles/metric_bundle.py
@@ -304,8 +304,9 @@ class MetricBundle:
 
         Parameters
         ----------
-        summary_metrics : List[BaseMetric]
-            Instantiated summary metrics to use to calculate summary statistics for this metric.
+        summary_metrics : `List` of [`BaseMetric`]
+            Instantiated summary metrics to use to calculate
+            summary statistics for this metric.
         """
         if summary_metrics is not None:
             if isinstance(summary_metrics, metrics.BaseMetric):
@@ -317,7 +318,8 @@ class MetricBundle:
                         raise ValueError("SummaryStats must only contain rubin_sim.maf.metrics objects")
                     self.summary_metrics.append(s)
         else:
-            # Add identity metric to unislicer metric values (to get them into resultsDB).
+            # Add identity metric to unislicer metric values
+            # (to get them into resultsDB).
             if self.slicer.slicer_name == "UniSlicer":
                 self.summary_metrics = [metrics.IdentityMetric()]
             else:
@@ -326,12 +328,13 @@ class MetricBundle:
     def set_plot_funcs(self, plot_funcs):
         """Set or reset the plotting functions.
 
-        The default is to use all the plotFuncs associated with the slicer, which
-        is what happens in self.plot if setPlotFuncs is not used to override self.plotFuncs.
+        The default is to use all the plotFuncs associated with the slicer,
+        which is what happens in self.plot if setPlotFuncs is not used to
+        override self.plotFuncs.
 
         Parameters
         ----------
-        plot_funcs : List[BasePlotter]
+        plot_funcs : `List` [`BasePlotter`]
             The plotter or plotters to use to generate visuals for this metric.
         """
         if plot_funcs is not None:
@@ -386,13 +389,14 @@ class MetricBundle:
 
         Parameters
         ----------
-        display_dict : Optional[dict]
-            Dictionary of display parameters for showMaf.
-            Expected keywords: 'group', 'subgroup', 'order', 'caption'.
-            'group', 'subgroup', and 'order' control where the metric results are shown on the showMaf page.
+        display_dict : `dict` of `str`
+            Dictionary of display parameters for show_maf.
+            Expected keys are: 'group', 'subgroup', 'order', 'caption'.
+            'group', 'subgroup', and 'order' control where the
+            metric results are shown on the show_maf page.
             'caption' provides a caption to use with the metric results.
             These values are saved in the results database.
-        results_db : Optional[ResultsDb]
+        results_db : `maf.ResultsDb`
             A MAF results database, used to save the display parameters.
         """
         # Set up a temporary dictionary with the default values.
@@ -439,21 +443,22 @@ class MetricBundle:
             results_db.update_display(metric_id, self.display_dict)
 
     def set_run_name(self, run_name, update_file_root=True):
-        """Set (or reset) the run_name. FileRoot will be updated accordingly if desired.
+        """Set (or reset) the run_name.
+        FileRoot will be updated accordingly if desired.
 
         Parameters
         ----------
-        run_name: str
+        run_name: `str`
             Run Name, which will become part of the fileRoot.
-        fileRoot: bool, optional
-            Flag to update the fileRoot with the run_name. Default True.
+        fileRoot: `bool`, optional
+            Flag to update the fileRoot with the run_name.
         """
         self.run_name = run_name
         if update_file_root:
             self._build_file_root()
 
     def write_db(self, results_db=None, outfile_suffix=None):
-        """Write the metric_values to the database"""
+        """Write the metric information to the results database"""
         if outfile_suffix is not None:
             outfile = self.file_root + "_" + outfile_suffix + ".npz"
         else:
@@ -474,13 +479,14 @@ class MetricBundle:
 
         Parameters
         ----------
-        comment : Optional[str]
+        comment : `str`
             Any additional comments to add to the output file
-        out_dir : Optional[str]
+        out_dir : `str`
             The output directory
-        outfile_suffix : Optional[str]
-            Additional suffix to add to the output files (typically a numerical suffix for movies)
-        results_db : Optional[ResultsDb]
+        outfile_suffix :`str`
+            Additional suffix to add to the output files
+            (typically a numerical suffix for movies)
+        results_db : `maf.ResultsDb`
             Results database to store information on the file output
         """
         if outfile_suffix is not None:
@@ -518,12 +524,12 @@ class MetricBundle:
         return io
 
     def read(self, filename):
-        """Read metric_values and associated info_label from disk.
+        """Read metric data from disk.
         Overwrites any data currently in metricbundle.
 
         Parameters
         ----------
-        filename : str
+        filename : `str`
            The file from which to read the metric bundle data.
         """
         if not os.path.isfile(filename):

--- a/rubin_sim/maf/metric_bundles/metric_bundle.py
+++ b/rubin_sim/maf/metric_bundles/metric_bundle.py
@@ -502,6 +502,7 @@ class MetricBundle:
             info_label=self.info_label + comment,
             display_dict=self.display_dict,
             plot_dict=self.plot_dict,
+            summary_values=self.summary_values,
         )
         if results_db is not None:
             self.write_db(results_db=results_db)
@@ -566,6 +567,8 @@ class MetricBundle:
                 self.set_plot_dict(header["plot_dict"])
             if "display_dict" in header:
                 self.set_display_dict(header["display_dict"])
+            if "summary_values" in header:
+                self.summary_values = header["summary_values"]
         if self.info_label is None:
             self._build_metadata()
         path, head = os.path.split(filename)

--- a/rubin_sim/maf/metrics/base_metric.py
+++ b/rubin_sim/maf/metrics/base_metric.py
@@ -61,7 +61,8 @@ class MetricRegistry(type):
 
 class ColRegistry:
     """
-    ColRegistry tracks the columns needed for all metric objects (kept internally in a set).
+    ColRegistry tracks the columns needed for all metric objects
+    (kept internally in a set).
 
     ColRegistry.col_set : a set of all unique columns required for metrics.
     ColRegistry.dbCols : the subset of these which come from the database.
@@ -82,12 +83,13 @@ class ColRegistry:
     def add_cols(self, col_array):
         """Add the columns in ColArray into the ColRegistry.
 
-        Add the columns in col_array into the ColRegistry set (self.col_set) and identifies their source,
-         using ColInfo (rubin_sim.maf.stackers.getColInfo).
+        Add the columns in col_array into the ColRegistry set (self.col_set)
+        and identifies their source, using ColInfo
+        (rubin_sim.maf.stackers.getColInfo).
 
         Parameters
         ----------
-        col_array : list
+        col_array : `list`
             list of columns used in a metric.
         """
         for col in col_array:
@@ -104,8 +106,9 @@ class ColRegistry:
 class BaseMetric(with_metaclass(MetricRegistry, object)):
     """
     Base class for the metrics.
-    Sets up some basic functionality for the MAF framework: after __init__ every metric will
-    record the columns (and stackers) it requires into the column registry, and the metric_name,
+    Sets up some basic functionality for the MAF framework:
+    after __init__ every metric will record the columns (and stackers)
+    it requires into the column registry, and the metric_name,
     metric_dtype, and units for the metric will be set.
 
     Parameters
@@ -170,8 +173,7 @@ class BaseMetric(with_metaclass(MetricRegistry, object)):
         self.reduce_order = {}
         for i, r in enumerate(inspect.getmembers(self, predicate=inspect.ismethod)):
             if r[0].startswith("reduce"):
-                # Automatically named reduce functions have "reduce_" at the start of their name,
-                # which is undesirable to read in the output.
+                # Remove the "reduce_" part of the reduce functions names.
                 reducename = r[0].replace("reduce_", "", 1)
                 self.reduce_funcs[reducename] = r[1]
                 self.reduce_order[reducename] = i
@@ -189,7 +191,8 @@ class BaseMetric(with_metaclass(MetricRegistry, object)):
                 units = ""
         self.units = units
         # Add the ability to set a comment
-        # (that could be propagated automatically to a benchmark's display caption).
+        # (that could be propagated automatically to a benchmark's
+        # display caption).
         self.comment = None
 
         # Default to only return one metric value per slice
@@ -200,9 +203,9 @@ class BaseMetric(with_metaclass(MetricRegistry, object)):
 
         Parameters
         ----------
-        data_slice : `numpy.recarray`
-           Values passed to metric by the slicer, which the metric will use to calculate
-           metric values at each slice_point.
+        data_slice : `numpy.ndarray`, (N,)
+           Values passed to metric by the slicer, which the metric will
+           use to calculate metric values at each slice_point.
         slice_point : `dict` or None
            Dictionary of slice_point metadata passed to each metric.
            E.g. the ra/dec of the healpix pixel or opsim fieldId.

--- a/rubin_sim/maf/metrics/brown_dwarf_metric.py
+++ b/rubin_sim/maf/metrics/brown_dwarf_metric.py
@@ -126,9 +126,7 @@ class BDParallaxMetric(BaseMetric):
                     self.mags[str(filt)][:, np.newaxis], data_slice[self.m5_col][good]
                 )
 
-        position_errors = np.sqrt(
-            mafUtils.astrom_precision(data_slice[self.seeing_col], snr) ** 2 + self.atm_err**2
-        )
+        position_errors = mafUtils.astrom_precision(data_slice[self.seeing_col], snr, self.atm_err)
         # uncertainty in the parallax in mas
         sigma = self._final_sigma(position_errors, data_slice["ra_pi_amp"], data_slice["dec_pi_amp"])
         fitted_parallax_snr = self.parallaxes / sigma

--- a/rubin_sim/maf/metrics/calibration_metrics.py
+++ b/rubin_sim/maf/metrics/calibration_metrics.py
@@ -124,9 +124,7 @@ class ParallaxMetric(BaseMetric):
         for filt in filters:
             good = np.where(data_slice[self.filter_col] == filt)
             snr[good] = mafUtils.m52snr(self.mags[str(filt)], data_slice[self.m5_col][good])
-        position_errors = np.sqrt(
-            mafUtils.astrom_precision(data_slice[self.seeing_col], snr) ** 2 + self.atm_err**2
-        )
+        position_errors = mafUtils.astrom_precision(data_slice[self.seeing_col], snr, self.atm_err)
         sigma = self._final_sigma(position_errors, data_slice["ra_pi_amp"], data_slice["dec_pi_amp"])
         if self.normalize:
             # Leave the dec parallax as zero since one can't have ra and dec maximized at the same time.

--- a/rubin_sim/maf/metrics/calibration_metrics.py
+++ b/rubin_sim/maf/metrics/calibration_metrics.py
@@ -67,9 +67,7 @@ class ParallaxMetric(BaseMetric):
             units = "ratio"
         else:
             units = "mas"
-        super(ParallaxMetric, self).__init__(
-            cols, metric_name=metric_name, units=units, badval=badval, **kwargs
-        )
+        super().__init__(cols, units=units, badval=badval, **kwargs)
         # set return type
         self.m5_col = m5_col
         self.seeing_col = seeing_col

--- a/rubin_sim/maf/metrics/calibration_metrics.py
+++ b/rubin_sim/maf/metrics/calibration_metrics.py
@@ -240,9 +240,8 @@ class ProperMotionMetric(BaseMetric):
             else:
                 snr = mafUtils.m52snr(self.mags[f], data_slice[self.m5_col][observations])
                 precis[observations] = mafUtils.astrom_precision(
-                    data_slice[self.seeing_col][observations], snr
+                    data_slice[self.seeing_col][observations], snr, self.atm_err
                 )
-                precis[observations] = np.sqrt(precis[observations] ** 2 + self.atm_err**2)
         good = np.where(precis != self.badval)
         result = mafUtils.sigma_slope(data_slice[self.mjd_col][good], precis[good])
         result = result * 365.25 * 1e3  # Convert to mas/yr
@@ -364,9 +363,7 @@ class ParallaxCoverageMetric(BaseMetric):
 
     def _compute_weights(self, data_slice, snr):
         # Compute centroid uncertainty in each visit
-        position_errors = np.sqrt(
-            mafUtils.astrom_precision(data_slice[self.seeing_col], snr) ** 2 + self.atm_err**2
-        )
+        position_errors = mafUtils.astrom_precision(data_slice[self.seeing_col], snr, self.atm_err)
         weights = 1.0 / position_errors**2
         return weights
 
@@ -493,9 +490,7 @@ class ParallaxDcrDegenMetric(BaseMetric):
         # Compute the centroiding uncertainties
         # Note that these centroiding uncertainties depend on the physical size of the PSF, thus
         # we are using seeingFwhmGeom for these metrics, not seeingFwhmEff.
-        position_errors = np.sqrt(
-            mafUtils.astrom_precision(data_slice[self.seeing_col], snr) ** 2 + self.atm_err**2
-        )
+        position_errors = mafUtils.astrom_precision(data_slice[self.seeing_col], snr, self.atm_err)
         # Construct the vectors of RA/Dec offsets. xdata is the "input data". ydata is the "output".
         xdata = np.empty((2, data_slice.size * 2), dtype=float)
         xdata[0, :] = np.concatenate((data_slice["ra_pi_amp"], data_slice["dec_pi_amp"]))

--- a/rubin_sim/maf/metrics/calibration_metrics.py
+++ b/rubin_sim/maf/metrics/calibration_metrics.py
@@ -16,39 +16,42 @@ from .base_metric import BaseMetric
 
 
 class ParallaxMetric(BaseMetric):
-    """Calculate the uncertainty in a parallax measurement given a series of observations.
+    """Calculate the uncertainty in a parallax measurement
+    given a series of observations.
 
-    Uses columns ra_pi_amp and dec_pi_amp, calculated by the ParallaxFactorStacker.
+    Uses columns ra_pi_amp and dec_pi_amp,
+    calculated by the ParallaxFactorStacker.
 
     Parameters
     ----------
-    metricName : str, optional
-        Default 'parallax'.
-    m5_col : str, optional
-        The default column name for m5 information in the input data. Default fiveSigmaDepth.
-    filter_col : str, optional
-        The column name for the filter information. Default filter.
-    seeing_col : str, optional
-        The column name for the seeing information. Since the astrometry errors are based on the physical
-        size of the PSF, this should be the FWHM of the physical psf. Default seeingFwhmGeom.
-    rmag : float, optional
-        The r magnitude of the fiducial star in r band. Other filters are sclaed using sedTemplate keyword.
-        Default 20.0
-    SedTemplate : str, optional
-        The template to use. This can be 'flat' or 'O','B','A','F','G','K','M'. Default flat.
-    atm_err : float, optional
-        The expected centroiding error due to the atmosphere, in arcseconds. Default 0.01.
+    m5_col : `str`, optional
+        The default column name for m5 information in the input data.
+    filter_col : `str`, optional
+        The column name for the filter information.
+    seeing_col : `str`, optional
+        The column name for the seeing information.
+        Since the astrometry errors are based on the physical size of the PSF,
+        this should be the FWHM of the physical psf, e.g. seeingFwhmGeom.
+    rmag : `float`, optional
+        The r magnitude of the fiducial star in r band.
+        Other filters are scaled using sedTemplate keyword.
+    SedTemplate : `str`, optional
+        The template to use. This can be 'flat' or 'O','B','A','F','G','K','M'.
+    atm_err : `float`, optional
+        The expected centroiding error due to the atmosphere, in arcseconds.
+        Default 0.01.
     normalize : `bool`, optional
-        Compare the astrometric uncertainty to the uncertainty that would result if half the observations
-        were taken at the start and half at the end. A perfect survey will have a value close to 1, while
-        a poorly scheduled survey will be close to 0. Default False.
-    badval : float, optional
-        The value to return when the metric value cannot be calculated. Default -666.
+        Compare the astrometric uncertainty to the uncertainty
+        that would result if half the observations were taken at the start
+        and half at the end.
+        A perfect survey will have a value close to 1, while
+        a poorly scheduled survey will be close to 0.
+    badval : `float`, optional
+        The value to return when the metric value cannot be calculated.
     """
 
     def __init__(
         self,
-        metric_name="parallax",
         m5_col="fiveSigmaDepth",
         filter_col="filter",
         seeing_col="seeingFwhmGeom",

--- a/rubin_sim/maf/metrics/summary_metrics.py
+++ b/rubin_sim/maf/metrics/summary_metrics.py
@@ -1,5 +1,5 @@
 __all__ = (
-    "FootprintFraction",
+    "FootprintFractionMetric",
     "FOArea",
     "FONv",
     "IdentityMetric",
@@ -132,11 +132,10 @@ class FOArea(BaseMetric):
         asky=18000.0,
         nside=128,
         norm=False,
-        metric_name="FOArea",
         **kwargs,
     ):
         """asky = square degrees"""
-        super().__init__(col=col, metric_name=metric_name, **kwargs)
+        super().__init__(col=col, **kwargs)
         self.nvisit = n_visit
         self.nside = nside
         self.asky = asky

--- a/rubin_sim/maf/slicers/base_slicer.py
+++ b/rubin_sim/maf/slicers/base_slicer.py
@@ -170,9 +170,11 @@ class BaseSlicer(with_metaclass(SlicerRegistry, object)):
         info_label="",
         plot_dict=None,
         display_dict=None,
+        summary_values=None,
     ):
         """
-        Save metric values along with the information required to re-build the slicer.
+        Save metric values along with the information required to
+        re-build the slicer.
 
         Parameters
         -----------
@@ -206,6 +208,7 @@ class BaseSlicer(with_metaclass(SlicerRegistry, object)):
             display_dict = {"group": "Ungrouped"}
         header["display_dict"] = display_dict
         header["plot_dict"] = plot_dict
+        header["summary_values"] = summary_values
         for key in version_info:
             header[key] = version_info[key]
         if hasattr(metric_values, "mask"):  # If it is a masked array
@@ -216,16 +219,24 @@ class BaseSlicer(with_metaclass(SlicerRegistry, object)):
             data = metric_values
             mask = None
             fill = None
-        # npz file acts like dictionary: each keyword/value pair below acts as a dictionary in loaded NPZ file.
+        # npz file acts like dictionary: each keyword/value pair
+        # below acts as a dictionary in loaded NPZ file.
         np.savez(
             outfilename,
-            header=header,  # header saved as dictionary
-            metric_values=data,  # metric data values
-            mask=mask,  # metric mask values
-            fill=fill,  # metric badval/fill val
-            slicer_init=self.slicer_init,  # dictionary of instantiation parameters
-            slicer_name=self.slicer_name,  # class name
-            slice_points=self.slice_points,  # slice_point metadata saved (is a dictionary)
+            # header saved as dictionary
+            header=header,
+            # metric data values
+            metric_values=data,
+            # metric mask values
+            mask=mask,
+            # metric badval/fill val
+            fill=fill,
+            # dictionary of instantiation parameters
+            slicer_init=self.slicer_init,
+            # class name
+            slicer_name=self.slicer_name,
+            # slice_point metadata saved (is a dictionary)
+            slice_points=self.slice_points,
             slicer_n_slice=self.nslice,
             slicer_shape=self.shape,
         )

--- a/rubin_sim/maf/utils/astrometry_utils.py
+++ b/rubin_sim/maf/utils/astrometry_utils.py
@@ -42,36 +42,41 @@ def m52snr(m, m5):
 
     Parameters
     ----------
-    m : float or numpy.ndarray
+    m : `float` or `np.ndarray` (N,)
         The magnitude of the star
-    m5 : float or numpy.ndarray
+    m5 : `float` or `np.ndarray` (N,)
         The m5 limiting magnitude of the observation
 
     Returns
     -------
-    float or numpy.ndarray
+    snr : `float` or `np.ndarray` (N,)
         The SNR
     """
-    snr = 5.0 * 10.0 ** (-0.4 * (m - m5))
+    # gamma varies per band, but is fairly close to this value
+    rgamma = 0.039
+    xval = np.power(10, 0.4 * (m - m5))
+    snr = 1 / np.sqrt((0.04 - rgamma) * xval + rgamma * xval * xval)
     return snr
 
 
-def astrom_precision(fwhm, snr):
+def astrom_precision(fwhm, snr, systematic_floor=0.01):
     """
     Calculate the approximate precision of astrometric measurements,
     given a particular seeing and SNR value.
 
     Parameters
     ----------
-    fwhm : float or numpy.ndarray
+    fwhm : `float` or `np.ndarray` (N,)
         The seeing (FWHMgeom) of the observation.
-    snr : float or numpy.ndarray
+    snr : float` or `np.ndarray` (N,)
         The SNR of the object.
+    systematic_floor : `float`
+        Systematic noise floor for astrometric error.
 
     Returns
     -------
-    float or numpy.ndarray
+    astrp,+err " `float` or `numpy.ndarray` (N,)
         The astrometric precision.
     """
-    result = fwhm / (snr)
-    return result
+    astrom_err = np.sqrt((fwhm / snr) ** 2 + systematic_floor**2)
+    return astrom_err

--- a/rubin_sim/maf/utils/astrometry_utils.py
+++ b/rubin_sim/maf/utils/astrometry_utils.py
@@ -32,7 +32,7 @@ def sigma_slope(x, sigma_y):
         return result
 
 
-def m52snr(m, m5):
+def m52snr(m, m5, gamma=0.039):
     """
     Calculate the SNR for a star of magnitude m in an
     observation with 5-sigma limiting magnitude depth m5.
@@ -52,14 +52,13 @@ def m52snr(m, m5):
     snr : `float` or `np.ndarray` (N,)
         The SNR
     """
-    # gamma varies per band, but is fairly close to this value
-    rgamma = 0.039
+    # gamma varies per band, but is fairly close to 0.039 or 0.04
     xval = np.power(10, 0.4 * (m - m5))
-    snr = 1 / np.sqrt((0.04 - rgamma) * xval + rgamma * xval * xval)
+    snr = 1 / np.sqrt((0.04 - gamma) * xval + gamma * xval * xval)
     return snr
 
 
-def astrom_precision(fwhm, snr, systematic_floor=0.01):
+def astrom_precision(fwhm, snr, systematic_floor=0.00):
     """
     Calculate the approximate precision of astrometric measurements,
     given a particular seeing and SNR value.
@@ -71,12 +70,14 @@ def astrom_precision(fwhm, snr, systematic_floor=0.01):
     snr : float` or `np.ndarray` (N,)
         The SNR of the object.
     systematic_floor : `float`
-        Systematic noise floor for astrometric error.
+        Systematic noise floor for astrometric error, in arcseconds.
+        Default here is 0, for backwards compatibility.
+        General Rubin use should be 0.01.
 
     Returns
     -------
-    astrp,+err " `float` or `numpy.ndarray` (N,)
-        The astrometric precision.
+    astrom_err : `float` or `numpy.ndarray` (N,)
+        The astrometric precision, in arcseconds.
     """
     astrom_err = np.sqrt((fwhm / snr) ** 2 + systematic_floor**2)
     return astrom_err

--- a/rubin_sim/maf/utils/astrometry_utils.py
+++ b/rubin_sim/maf/utils/astrometry_utils.py
@@ -32,7 +32,7 @@ def sigma_slope(x, sigma_y):
         return result
 
 
-def m52snr(m, m5, gamma=0.039):
+def m52snr(m, m5, gamma=0.04):
     """
     Calculate the SNR for a star of magnitude m in an
     observation with 5-sigma limiting magnitude depth m5.
@@ -46,15 +46,24 @@ def m52snr(m, m5, gamma=0.039):
         The magnitude of the star
     m5 : `float` or `np.ndarray` (N,)
         The m5 limiting magnitude of the observation
+    gamma : `float` or None
+        The 'gamma' value used when calculating photometric or
+        astrometric errors and weighting SNR accordingly.
+        See equation 5 of the LSST Overview paper.
+        Use "None" to discount the gamma factor completely
+        and just use 10^^(0.4 * (m-m5)).
 
     Returns
     -------
     snr : `float` or `np.ndarray` (N,)
         The SNR
     """
-    # gamma varies per band, but is fairly close to 0.039 or 0.04
+    # gamma varies per band, but is fairly close to 0.04
     xval = np.power(10, 0.4 * (m - m5))
-    snr = 1 / np.sqrt((0.04 - gamma) * xval + gamma * xval * xval)
+    if gamma is None:
+        snr = xval
+    else:
+        snr = 1 / np.sqrt((0.04 - gamma) * xval + gamma * xval * xval)
     return snr
 
 

--- a/rubin_sim/phot_utils/signaltonoise.py
+++ b/rubin_sim/phot_utils/signaltonoise.py
@@ -17,7 +17,6 @@ __all__ = (
 
 import numpy
 
-from . import lsst_defaults
 from .lsst_defaults import LSSTdefaults
 from .photometric_parameters import PhotometricParameters
 from .sed import Sed

--- a/rubin_sim/phot_utils/signaltonoise.py
+++ b/rubin_sim/phot_utils/signaltonoise.py
@@ -32,12 +32,14 @@ def fwhm_eff2_fwhm_geom(fwhm_eff):
     Parameters
     ----------
     fwhm_eff: `float`
-        the single-gaussian equivalent FWHM value, appropriate for calc_neff, in arcseconds
+        the single-gaussian equivalent FWHM value, appropriate for calc_neff,
+        in arcseconds
 
     Returns
     -------
     fwhm_geom : `float`
-        FWHM geom, the geometric FWHM value as measured from a typical PSF profile in arcseconds.
+        FWHM geom, the geometric FWHM value as measured from a typical
+        PSF profile in arcseconds.
     """
     fwhm_geom = 0.822 * fwhm_eff + 0.052
     return fwhm_geom
@@ -52,12 +54,14 @@ def fwhm_geom2_fwhm_eff(fwhm_geom):
     Parameters
     ----------
     fwhm_geom: `float`
-        The geometric FWHM value, as measured from a typical PSF profile, in arcseconds.
+        The geometric FWHM value, as measured from a typical PSF profile,
+         in arcseconds.
 
     Returns
     -------
     fwhm_eff: `float`
-        FWHM effective, the single-gaussian equivalent FWHM value, appropriate for calc_neff, in arcseconds.
+        FWHM effective, the single-gaussian equivalent FWHM value,
+        appropriate for calc_neff, in arcseconds.
     """
     fwhm_eff = (fwhm_geom - 0.052) / 0.822
     return fwhm_eff
@@ -72,7 +76,8 @@ def calc_neff(fwhm_eff, platescale):
     Parameters
     ----------
     fwhm_eff: `float`
-        The width of a single-gaussian that produces correct Neff for typical PSF profile.
+        The width of a single-gaussian that produces correct
+        Neff for typical PSF profile.
     platescale: `float`
         The platescale in arcseconds per pixel (0.2 for LSST)
 
@@ -84,10 +89,11 @@ def calc_neff(fwhm_eff, platescale):
     Notes
     -----
     The fwhm_eff is a way to represent the equivalent seeing value, if the
-    atmosphere could be simply represented as a single gaussian (instead of a more
-    complicated von Karman profile for the atmosphere, convolved properly with the
-    telescope hardware additional blurring of 0.4").
-    A translation from the geometric FWHM to the fwhm_eff is provided in fwhm_geom2_fwhm_eff.
+    atmosphere could be simply represented as a single gaussian (instead of
+    a more complicated von Karman profile for the atmosphere, convolved
+    properly with the telescope hardware additional blurring of 0.4").
+    A translation from the geometric FWHM to the fwhm_eff is provided
+    in fwhm_geom2_fwhm_eff.
     """
     return 2.266 * (fwhm_eff / platescale) ** 2
 
@@ -126,13 +132,15 @@ def calc_total_non_source_noise_sq(sky_sed, hardwarebandpass, phot_params, fwhm_
     Parameters
     ----------
     sky_sed : `Sed`
-        A Sed object representing the sky (normalized so that sky_sed.calc_mag() gives the sky brightness
-        in magnitudes per square arcsecond)
+        A Sed object representing the sky (normalized so that
+        sky_sed.calc_mag() gives the sky brightness in
+        magnitudes per square arcsecond)
     hardwarebandpass : `Bandpass`
-        A Bandpass object containing just the instrumentation throughputs (no atmosphere)
+        A Bandpass object containing just the instrumentation
+        throughputs (no atmosphere)
     phot_params : `PhotometricParameters`
-        A PhotometricParameters object containing information about the photometric
-        properties of the telescope.
+        A PhotometricParameters object containing information
+        about the photometric properties of the telescope.
     fwhm_eff : `float`
         fwhm_eff in arcseconds
 
@@ -141,7 +149,7 @@ def calc_total_non_source_noise_sq(sky_sed, hardwarebandpass, phot_params, fwhm_
     total_noise_sq : `float`
         total non-source noise squared (in ADU counts)
         (this is simga^2_tot * neff in equation 41 of the SNR document
-        https://docushare.lsstcorp.org/docushare/dsweb/ImageStoreViewer/LSE-40 )
+        https://ls.st/LSE-40 )
     """
 
     # Calculate the effective number of pixels for double-Gaussian PSF
@@ -188,7 +196,8 @@ def calc_sky_counts_per_pixel_for_m5(m5target, total_bandpass, phot_params, fwhm
         A bandpass object representing the total throughput of the telescope
         (instrumentation plus atmosphere).
     phot_params : `PhotometricParameters`
-        A photometric parameters object containing the photometric response information for Rubin.
+        A photometric parameters object containing the photometric response
+        information for Rubin.
     fwhm_eff : `float`
         fwhm_eff in arcseconds.
 
@@ -223,8 +232,8 @@ def calc_sky_counts_per_pixel_for_m5(m5target, total_bandpass, phot_params, fwhm
     # calculate the square of the noise due to the instrument
     noise_instr_sq = calc_instr_noise_sq(phot_params=phot_params)
 
-    # now solve equation 41 of the SNR document for the neff * sigma_total^2 term
-    # given snr=5 and counts as calculated above
+    # now solve equation 41 of the SNR document for the neff * sigma_total^2
+    # term given snr=5 and counts as calculated above
     # SNR document can be found at
     # https://docushare.lsstcorp.org/docushare/dsweb/ImageStoreViewer/LSE-40
 
@@ -249,12 +258,15 @@ def calc_m5(skysed, total_bandpass, hardware, phot_params, fwhm_eff=None):
     Parameters
     ----------
     skysed : `Sed`
-        An SED representing the sky background emission, normalized such that skysed.calc_mag(Bandpass)
-        returns the expected sky brightness in magnitudes per sq arcsecond.
+        An SED representing the sky background emission, normalized such that
+        skysed.calc_mag(Bandpass) returns the expected sky brightness in
+        magnitudes per sq arcsecond.
     total_bandpass : `Bandpass`
-        The Bandpass representing the total throughput of the telescope (instrument plus atmosphere).
+        The Bandpass representing the total throughput of the telescope
+        (instrument plus atmosphere).
     hardware : `Bandpass`
-        The Bandpass representing the throughput of the telescope instrument only (no atmosphere).
+        The Bandpass representing the throughput of the telescope instrument
+        only (no atmosphere).
     phot_params : `PhotometricParameters`
         The PhotometricParameters class that carries details about the
         photometric response of the telescope.
@@ -291,8 +303,8 @@ def calc_m5(skysed, total_bandpass, hardware, phot_params, fwhm_eff=None):
         (snr**4) / 4.0 / phot_params.gain + (snr**2) * v_n
     )
 
-    # renormalize flatsource so that it has the required counts to be a 5-sigma detection
-    # given the specified background
+    # renormalize flatsource so that it has the required counts to be a
+    # 5-sigma detection given the specified background
     counts_flat = flatsource.calc_adu(total_bandpass, phot_params=phot_params)
     flatsource.multiply_flux_norm(counts_5sigma / counts_flat)
 
@@ -356,22 +368,24 @@ def calc_gamma(bandpass, m5, phot_params):
 
     # The expression for gamma below comes from:
     #
-    # 1) Take the approximation N^2 = N0^2 + alpha S from footnote 88 in the overview paper
-    # where N is the noise in flux of a source, N0 is the noise in flux due to sky brightness
-    # and instrumentation, S is the number of counts registered from the source and alpha
-    # is some constant
+    # 1) Take the approximation N^2 = N0^2 + alpha S from footnote 88
+    # in the overview paper where N is the noise in flux of a source,
+    # N0 is the noise in flux due to sky brightness and instrumentation,
+    # S is the number of counts registered from the source and
+    # alpha is some constant
     #
-    # 2) Divide by S^2 and demand that N/S = 0.2 for a source detected at m5. Solve
-    # the resulting equation for alpha in terms of N0 and S5 (the number of counts from
-    # a source at m5)
+    # 2) Divide by S^2 and demand that N/S = 0.2 for a source detected at m5.
+    # Solve the resulting equation for alpha in terms of N0 and S5
+    # (the number of counts from a source at m5)
     #
-    # 3) Substitute this expression for alpha back into the equation for (N/S)^2
-    # for a general source.  Re-factor the equation so that it looks like equation
-    # 5 of the overview paper (note that x = S5/S).  This should give you gamma = (N0/S5)^2
+    # 3) Substitute this expression for alpha into the equation for (N/S)^2
+    # for a general source.  Re-factor the equation so that it looks like
+    # equation 5 of the overview paper (note that x = S5/S).
+    # This should give you gamma = (N0/S5)^2
     #
-    # 4) Solve equation 41 of the SNR document for the neff * sigma_total^2 term
-    # given snr=5 and counts as calculated above.  Note that neff * sigma_total^2
-    # is N0^2 in the equation above
+    # 4) Solve equation 41 of the SNR document for neff * sigma_total^2 term
+    # given snr=5 and counts as calculated above.
+    # Note that neff * sigma_total^2 is N0^2 in the equation above
     #
     # This should give you
 
@@ -381,16 +395,19 @@ def calc_gamma(bandpass, m5, phot_params):
 
 
 def calc_snr_m5(magnitude, bandpass, m5, phot_params, gamma=None):
-    """Calculate the SNR of a source based on the 5-sigma limit for an observation.
+    """Calculate the SNR of a source based on the 5-sigma limit for an
+    observation.
 
-    Calculate signal to noise in flux using the model from equation (5) of arXiv:0805.2366
+    Calculate signal to noise in flux using the model from equation (5)
+    of arXiv:0805.2366
 
     Parameters
     ----------
     magnitude : `float` or `np.ndarray`, (N,)
         Magnitudes of the sources whose signal to noise you are calculating.
     bandpass : `Bandpass`
-        The Bandpass in which the magnitude was calculated (total instrument + atmosphere).
+        The Bandpass in which the magnitude was calculated
+        (total instrument + atmosphere).
     m5 : `float`
         The 5-sigma point source limiting magnitude of the exposure.
     phot_params : `PhotometricParameters`
@@ -423,14 +440,16 @@ def calc_snr_m5(magnitude, bandpass, m5, phot_params, gamma=None):
 
 
 def calc_mag_error_m5(magnitude, bandpass, m5, phot_params, gamma=None):
-    """Calculate magnitude error using the model from equation (5) of arXiv:0805.2366
+    """Calculate magnitude error using the model from equation (5)
+    of arXiv:0805.2366
 
     Parameters
     ----------
     magnitude : `float`
         Magnitude of the source.
     bandpass : `Bandpass`
-        The Bandpass in which to calculate the magnitude error (total instrument + atmosphere).
+        The Bandpass in which to calculate the magnitude error
+        (total instrument + atmosphere).
     m5 : `float`
         The 5-sigma point source limiting magnitude.
     phot_params : `PhotometricParameters`
@@ -470,9 +489,9 @@ def calc_snr_sed(
 ):
     """Calculate the signal to noise ratio for a source, based on the SED.
 
-    For a given source, sky sed, total bandpass and hardware bandpass, as well as
-    fwhm_eff / exptime, calculates the SNR with optimal PSF extraction
-    assuming a double-gaussian PSF.
+    For a given source, sky sed, total bandpass and hardware bandpass,
+    as well af fwhm_eff / exptime, calculates the SNR with
+    optimal PSF extraction assuming a double-gaussian PSF.
 
     Parameters
     ----------
@@ -480,12 +499,15 @@ def calc_snr_sed(
         A SED representing the source, normalized such that source_sed.calc_mag
         gives the desired magnitude.
     total_bandpass : `Bandpass`
-        The Bandpass representing the total throughput of the telescope (instrument plus atmosphere).
+        The Bandpass representing the total throughput of the telescope
+        (instrument plus atmosphere).
     sky_sed : `Sed`
-        A SED representing the sky background emission, normalized such that skysed.calc_mag(Bandpass)
-        returns the expected sky brightness in magnitudes per sq arcsecond.
+        A SED representing the sky background emission, normalized such that
+        skysed.calc_mag(Bandpass) returns the expected sky brightness in
+        magnitudes per sq arcsecond.
     hardware : `Bandpass`
-        The Bandpass representing the throughput of the telescope instrument only (no atmosphere).
+        The Bandpass representing the throughput of the telescope instrument
+        only (no atmosphere).
     phot_params : `PhotometricParameters`
         The PhotometricParameters class that carries details about the
         photometric response of the telescope.
@@ -540,9 +562,10 @@ def calc_mag_error_sed(
     fwhm_eff,
     verbose=False,
 ):
-    """Calculate the magnitudeError for a source, given the bandpass(es) and sky SED.
+    """Calculate the magnitudeError for a source, given the bandpass(es)
+    and sky SED.
 
-    For a given source, sky sed, total bandpass and hardware bandpass, as well as
+    For a given source, sky sed, total bandpass and hardware bandpass, and
     fwhm_eff / exptime, calculates the SNR with optimal PSF extraction
     assuming a double-gaussian PSF.
 
@@ -552,12 +575,15 @@ def calc_mag_error_sed(
         A SED representing the source, normalized such that source_sed.calc_mag
         gives the desired magnitude.
     total_bandpass : `Bandpass`
-        The Bandpass representing the total throughput of the telescope (instrument plus atmosphere).
+        The Bandpass representing the total throughput of the telescope
+        (instrument plus atmosphere).
     sky_sed : `Sed`
-        A SED representing the sky background emission, normalized such that skysed.calc_mag(Bandpass)
-        returns the expected sky brightness in magnitudes per sq arcsecond.
+        A SED representing the sky background emission, normalized such that
+        skysed.calc_mag(Bandpass) returns the expected sky brightness in
+        magnitudes per sq arcsecond.
     hardware_bandpass : `Bandpass`
-        The Bandpass representing the throughput of the telescope instrument only (no atmosphere).
+        The Bandpass representing the throughput of the telescope instrument
+        only (no atmosphere).
     phot_params : `PhotometricParameters`
         The PhotometricParameters class that carries details about the
         photometric response of the telescope.
@@ -592,8 +618,8 @@ def calc_astrometric_error(mag, m5, fwhm_geom=0.7, nvisit=1, systematic_floor=10
     """Calculate an expected astrometric error.
 
     The astrometric error can be estimated for catalog purposes by using the
-    typical FWHM and n_visit = total number of visits, or can be used for a single
-    visit by using the actual FWHM and n_visit =1.
+    typical FWHM and n_visit = total number of visits, or can be used for a
+    single visit by using the actual FWHM and n_visit =1.
 
 
     Parameters
@@ -601,14 +627,17 @@ def calc_astrometric_error(mag, m5, fwhm_geom=0.7, nvisit=1, systematic_floor=10
     mag: `float`
         Magnitude of the source
     m5: `float`
-        Point source five sigma limiting magnitude of the image (or typical depth per image).
+        Point source five sigma limiting magnitude of the image
+        (or typical depth per image).
     fwhm_geom: `float`, optional
-        The geometric (physical) FWHM of the image, in arcseconds. Default 0.7.
+        The geometric (physical) FWHM of the image, in arcseconds.
     nvisit: `int`, optional
         The number of visits/measurement. Default 1.
-        If this is >1, the random error contribution is reduced by sqrt(nvisits).
+        If this is >1, the random error contribution is reduced by
+        sqrt(nvisits).
     systematic_floor: `float`, optional
-        The systematic noise floor for the astrometric measurements, in mas. Default 10mas.
+        The systematic noise floor for the astrometric measurements,
+        in mas. Default 10mas.
 
     Returns
     -------

--- a/rubin_sim/scheduler/model_observatory/model_observatory.py
+++ b/rubin_sim/scheduler/model_observatory/model_observatory.py
@@ -280,6 +280,7 @@ class ModelObservatory:
             self.seeing_fwhm_eff[key].fill(np.nan)
         # Use the model to get the seeing at this time and airmasses.
         fwhm_500 = self.seeing_data(current_time)
+        self.conditions.fwhm_500 = fwhm_500
         seeing_dict = self.seeing_model(fwhm_500, airmass[good])
         fwhm_eff = seeing_dict["fwhmEff"]
         for i, key in enumerate(self.seeing_model.filter_list):

--- a/rubin_sim/scheduler/model_observatory/model_observatory.py
+++ b/rubin_sim/scheduler/model_observatory/model_observatory.py
@@ -280,7 +280,7 @@ class ModelObservatory:
             self.seeing_fwhm_eff[key].fill(np.nan)
         # Use the model to get the seeing at this time and airmasses.
         fwhm_500 = self.seeing_data(current_time)
-        self.conditions.fwhm_500 = fwhm_500
+        self.fwhm_500 = fwhm_500
         seeing_dict = self.seeing_model(fwhm_500, airmass[good])
         fwhm_eff = seeing_dict["fwhmEff"]
         for i, key in enumerate(self.seeing_model.filter_list):


### PR DESCRIPTION
Many of the commits in this PR are updating line length in doc strings, moving a bit more code to snake_case from camelCase, removing unnecessary or unused code (imports or values that were not used), updating super() calls to remove the <parent class> / self arguments, or standardizing metric API ("Metric" at the end of metric classnames, metric_name doesn't need to be a kwarg if the default is the same as the class name). 

The meaningful changes though are: 
* addition of fwhm_500 to the ModelObservatory attributes (this was helpful for a test of m5 difference basis functions, when changing the input seeing .. in order to track what the 'original' value was). 
* update FO plot to use sky and n_visits kwargs correctly in the summary metrics printed in the legend

and the bigger changes: 
* updating m52snr to use a more accurate SNR formula
* updating the astrometric precision estimate to also include the systematic floor (instead of having to add this separately in the returned values) -- moving it to the function should make it easier for other users to remember to include this
* adding a y-band parallax uncertainty metric to the astrometry_batch 