### PR TITLE
tickets/SP-2082: Support getting obsloctac visits from the pre-night sim archive

### DIFF
--- a/rubin_sim/maf/utils/opsim_utils.py
+++ b/rubin_sim/maf/utils/opsim_utils.py
@@ -16,8 +16,8 @@ from sqlalchemy.engine import make_url
 
 def get_sim_data(
     db_con,
-    sqlconstraint,
-    dbcols,
+    sqlconstraint=None,
+    dbcols=None,
     stackers=None,
     table_name=None,
     full_sql_query=None,
@@ -79,10 +79,13 @@ def get_sim_data(
         table_name = "observations"
 
     if full_sql_query is None:
-        col_str = ""
-        for colname in dbcols:
-            col_str += colname + ", "
-        col_str = col_str[0:-2] + " "
+        if dbcols is None:
+            col_str = "*"
+        else:
+            col_str = ""
+            for colname in dbcols:
+                col_str += colname + ", "
+            col_str = col_str[0:-2] + " "
 
         query = "SELECT %s FROM %s" % (col_str, table_name)
         if len(sqlconstraint) > 0:
@@ -101,7 +104,7 @@ def get_sim_data(
             from lsst.resources import ResourcePath
 
             with ResourcePath(db_con).as_local() as local_db_path:
-                with closing(sqlite3.connect(local_db_path.ospath)) is con:
+                with closing(sqlite3.connect(local_db_path.ospath)) as con:
                     sim_data = pd.read_sql(query, con).to_records(index=False)
         except ModuleNotFoundError:
             raise RuntimeError(

--- a/rubin_sim/maf/utils/opsim_utils.py
+++ b/rubin_sim/maf/utils/opsim_utils.py
@@ -6,6 +6,7 @@ __all__ = (
 
 import os
 import sqlite3
+import urllib
 from contextlib import closing
 
 import numpy as np
@@ -79,13 +80,7 @@ def get_sim_data(
         table_name = "observations"
 
     if full_sql_query is None:
-        if dbcols is None:
-            col_str = "*"
-        else:
-            col_str = ""
-            for colname in dbcols:
-                col_str += colname + ", "
-            col_str = col_str[0:-2] + " "
+        col_str = "*" if dbcols is None else ", ".join(dbcols)
 
         query = "SELECT %s FROM %s" % (col_str, table_name)
         if len(sqlconstraint) > 0:
@@ -99,7 +94,7 @@ def get_sim_data(
     elif isinstance(db_con, str) and os.path.isfile(db_con):
         with closing(sqlite3.connect(db_con)) as con:
             sim_data = pd.read_sql(query, con).to_records(index=False)
-    else:
+    elif (not isinstance(db_con, str)) or urllib.parse.urlparse(db_con).scheme != "":
         try:
             from lsst.resources import ResourcePath
 
@@ -111,6 +106,8 @@ def get_sim_data(
                 f"Cannot read visits from {db_con}."
                 "Maybe it does not exist, or maybe you need to install lsst.resources."
             )
+    else:
+        raise RuntimeError("Cannot find {db_con}.")
 
     if len(sim_data) == 0:
         raise UserWarning("No data found matching sqlconstraint %s" % (sqlconstraint))

--- a/rubin_sim/maf/utils/opsim_utils.py
+++ b/rubin_sim/maf/utils/opsim_utils.py
@@ -96,7 +96,7 @@ def get_sim_data(
 
     if isinstance(db_con, sqlite3.Connection):
         sim_data = pd.read_sql(query, db_con).to_records(index=False)
-    elif isinstance(db_con, str) and os.path.isfile(str):
+    elif isinstance(db_con, str) and os.path.isfile(db_con):
         with closing(sqlite3.connect(db_con)) as con:
             sim_data = pd.read_sql(query, con).to_records(index=False)
     else:

--- a/tests/sim_archive/test_sim_archive.py
+++ b/tests/sim_archive/test_sim_archive.py
@@ -21,9 +21,9 @@ if HAVE_LSST_RESOURCES:
     from rubin_sim.sim_archive.sim_archive import (
         check_opsim_archive_resource,
         compile_sim_metadata,
-        fetch_latest_prenight_sim_for_night,
+        fetch_latest_prenight_sim_for_nights,
         fetch_obsloctap_visits,
-        find_latest_prenight_sim_for_night,
+        find_latest_prenight_sim_for_nights,
         make_sim_archive_cli,
         make_sim_archive_dir,
         read_archived_sim_metadata,
@@ -143,20 +143,24 @@ class TestSimArchive(unittest.TestCase):
     @unittest.skipIf(not HAVE_LSST_RESOURCES, "No lsst.resources")
     def test_find_latest_prenight_sim_for_night(self):
         day_obs = "2025-03-25"
-        sim_metadata = find_latest_prenight_sim_for_night(day_obs)
+        max_simulation_age = int(np.ceil(Time.now().mjd - Time(day_obs).mjd)) + 1
+        sim_metadata = find_latest_prenight_sim_for_nights(day_obs, max_simulation_age=max_simulation_age)
         assert sim_metadata["simulated_dates"]["first"] <= day_obs <= sim_metadata["simulated_dates"]["last"]
 
     @unittest.skipIf(not HAVE_LSST_RESOURCES, "No lsst.resources")
     def test_fetch_latest_prenight_sim_for_night(self):
         day_obs = "2025-03-25"
-        visits = fetch_latest_prenight_sim_for_night(day_obs)
+        max_simulation_age = int(np.ceil(Time.now().mjd - Time(day_obs).mjd)) + 1
+        visits = fetch_latest_prenight_sim_for_nights(day_obs, max_simulation_age=max_simulation_age)
         assert len(visits) > 0
 
     @unittest.skipIf(not HAVE_LSST_RESOURCES, "No lsst.resources")
     def test_fetch_obsloctap_visits(self):
         day_obs = "2025-03-25"
-        visits = pd.DataFrame(fetch_obsloctap_visits(day_obs))
-        assert np.all(np.floor(visits["observationStartMJD"] - 0.5) == Time(day_obs).mjd)
+        num_nights = 2
+        visits = pd.DataFrame(fetch_obsloctap_visits(day_obs, nights=num_nights))
+        assert np.floor(visits["observationStartMJD"].min() - 0.5) == Time(day_obs).mjd
+        assert np.floor(visits["observationStartMJD"].max() - 0.5) == Time(day_obs).mjd + num_nights - 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've reworked the start and end times of the obsloctap function to match what @rhiannonlynne proposed to Will:

> you call rubin_sim.sim_archive.fetch_obslactap_visits() at any time,
and we return the visits starting from the next sunset after the current time through the 2nd sunrise after that.
So, if you happened to call during the night (after sunset, before sunrise), we will NOT return any visits from the current night, but will return the visits from the next two nights.