### PR TITLE
tickets/PREOPS-4124 Support restricting the scheduler reward summary stats to a region of interest

### DIFF
--- a/rubin_sim/scheduler/basis_functions/basis_functions.py
+++ b/rubin_sim/scheduler/basis_functions/basis_functions.py
@@ -2,6 +2,7 @@ __all__ = (
     "BaseBasisFunction",
     "HealpixLimitedBasisFunctionMixin",
     "ConstantBasisFunction",
+    "SimpleArrayBasisFunction",
     "DelayStartBasisFunction",
     "TargetMapBasisFunction",
     "AvoidLongGapsBasisFunction",
@@ -229,6 +230,16 @@ class ConstantBasisFunction(BaseBasisFunction):
 
     def __call__(self, conditions, **kwargs):
         return 1
+
+
+class SimpleArrayBasisFunction(BaseBasisFunction):
+    def __init__(self, value, *args, **kwargs):
+        self.assigned_value = value
+        super().__init__(*args, **kwargs)
+
+    def _calc_value(self, conditions, **kwargs):
+        self.value = self.assigned_value
+        return self.value
 
 
 class DelayStartBasisFunction(BaseBasisFunction):

--- a/rubin_sim/scheduler/surveys/dd_surveys.py
+++ b/rubin_sim/scheduler/surveys/dd_surveys.py
@@ -3,6 +3,7 @@ __all__ = ("DeepDrillingSurvey", "generate_dd_surveys", "dd_bfs")
 import copy
 import logging
 import random
+from functools import cached_property
 
 import numpy as np
 
@@ -10,7 +11,7 @@ import rubin_sim.scheduler.basis_functions as basis_functions
 from rubin_sim.scheduler import features
 from rubin_sim.scheduler.surveys import BaseSurvey
 from rubin_sim.scheduler.utils import empty_observation
-from rubin_sim.utils import ddf_locations
+from rubin_sim.utils import ddf_locations, ra_dec2_hpid
 
 log = logging.getLogger(__name__)
 
@@ -110,6 +111,11 @@ class DeepDrillingSurvey(BaseSurvey):
         if self.reward_value is None:
             self.extra_features["Ntot"] = features.N_obs_survey()
             self.extra_features["N_survey"] = features.N_obs_survey(note=self.survey_name)
+
+    @cached_property
+    def roi_hpid(self):
+        hpid = ra_dec2_hpid(self.nside, np.degrees(self.ra), np.degrees(self.dec))
+        return hpid
 
     def check_continue(self, observation, conditions):
         # feasibility basis functions?

--- a/tests/scheduler/test_scalarbf.py
+++ b/tests/scheduler/test_scalarbf.py
@@ -1,0 +1,57 @@
+import unittest
+import healpy as hp
+import numpy as np
+from rubin_sim.scheduler.features import Conditions
+from rubin_sim.scheduler.utils import set_default_nside
+from rubin_sim.scheduler.basis_functions import HealpixLimitedBasisFunctionMixin
+from rubin_sim.scheduler.basis_functions import BaseBasisFunction
+
+
+class SimpleArrayBasisFunction(BaseBasisFunction):
+    def __init__(self, value, *args, **kwargs):
+        self.assigned_value = value
+        super().__init__(*args, **kwargs)
+
+    def _calc_value(self, conditions, **kwargs):
+        self.value = self.assigned_value
+        return self.value
+
+
+class SimpleArrayAtHpixBasisFunction(HealpixLimitedBasisFunctionMixin, SimpleArrayBasisFunction):
+    pass
+
+
+class TestHealpixLimitedBasisFunctionMixin(unittest.TestCase):
+    def setUp(self):
+        self.hpid = 2111
+        random_seed = 6563
+        self.nside = set_default_nside()
+        self.npix = hp.nside2npix(self.nside)
+        self.rng = np.random.default_rng(seed=random_seed)
+        self.all_values = self.rng.random(self.npix)
+        self.value = self.all_values[self.hpid]
+        self.conditions = Conditions(nside=self.nside, mjd=60200.2)
+
+    def test_array_data(self):
+        basis_function = SimpleArrayBasisFunction(self.all_values)
+        test_values = basis_function(self.conditions)
+        self.assertTrue(np.array_equal(test_values, self.all_values))
+
+    def test_scalar_data(self):
+        basis_function = SimpleArrayAtHpixBasisFunction(self.hpid, self.all_values)
+        test_value = basis_function(self.conditions)
+        self.assertEqual(test_value, self.value)
+
+        feasible = basis_function(self.conditions)
+        self.assertTrue(feasible)
+
+    def test_infeasible_at_hpix(self):
+        values_invalid_at_hpix = self.all_values.copy()
+        values_invalid_at_hpix[self.hpid] = -np.inf
+        basis_function = SimpleArrayAtHpixBasisFunction(self.hpid, values_invalid_at_hpix)
+        feasible = basis_function.check_feasibility(self.conditions)
+        self.assertFalse(feasible)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scheduler/test_scalarbf.py
+++ b/tests/scheduler/test_scalarbf.py
@@ -4,17 +4,7 @@ import numpy as np
 from rubin_sim.scheduler.features import Conditions
 from rubin_sim.scheduler.utils import set_default_nside
 from rubin_sim.scheduler.basis_functions import HealpixLimitedBasisFunctionMixin
-from rubin_sim.scheduler.basis_functions import BaseBasisFunction
-
-
-class SimpleArrayBasisFunction(BaseBasisFunction):
-    def __init__(self, value, *args, **kwargs):
-        self.assigned_value = value
-        super().__init__(*args, **kwargs)
-
-    def _calc_value(self, conditions, **kwargs):
-        self.value = self.assigned_value
-        return self.value
+from rubin_sim.scheduler.basis_functions import SimpleArrayBasisFunction
 
 
 class SimpleArrayAtHpixBasisFunction(HealpixLimitedBasisFunctionMixin, SimpleArrayBasisFunction):

--- a/tests/scheduler/test_surveys.py
+++ b/tests/scheduler/test_surveys.py
@@ -2,11 +2,15 @@ import os
 import unittest
 
 import pandas as pd
+import numpy as np
+import healpy as hp
 
 import rubin_sim.scheduler.basis_functions as basis_functions
 import rubin_sim.scheduler.surveys as surveys
 from rubin_sim.data import get_data_dir
+from rubin_sim.scheduler.utils import set_default_nside
 from rubin_sim.scheduler.model_observatory import ModelObservatory
+from rubin_sim.scheduler.basis_functions import SimpleArrayBasisFunction
 
 
 class TestSurveys(unittest.TestCase):
@@ -33,6 +37,48 @@ class TestSurveys(unittest.TestCase):
         reward_df = survey.make_reward_df(conditions)
         self.assertIsInstance(reward_df, pd.DataFrame)
         reward_df = survey.make_reward_df(conditions, accum=False)
+
+    def test_roi(self):
+        random_seed = 6563
+        infeasible_hpix = 123
+        nside = set_default_nside()
+        npix = hp.nside2npix(nside)
+        rng = np.random.default_rng(seed=random_seed)
+        num_bfs = 3
+        bf_values = rng.random((num_bfs, npix))
+        bf_values[:, infeasible_hpix] = -np.inf
+        bfs = [SimpleArrayBasisFunction(values) for values in bf_values]
+
+        observatory = ModelObservatory()
+        conditions = observatory.return_conditions()
+
+        # A few cases with an ROI with one valid healpix
+        for i in range(3):
+            hpix = rng.integers(npix)
+            ra, decl = hp.pix2ang(nside, hpix, lonlat=True)
+            survey = surveys.FieldSurvey(bfs, RA=ra, dec=decl, reward_value=1)
+            reward_df = survey.make_reward_df(conditions)
+            for value, max_basis_reward in zip(bf_values[:, hpix], reward_df["max_basis_reward"]):
+                self.assertEqual(max_basis_reward, value)
+
+        # One case with an ROI with only an infeasible healpix
+        ra, decl = hp.pix2ang(nside, infeasible_hpix, lonlat=True)
+        survey = surveys.FieldSurvey(bfs, RA=ra, dec=decl, reward_value=1)
+        reward_df = survey.make_reward_df(conditions)
+        for max_basis_reward in reward_df["max_basis_reward"]:
+            self.assertEqual(max_basis_reward, -np.inf)
+
+        for area in reward_df["basis_area"]:
+            self.assertEqual(area, 0.0)
+
+        for feasible in reward_df["feasible"]:
+            self.assertFalse(feasible)
+
+        # Make sure it still works as expected if no ROI is set
+        weights = [1] * num_bfs
+        survey = surveys.BaseMarkovSurvey(bfs, weights)
+        for value, max_basis_reward in zip(bf_values.max(axis=1), reward_df["max_basis_reward"]):
+            self.assertEqual(max_basis_reward, value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are two approaches implemented here, which one might want to use in different circumstances.

First, one can use a mixin to turn a basis function that returns a healpy array into a scalar one.

Second, you can set an ROI on a survey, such that when the reward_df is made for that survey, only areas within the ROI are considered when finding the max, area, and feasibility.