### PR TITLE
tickets/SP-2209: Make automatic nominal prenight sim run for 3 nights

### DIFF
--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -278,6 +278,7 @@ def run_prenights(
             sim_start_mjd,
             label=f"Nominal start and overhead, ideal conditions, run at {exec_time}",
             tags=["ideal", "nominal"],
+            sim_duration=sim_duration,
         )
         completed_run_without_delay = True
 


### PR DESCRIPTION
See [here](https://usdf-rsp.slac.stanford.edu/times-square/github/lsst/schedview_notebooks/prenight/prenight_sims?day_obs=2025-05-09&earliest_sim=2025-05-09&ts_hide_code=1).

The simulation listed there as 2025-05-09/13 was made using a personal branch of rubin_sim that combines changes of SP-2208 and SP-2209 which let it simulate Simonyi scheduling (SP-2208) for three nights, even in nominal conditions (SP-2209).
