### PR TITLE
Cleaned up assignment of self.coeffs to discard wasteful initilization.

### DIFF
--- a/rubin_sim/moving_objects/cheby_values.py
+++ b/rubin_sim/moving_objects/cheby_values.py
@@ -46,10 +46,9 @@ class ChebyValues:
             ChebyFits object, with attribute 'coeffs' -
             a dictionary of lists of coefficients.
         """
-        self.coeffs = cheby_fits.coeffs
         # Convert list of coefficients into numpy arrays.
-        for k in self.coeffs:
-            self.coeffs[k] = np.array(self.coeffs[k])
+        for k in cheby_fits.coeffs:
+            self.coeffs[k] = np.array(cheby_fits.coeffs[k])
         # Check that expected values were received.
         missing_keys = set(self.coeff_keys) - set(self.coeffs)
         if len(missing_keys) > 0:


### PR DESCRIPTION
I am new to the LSST code community. Thank you all for the interesting work you all are doing here. I saw an extremely small change that would discard the neew to initialize self.coeffs in the cheby_values class. It doesn't changed the functionality of the set_coefficients but makes it more concise in my opinion. 