### PR TITLE
SP-2099: gather_summaries reads run_name per metric from resultsDb

### DIFF
--- a/tests/maf/test_gathersummaries.py
+++ b/tests/maf/test_gathersummaries.py
@@ -12,7 +12,7 @@ class TestGather(unittest.TestCase):
         results_db.update_metric(
             "test_metric_name",
             "test_slicer_name",
-            "temp",
+            "temp1",
             "test_sql_constraint",
             "test_metric_info_label",
             "test_metric_datafile",
@@ -24,7 +24,7 @@ class TestGather(unittest.TestCase):
         results_db.update_metric(
             "test_metric_name",
             "test_slicer_name",
-            "temp",
+            "temp2",
             "test_sql_constraint",
             "test_metric_info_label",
             "test_metric_datafile",


### PR DESCRIPTION
This update runs in about the same time (maybe faster) as the current version of gather_summaries, but allows multiple opsims to share the same resultsDb. The run_name in the resultsDb is propagated to the summary gathering, for use as the 'row' index. 