### PR TITLE
Switched interp2d to RectBivariateSpline

### DIFF
--- a/rubin_sim/maf/metrics/qso_number_counts_metric.py
+++ b/rubin_sim/maf/metrics/qso_number_counts_metric.py
@@ -90,10 +90,12 @@ class QSONumberCountsMetric(BaseMetric):
         c_mz_data = np.cumsum(c_mz_data, axis=1)
 
         # Create a 2D interpolation object for the long table.
-        #self.nqso_cumulative = interpolate.interp2d(zs[:-1], mags[:-1], #c_mz_data[:-1, :-1], kind="cubic")
-        self.nqso_cumulative_aux = interpolate.RectBivariateSpline(zs[:-1], mags[:-1], c_mz_data[:-1,:-1].T, kx=3, ky=3)
+        # self.nqso_cumulative = interpolate.interp2d(zs[:-1], mags[:-1], #c_mz_data[:-1, :-1], kind="cubic")
+        self.nqso_cumulative_aux = interpolate.RectBivariateSpline(
+            zs[:-1], mags[:-1], c_mz_data[:-1, :-1].T, kx=3, ky=3
+        )
 
-        self.nqso_cumulative = lambda z_new, m_new: self.nqso_cumulative_aux(z_new,m_new).T[0]
+        self.nqso_cumulative = lambda z_new, m_new: self.nqso_cumulative_aux(z_new, m_new).T[0]
 
         super().__init__(
             col=[m5_col, filter_col, "saturation_mag"],

--- a/rubin_sim/maf/metrics/qso_number_counts_metric.py
+++ b/rubin_sim/maf/metrics/qso_number_counts_metric.py
@@ -90,7 +90,10 @@ class QSONumberCountsMetric(BaseMetric):
         c_mz_data = np.cumsum(c_mz_data, axis=1)
 
         # Create a 2D interpolation object for the long table.
-        self.nqso_cumulative = interpolate.interp2d(zs[:-1], mags[:-1], c_mz_data[:-1, :-1], kind="cubic")
+        #self.nqso_cumulative = interpolate.interp2d(zs[:-1], mags[:-1], #c_mz_data[:-1, :-1], kind="cubic")
+        self.nqso_cumulative_aux = interpolate.RectBivariateSpline(zs[:-1], mags[:-1], c_mz_data[:-1,:-1].T, kx=3, ky=3)
+
+        self.nqso_cumulative = lambda z_new, m_new: self.nqso_cumulative_aux(z_new,m_new).T[0]
 
         super().__init__(
             col=[m5_col, filter_col, "saturation_mag"],


### PR DESCRIPTION
The code used an interpolation scheme from a pre-calculated table to obtain the expected QSO number counts as a function of redshift and magnitude. 

The original code used scipy.interpolate.interp2d with a cubic spline, but this routine is being deprecated. I have updated the code to instead use scipy.interpolate.RectBivariateSpline also with a cubic spline. Testing shows that the results are the same for a range of redshift and magnitudes between the two methods. 