### PR TITLE
Simple metrics for density uniformity

### DIFF
--- a/rubin_sim/maf/metrics/summary_metrics.py
+++ b/rubin_sim/maf/metrics/summary_metrics.py
@@ -205,29 +205,59 @@ class ZeropointMetric(BaseMetric):
             return result
 
 
+class FskyMetric(BaseMetric):
+    """Calculate fraction of a desired footprint got covered.
+        To be applied as a summary metric to any healpix slicer.
+        Pixels with hp.UNSEEN or np.nan will be ignored, as well
+        as values falling outside of a ]min_val, max_val[ range.
+    Parameters
+    ----------
+    min_val, max_val : `float`
+        Minimum and maximum values for valid pixels (excluded)
+    """
+
+    def __init__(self, min_val=-np.inf, max_val=np.inf, **kwargs):
+        super().__init__(**kwargs)
+        self.min_val = min_val
+        self.mask_val = hp.UNSEEN
+        self.max_val = max_val
+
+    def run(self, data_slice, slice_point=None):
+        valid = data_slice["metricdata"] > self.min_val
+        valid &= data_slice["metricdata"] < self.max_val
+        valid &= data_slice["metricdata"] != self.mask_val
+        npix = data_slice["metricdata"].size
+        result = np.sum(valid) / npix
+        return result
+
+
 class TotalPowerMetric(BaseMetric):
     """
     Calculate the total power in the angular power spectrum between lmin/lmax.
     """
 
     def __init__(
-        self, col="metricdata", lmin=100.0, lmax=300.0, remove_dipole=True, mask_val=np.nan, **kwargs
+        self, col="metricdata", lmin=100.0, lmax=300.0, remove_monopole=True, remove_dipole=True, mask_val=np.nan, **kwargs
     ):
         self.lmin = lmin
         self.lmax = lmax
+        self.remove_monopole = remove_monopole
         self.remove_dipole = remove_dipole
         super(TotalPowerMetric, self).__init__(col=col, mask_val=mask_val, **kwargs)
 
     def run(self, data_slice, slice_point=None):
         # Calculate the power spectrum.
+        data = data_slice[self.colname]
+        if self.remove_monopole:
+            data = hp.remove_monopole(data, verbose=False, bad=self.mask_val)
         if self.remove_dipole:
-            cl = hp.anafast(hp.remove_dipole(data_slice[self.colname], verbose=False))
-        else:
-            cl = hp.anafast(data_slice[self.colname])
+            data = hp.remove_dipole(data, verbose=False, bad=self.mask_val)
+        cl = hp.anafast(data)
         ell = np.arange(np.size(cl))
         condition = np.where((ell <= self.lmax) & (ell >= self.lmin))[0]
         totalpower = np.sum(cl[condition] * (2 * ell[condition] + 1))
         return totalpower
+
 
 
 class StaticProbesFoMEmulatorMetricSimple(BaseMetric):

--- a/rubin_sim/maf/metrics/uniformity_metrics.py
+++ b/rubin_sim/maf/metrics/uniformity_metrics.py
@@ -1,0 +1,91 @@
+__all__ = "LinearMultibandModelMetric"
+
+import numpy as np
+from rubin_sim.maf.metrics.base_metric import BaseMetric
+from rubin_sim.maf.metrics.exgal_m5 import ExgalM5
+import healpy as hp
+
+
+class LinearMultibandModelMetric(BaseMetric):
+    """ """
+
+    def __init__(
+        self,
+        model_dict,
+        metric_name="LinearMultibandModel",
+        m5_col="fiveSigmaDepth",
+        filter_col="filter",
+        post_processing_fn=lambda x : x,
+        units="mag",
+        extinction_cut=0.2,
+        min_depth_cut={'i': 25.0},
+        max_depth_cut={},
+        mean_depth={"u": 0.0, "g": 0.0, "r": 0.0, "i": 0.0, "z": 0.0, "y": 0.0},
+        n_filters=6,
+        **kwargs,
+    ):
+        """
+        Args:
+
+        """
+        self.n_filters = n_filters
+        self.extinction_cut = extinction_cut
+        self.min_depth_cut = min_depth_cut
+        self.max_depth_cut = max_depth_cut
+        if "cst" in model_dict:
+            self.cst = model_dict["cst"]
+        else:
+            self.cst = 0.0
+        lsst_filters = ["u", "g", "r", "i", "z", "y"]
+        self.bands = [x for x in model_dict.keys() if x in lsst_filters]
+        self.model_arr = np.array([model_dict[x] for x in self.bands])[:, None]
+        self.mean_depth = mean_depth
+        self.m5_col = m5_col
+        self.filter_col = filter_col
+        self.post_processing_fn = post_processing_fn
+        self.exgal_m5 = ExgalM5(m5_col=m5_col, units=units)
+
+        self.exgal_m5 = ExgalM5(
+            m5_col=m5_col,
+            filter_col=filter_col,
+            units=units,
+            metric_name=metric_name+"ExgalM5",
+        )
+        super().__init__(
+            col=[m5_col, filter_col], metric_name=metric_name, units=units, maps=self.exgal_m5.maps, **kwargs
+        )
+
+    def run(self, data_slice, slice_point=None):
+        """ """
+
+        if slice_point["ebv"] > self.extinction_cut:
+            return self.badval
+
+        n_filters = len(set(data_slice[self.filter_col]))
+        if n_filters < self.n_filters:
+            return self.badval
+
+        # add extinction_cut and depth cuts? and n_filters cuts
+        depths = np.vstack(
+            [
+                self.exgal_m5.run(data_slice[data_slice[self.filter_col] == lsst_filter], slice_point) - self.mean_depth[lsst_filter]
+                for lsst_filter in self.bands
+            ]
+        ).T
+        assert depths.shape[0] >= 1
+
+        if np.any(depths == self.badval):
+            return self.badval
+        for i, lsst_filter in enumerate(self.bands):
+            if lsst_filter in self.min_depth_cut and depths[0, i] < self.min_depth_cut[lsst_filter] - self.mean_depth[lsst_filter]:
+                return self.badval
+            if lsst_filter in self.max_depth_cut and depths[0, i] > self.max_depth_cut[lsst_filter] - self.mean_depth[lsst_filter]:
+                return self.badval
+
+        val = self.post_processing_fn(
+            self.cst + np.dot(depths, self.model_arr)
+        )
+
+        return val
+
+


### PR DESCRIPTION
This PR has three simple new metrics:
- a sky fraction metric (more flexible than existing ones)
- and edit to the totalpowermetric to include a remove_monopole 
- a new metric for linear combination of depth fluctuations

They come together in a sigma8 tomography metric which is demonstrated here: https://github.com/ixkael/ObsStrat/blob/meanz_uniformity_maf/code/meanz_uniformity/sigma8tomography_demo.ipynb

Annoyingly I didn't have time to figure out how to properly code this in a nice metric. This is partly because I couldn't think of an elegant way to avoid multiple calls to other existing metrics (including the new LinearMultibandModelMetric). For example the average depth is needed, and I wasn't sure how to avoid calling the ExgalM5 twice. The other problem is the need to use the depth maps N times (with N the number of redshift bins considered, here 5). Again I couldn't think of a nice way to run the metrics in a nested way in time for this deadline. But I hope the demo notebook illustrates things clearly enough, and I am happy to assist in any way I can.