### PR TITLE
Add rubin-scheduler to all_req.txt

### DIFF
--- a/all_req.txt
+++ b/all_req.txt
@@ -8,6 +8,7 @@ numexpr
 scipy
 sqlalchemy
 astropy
+palpy
 pytables
 h5py
 openorb

--- a/all_req.txt
+++ b/all_req.txt
@@ -26,3 +26,4 @@ pytest-cov
 pytest-black
 black
 ruff
+rubin-scheduler


### PR DESCRIPTION
Currently the [Developer Installation](https://github.com/ebellm/rubin_sim/tree/u/ebellm/templates#developer-installation) instructions fail because `rs_download_data` now depends on `rubin-scheduler`, which is not included in `all_req.txt`.