### PR TITLE
SP-1791: update some stats to make analyzing scheduler_note values easier

### DIFF
--- a/rubin_sim/maf/batches/col_map_dict.py
+++ b/rubin_sim/maf/batches/col_map_dict.py
@@ -40,6 +40,7 @@ def col_map_dict(dict_name=None):
         ]
         col_map["metadataAngleList"] = ["rotSkyPos"]
         col_map["scheduler_note"] = "scheduler_note"
+        col_map["scheduler_note_root"] = "scheduler_note_root"
 
     elif dict_name == "opsimv4":
         col_map = {}

--- a/rubin_sim/maf/batches/ddf_batch.py
+++ b/rubin_sim/maf/batches/ddf_batch.py
@@ -204,6 +204,7 @@ def ddfBatch(
                 info_label=" ".join([fieldname]),
                 summary_metrics=lightcurve_summary(),
                 display_dict=displayDict,
+                plot_funcs=[],
             )
         )
 

--- a/rubin_sim/maf/batches/glance_batch.py
+++ b/rubin_sim/maf/batches/glance_batch.py
@@ -364,16 +364,35 @@ def glanceBatch(
 
     # stats from the scheduler_note column
     if "scheduler_note" in colmap.keys():
-        displayDict = {"group": "Basic Stats", "subgroup": "Percent stats"}
+        displayDict = {"group": "Basic Stats", "subgroup": "Percent root stats"}
         metric = metrics.StringCountMetric(
-            col=colmap["scheduler_note"], percent=True, metric_name="Percents", clip_end=True
+            col=colmap["scheduler_note_root"], percent=True, metric_name="Percents", clip_end=False
         )
         sql = ""
         slicer = slicers.UniSlicer()
         bundle = metric_bundles.MetricBundle(metric, slicer, sql, display_dict=displayDict)
         bundle_list.append(bundle)
+        displayDict["subgroup"] = "Count root Stats"
+        metric = metrics.StringCountMetric(
+            col=colmap["scheduler_note_root"], metric_name="Counts", clip_end=False
+        )
+        bundle = metric_bundles.MetricBundle(metric, slicer, sql, display_dict=displayDict)
+        bundle_list.append(bundle)
+
+    # For pairs and twilights
+    if "scheduler_note" in colmap.keys():
+        displayDict = {"group": "Basic Stats", "subgroup": "Percent stats"}
+        metric = metrics.StringCountMetric(
+            col=colmap["scheduler_note"], percent=True, metric_name="Percents", clip_end=False
+        )
+        sql = (
+            "scheduler_note like 'pair%%' or scheduler_note like 'twilight%%' or scheduler_note like 'blob%%'"
+        )
+        slicer = slicers.UniSlicer()
+        bundle = metric_bundles.MetricBundle(metric, slicer, sql, display_dict=displayDict)
+        bundle_list.append(bundle)
         displayDict["subgroup"] = "Count Stats"
-        metric = metrics.StringCountMetric(col=colmap["scheduler_note"], metric_name="Counts", clip_end=True)
+        metric = metrics.StringCountMetric(col=colmap["scheduler_note"], metric_name="Counts", clip_end=False)
         bundle = metric_bundles.MetricBundle(metric, slicer, sql, display_dict=displayDict)
         bundle_list.append(bundle)
 

--- a/rubin_sim/maf/stackers/general_stackers.py
+++ b/rubin_sim/maf/stackers/general_stackers.py
@@ -119,6 +119,26 @@ class SaturationStacker(BaseStacker):
         return sim_data
 
 
+class NoteRootStacker(BaseStacker):
+    """Strip off things after a comma in the scheduler_note"""
+
+    cols_added = ["scheduler_note_root"]
+
+    def __init__(self, note_col="scheduler_note"):
+        self.units = ["mag"]
+        self.cols_req = [note_col]
+        self.note_col = note_col
+        self.cols_added_dtypes = ["<U50"]
+
+    def _run(self, sim_data, cols_present=False):
+        if cols_present:
+            # Column already present in data; assume it is fine.
+            return sim_data
+        new_note = [note.split(",")[0] for note in sim_data[self.note_col]]
+        sim_data["scheduler_note_root"] = new_note
+        return sim_data
+
+
 class FiveSigmaStacker(BaseStacker):
     """Calculate the 5-sigma limiting depth for a point source in the given
     conditions.


### PR DESCRIPTION
Since we often use the `scheduler_note` as a comma-separated way to track info, it is useful to add a column that is just the `scheduler_note` root, and compute some stats on that.