### PR TITLE
SP-2039: Update workflows - miniforge conda and py3.12

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,18 +18,16 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: "3.11"
-          miniforge-variant: Miniforge3
+          python-version: "3.12"
+          miniforge-version: latest
           channels: conda-forge,defaults
-          use-mamba: true
-          channel-priority: strict
           show-channel-urls: true
 
       - name: configure conda and install requirements
         shell: bash -l {0}
         run: |
-          mamba install --quiet pip
-          mamba install --quiet --file=requirements.txt
+          conda install --yes pip
+          conda install --yes --file=requirements.txt
           pip install "documenteer[guide]"
 
       - name: install rubin_sim

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -15,17 +15,15 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
+          python-version: "3.12"
+          miniforge-version: latest
           channels: conda-forge,defaults
-          use-mamba: true
-          channel-priority: strict
           show-channel-urls: true
 
       - name: Configure conda and install minimal requirements for cache
         shell: bash -l {0}
         run: |
-          mamba install --quiet rubin-scheduler -c conda-forge
+          conda install --yes rubin-scheduler
 
       - name: Install rubin_sim from git
         shell: bash -l {0}

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -21,4 +21,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -28,17 +28,15 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Miniforge3
-          channels: conda-forge
-          use-mamba: true
-          channel-priority: strict
+          miniforge-version: latest
+          channels: conda-forge,defaults
           show-channel-urls: true
 
       - name: configure conda and install requirements
         shell: bash -l {0}
         run: |
-          mamba install --quiet --file=requirements.txt
-          mamba install --quiet --file=test-requirements.txt
+          conda install --yes --file=requirements.txt
+          conda install --yes --file=test-requirements.txt
 
       - name: install rubin_sim
         shell: bash -l {0}
@@ -99,7 +97,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.12"
           cache: "pip"
 
       - name: Install dependencies for build

--- a/example_deployment.yaml
+++ b/example_deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maf
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: maf
+  name: maf-server
+  labels:
+    app: maf-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels: app maf-server
+  template:
+    metadata:
+      labels:
+        app: maf-server
+    spec:
+      containers:
+      - name: maf
+        image: "ghcr.io/....:tag"
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 1
+            memory: "2Gi"
+          requests:
+            cpu: 500m
+            memory: "1Gi"
+        volumeMounts:
+        - mountPath: /sdf/data/rubin
+          name: sdf-data-rubin
+      volumes:
+      - name: sdf-data-rubin
+        persistentVolumeClaim:
+          claimName: sdf-data-rubin
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: maf
+  name: sdf-data-rubin
+spec:
+  storageClassName: sdf-data-rubin
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: maf
+  name: usdf-maf
+  labels:
+    app: maf-server
+  annotations:
+    metallb.universe.tf/address-pool: sdf-services
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: maf-server

--- a/showmaf-deploy.yaml
+++ b/showmaf-deploy.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maf
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: maf
+  name: maf-server
+  labels:
+    app: maf-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maf-server
+  template:
+    metadata:
+      labels:
+        app: maf-server
+    spec:
+      containers:
+      - name: maf
+        image: "ghcr.io/lsst/rubin_sim:main"
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 1
+            memory: "10Gi"
+          requests:
+            cpu: 500m
+            memory: "8Gi"
+        volumeMounts:
+        - mountPath: /data/fbs_sims
+          name: sdf-data-rubin
+          subPath: shared/fbs_sims
+      volumes:
+      - name: sdf-data-rubin
+        persistentVolumeClaim:
+          claimName: sdf-data-rubin
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: maf
+  name: sdf-data-rubin
+spec:
+  storageClassName: sdf-data-rubin
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: maf
+  name: usdf-maf
+  labels:
+    app: maf-server
+  annotations:
+    metallb.universe.tf/address-pool: sdf-services
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: maf-server
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: maf-ingress
+  namespace: maf
+  labels:
+    app: maf-server
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: usdf-maf.slac.stanford.edu
+    http:
+      paths:
+      - backend:
+          service:
+            name: usdf-maf
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/tests/maf/test_batches.py
+++ b/tests/maf/test_batches.py
@@ -36,10 +36,6 @@ class TestBatches(unittest.TestCase):
 
         cls.out_dir = tempfile.mkdtemp(prefix="TMB")
 
-    def setup(self):
-        self.out_dir = TestBatches.out_dir
-        self.example_file = TestBatches.example_file
-
     @unittest.skipUnless(
         os.path.isdir(os.path.join(get_data_dir(), "maf")),
         "Skip these batches unless MAF data present, required for setup",
@@ -146,7 +142,7 @@ class TestBatches(unittest.TestCase):
         batch = batches.glanceBatch()
         results_db = db.ResultsDb(out_dir=self.out_dir)
         bgroup = metric_bundles.MetricBundleGroup(
-            batch, self.example_file, out_dir=self.out_dir, results_db=results_db
+            batch, self.example_file, out_dir=self.out_dir, results_db=results_db, save_early=False
         )
         bgroup.run_all()
 
@@ -154,7 +150,7 @@ class TestBatches(unittest.TestCase):
         batch = batches.ddfBatch()
         results_db = db.ResultsDb(out_dir=self.out_dir)
         bgroup = metric_bundles.MetricBundleGroup(
-            batch, self.example_file, out_dir=self.out_dir, results_db=results_db
+            batch, self.example_file, out_dir=self.out_dir, results_db=results_db, save_early=False
         )
         bgroup.run_all()
 


### PR DESCRIPTION
Remove old configuration parameters for setup-miniconda, swap to conda from mamba install, and update to py3.12 for workflows which just use a single python. 