### PR TITLE
Tickets/sp 1966

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,8 @@ Installation from PyPI:
 ::
 
     pip install rubin-sim
+    scheduler_download_data 
+    rs_download_data
 
 Note: pip installation of rubin-sim will lack the JPL data (DE405, etc.)
 that is needed to actually run ``pyoorb``, used in ``rubin_sim.moving_objects``, as this is not currently available from PyPI.
@@ -24,10 +26,12 @@ or from conda-forge:
 ::
 
     conda install -c conda-forge rubin-sim
+    scheduler_download_data 
+    rs_download_data
 
-Please note that following either installation,
-additional data must be downloaded to use the software,
-following the instructions at
+The `scheduler_download_data` and `rs_download_data` commands will
+download data files to the default location of `~/rubin_sim_data`.
+To store the data elsewhere, see instructions at
 :ref:`Data Download<data-download>`.
 
 For Developer Use
@@ -39,34 +43,21 @@ First, clone the `rubin_sim <https://github.com/lsst/rubin_sim>`_ repository:
 
  git clone git@github.com:lsst/rubin_sim.git
  cd rubin_sim
-
-
-Create a conda environment for it:
-
-::
-
- conda create --channel conda-forge --name rubin-sim --file requirements.txt python=3.11
-
-
-If you want to run tests (please do), install the test requirements as well:
-
-::
-
+ conda create --channel conda-forge --name rubin-sim --file requirements.txt python=3.12
  conda activate rubin-sim
- conda install -c conda-forge --file=test-requirements.txt
-
-
-Install the ``rubin_sim`` package into this environment (from the rubin_sim directory):
-
-::
-
+ conda install -c conda-forge --file=test-requirements.txt # Optional test requirements
  pip install -e . --no-deps
+ scheduler_download_data 
+ rs_download_data
 
-Please note that following installation,
-additional data must be downloaded to use the software,
-following the instructions at
+The `scheduler_download_data` and `rs_download_data` commands will
+download data files to the default location of `~/rubin_sim_data`.
+To store the data elsewhere, see instructions at
 :ref:`Data Download<data-download>`.
 
+Note conda may override previous installs of 
+`rubin_scheduler`, in which case one can uninstall the conda version
+and re-run `pip install -e . --no-deps` from the needed git repo directory.
 
 Building Documentation
 ----------------------

--- a/rubin_sim/data/rs_download_data.py
+++ b/rubin_sim/data/rs_download_data.py
@@ -57,7 +57,7 @@ def data_dict() -> dict:
         "movingObjects": "movingObjects_oct_2021.tgz",
         "orbits": "orbits_2022_3_1.tgz",
         "orbits_precompute": "orbits_precompute_2023_05_23.tgz",
-        "sim_baseline": "sim_baseline_2024_10_08.tgz",
+        "sim_baseline": "sim_baseline_2025_03_03.tgz",
         "skybrightness": "skybrightness_2023_09_11.tgz",
         "throughputs": "throughputs_2023_09_22.tgz",
         "tests": "tests_2024_04_23.tgz",


### PR DESCRIPTION
Update to the latest example simulation (4.3.1)  
Update install instructions to python 3.12
Consolidate install instructions a bit so they are in a single block rather than spread over blocks/pages.