### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 license = { text = "GPL" }
 classifiers = [ 
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved ::  GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -49,6 +48,7 @@ test = [
      "pytest",
      "black",
      "ruff",
+     "isort",
      "pytest-cov",
      "pytest-black",
 ]


### PR DESCRIPTION
Fix pyproject.toml to let pypi distribution work properly. The "License" line in pyproject.toml was causing it to be rejected by pypi. 