### PR TITLE
move dust maps data to scheduler

### DIFF
--- a/rubin_sim/data/rs_download_data.py
+++ b/rubin_sim/data/rs_download_data.py
@@ -35,12 +35,12 @@ def data_dict():
         "movingObjects": "movingObjects_oct_2021.tgz",
         "orbits": "orbits_2022_3_1.tgz",
         "orbits_precompute": "orbits_precompute_2023_05_23.tgz",
-        "scheduler": "scheduler_2023_03_09.tgz",
-        "sim_baseline": "sim_baseline_2023_01_18.tgz",
+        "scheduler": "scheduler_2023_09_22.tgz",
+        "sim_baseline": "sim_baseline_2023_09_22.tgz",
         "site_models": "site_models_2023_03_28.tgz",
         "skybrightness": "skybrightness_2023_09_11.tgz",
         "skybrightness_pre": "skybrightness_pre_2023_09_19.tgz",
-        "throughputs": "throughputs_2023_09_07.tgz",
+        "throughputs": "throughputs_2023_09_22.tgz",
         "tests": "tests_2022_10_18.tgz",
     }
     return file_dict

--- a/rubin_sim/scheduler/utils/footprints.py
+++ b/rubin_sim/scheduler/utils/footprints.py
@@ -452,8 +452,8 @@ def ra_dec_hp_map(nside=None):
 def get_dustmap(nside=None):
     if nside is None:
         nside = set_default_nside()
-    ebv_data_dir = os.path.join(get_data_dir(), "maps")
-    filename = "DustMaps/dust_nside_%i.npz" % nside
+    ebv_data_dir = os.path.join(get_data_dir(), "scheduler")
+    filename = "dust_maps/dust_nside_%i.npz" % nside
     dustmap = np.load(os.path.join(ebv_data_dir, filename))["ebvMap"]
     return dustmap
 
@@ -980,7 +980,7 @@ def combo_dust_fp(
     """
 
     ebv_data_dir = get_data_dir()
-    filename = "maps/DustMaps/dust_nside_%i.npz" % nside
+    filename = "scheduler/dust_maps/dust_nside_%i.npz" % nside
     dustmap = np.load(os.path.join(ebv_data_dir, filename))["ebvMap"]
 
     if smooth:

--- a/rubin_sim/scheduler/utils/sky_area.py
+++ b/rubin_sim/scheduler/utils/sky_area.py
@@ -142,14 +142,11 @@ class SkyAreaGenerator:
     def read_dustmap(self, dustmap_file=None):
         """Read the dustmap from rubin_sim, in the appropriate resolution."""
         # Dustmap from rubin_sim_data  - this is basically just a data directory
-        # The dustmap data is downloadable from
-        # https://lsst.ncsa.illinois.edu/sim-data/rubin_sim_data/maps_may_2021.tgz
-        # (then just set RUBIN_SIM_DATA_DIR to where you downloaded it, after untarring the file)
         if dustmap_file is None:
             datadir = rs_data.get_data_dir()
             if datadir is None:
                 raise Exception('Cannot find datadir, please set "RUBIN_SIM_DATA_DIR"')
-            datadir = os.path.join(datadir, "maps", "DustMaps")
+            datadir = os.path.join(datadir, "scheduler", "dust_maps")
             filename = os.path.join(datadir, "dust_nside_%i.npz" % self.nside)
         self.dustmap = np.load(filename)["ebvMap"]
 


### PR DESCRIPTION
Move copies of the HEALpix dust extinction maps to the scheduler data so the scheduler does not rely on `maps` data anymore
update sim_baseline to v3.3
clean up throughputs data (it had hidden git repo directories, etc)