### PR TITLE
SP-1922: Bugfixes in scripts - set clobber properly, set order of batches

### DIFF
--- a/rubin_sim/maf/make_fbs_tracking_db.py
+++ b/rubin_sim/maf/make_fbs_tracking_db.py
@@ -27,8 +27,8 @@ def make_fbs_tracking_db():
     args = parser.parse_args()
 
     batches = {
-        "meta": "General Info Metrics",
         "glance": "Quick Look Metrics",
+        "meta": "General Info Metrics",
         "sci": "Science Metrics",
         "ss": "Solar System Metrics",
         "ddf": "Deep Drilling Metrics",
@@ -45,7 +45,7 @@ def make_fbs_tracking_db():
             db_name = vals[-1]
             run_name = db_name.replace(".db", "")
             run_version = run_name.split("_10yrs")[0][-4:]
-            run_group = run_version + family
+            run_group = " ".join([run_version, family])
 
             # Try to build a comment on the run based on the run_name
             run_comment = run_name.replace("_10yrs", "")[0:-4]

--- a/rubin_sim/maf/metadata_dir.py
+++ b/rubin_sim/maf/metadata_dir.py
@@ -37,7 +37,8 @@ def metadata_dir():
     parser.add_argument(
         "--no_clobber",
         dest="no_clobber",
-        action="store_false",
+        action="store_true",
+        default=False,
         help="Do not remove existing directory outputs",
     )
     args = parser.parse_args()

--- a/rubin_sim/maf/scimaf_dir.py
+++ b/rubin_sim/maf/scimaf_dir.py
@@ -25,7 +25,8 @@ def scimaf_dir():
     parser.add_argument(
         "--no_clobber",
         dest="no_clobber",
-        action="store_false",
+        action="store_true",
+        default=False,
         help="Do not remove existing directory outputs",
     )
     parser.set_defaults(no_long_micro=False)


### PR DESCRIPTION
Thought I'd fixed these earlier, but this should now: 
* properly set no_clobber (to avoid repeating plots when we rerun metric batches)
* set the group name properly for show_maf webpages
* set the order of the metric batches consistently with what was previously online