### PR TITLE
tickets/SP-2576: Fixes to get pre-night slurm jobs to run again

### DIFF
--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -50,8 +50,8 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="tickets/SP-2447"
-SCHEDVIEW_REFERENCE="tickets/SP-2447"
+RUBIN_SIM_REFERENCE="v2.2.5.dev1"
+SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \
   git+https://github.com/lsst/rubin_sim.git@${RUBIN_SIM_REFERENCE} \

--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev5"
+RUBIN_SIM_REFERENCE="v2.2.5.dev6"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev3"
+RUBIN_SIM_REFERENCE="v2.2.5.dev4"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -2,7 +2,7 @@
 #SBATCH --account=rubin:developers      # Account name
 #SBATCH --job-name=auxtel_prenight_daily   # Job name
 #SBATCH --output=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.out # Output file (stdout)
-#SBATCH --error=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.err  # Error file (stderr)
+#SBATCH --error=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.out  # Error file (stderr)
 #SBATCH --partition=milano              # Partition (queue) names
 #SBATCH --nodes=1                       # Number of nodes
 #SBATCH --ntasks=1                      # Number of tasks run in parallel
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev1"
+RUBIN_SIM_REFERENCE="v2.2.5.dev2"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev4"
+RUBIN_SIM_REFERENCE="v2.2.5.dev5"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_auxtel_prenight_sims.sh
+++ b/batch/run_auxtel_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev2"
+RUBIN_SIM_REFERENCE="v2.2.5.dev3"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -50,9 +50,9 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev2"
+RUBIN_SIM_REFERENCE="v2.2.5.dev3"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
-SIMS_SV_SURVEY_REFERENCE="v0.1.0"
+SIMS_SV_SURVEY_REFERENCE="v0.1.0.dev1"
 RUBIN_NIGHTS_REFERENCE="v0.3.0"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -50,9 +50,9 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev4"
+RUBIN_SIM_REFERENCE="v2.2.5.dev5"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
-SIMS_SV_SURVEY_REFERENCE="v0.1.0.dev1"
+SIMS_SV_SURVEY_REFERENCE="v0.1.0.dev2"
 RUBIN_NIGHTS_REFERENCE="v0.3.0"
 
 pip install --no-deps --target=${PACKAGE_DIR} \

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -7,7 +7,7 @@
 #SBATCH --nodes=1                       # Number of nodes
 #SBATCH --ntasks=1                      # Number of tasks run in parallel
 #SBATCH --cpus-per-task=1               # Number of CPUs per task
-#SBATCH --mem=6G                       # Requested memory
+#SBATCH --mem=8G                       # Requested memory
 #SBATCH --time=1:00:00                 # Wall time (hh:mm:ss)
 
 echo "******** START of run_prenight_sims.sh **********"

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -2,7 +2,7 @@
 #SBATCH --account=rubin:developers      # Account name
 #SBATCH --job-name=auxtel_prenight_daily   # Job name
 #SBATCH --output=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.out # Output file (stdout)
-#SBATCH --error=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.err  # Error file (stderr)
+#SBATCH --error=/sdf/data/rubin/shared/scheduler/prenight/sbatch/run_prenight_sims_%A_%a.out  # Error file (stderr)
 #SBATCH --partition=milano              # Partition (queue) names
 #SBATCH --nodes=1                       # Number of nodes
 #SBATCH --ntasks=1                      # Number of tasks run in parallel
@@ -50,10 +50,10 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="tickets/SP-2447"
-SCHEDVIEW_REFERENCE="tickets/SP-2447"
-SIMS_SV_SURVEY_REFERENCE="tickets/SP-2447b"
-RUBIN_NIGHTS_REFERENCE="b82cafd8"
+RUBIN_SIM_REFERENCE="v2.2.5.dev1"
+SCHEDVIEW_REFERENCE="v0.19.0.dev1"
+SIMS_SV_SURVEY_REFERENCE="v0.1.0"
+RUBIN_NIGHTS_REFERENCE="v0.3.0"
 
 pip install --no-deps --target=${PACKAGE_DIR} \
   git+https://github.com/lsst/rubin_sim.git@${RUBIN_SIM_REFERENCE} \

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev1"
+RUBIN_SIM_REFERENCE="v2.2.5.dev2"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 SIMS_SV_SURVEY_REFERENCE="v0.1.0"
 RUBIN_NIGHTS_REFERENCE="v0.3.0"

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev5"
+RUBIN_SIM_REFERENCE="v2.2.5.dev6"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 SIMS_SV_SURVEY_REFERENCE="v0.1.0.dev2"
 RUBIN_NIGHTS_REFERENCE="v0.3.0"

--- a/batch/run_prenight_sims.sh
+++ b/batch/run_prenight_sims.sh
@@ -50,7 +50,7 @@ export PATH=${PACKAGE_DIR}/bin:${PATH}
 # Cannot get ts_fbs_utils from the EFD, so just guess the highest semantic version tag in the repo.
 # A "reference" can be a tag, hash, or branch.
 TS_FBS_UTILS_REFERENCE=$(curl -s https://api.github.com/repos/lsst-ts/ts_fbs_utils/tags | jq -r '.[].name' | egrep '^v[0-9]+.[0-9]+.[0-9]+$' | sort -V | tail -1)
-RUBIN_SIM_REFERENCE="v2.2.5.dev3"
+RUBIN_SIM_REFERENCE="v2.2.5.dev4"
 SCHEDVIEW_REFERENCE="v0.19.0.dev1"
 SIMS_SV_SURVEY_REFERENCE="v0.1.0.dev1"
 RUBIN_NIGHTS_REFERENCE="v0.3.0"
@@ -109,7 +109,7 @@ OPSIMRUN="prenight_nominal_$(date --iso=s)"
 LABEL="Nominal start and overhead, ideal conditions, run at $(date --iso=s)"
 date --iso=s
 run_sv_sim scheduler.p observatory.p "" ${DAYOBS} 3 "${OPSIMRUN}" \
-  --keep_rewards --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
+  --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
   --delay 0 --anom_overhead_scale 0 \
   --tags ideal nominal
 
@@ -120,7 +120,7 @@ for DELAY in 10 60 ; do
   LABEL="Start time delayed by ${DELAY} minutes, nominal slew and visit overhead, ideal conditions, run at $(date --iso=s)"
   date --iso=s
   run_sv_sim scheduler.p observatory.p "" ${DAYOBS} 3 "${OPSIMRUN}" \
-    --keep_rewards --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
+    --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
     --delay ${DELAY} --anom_overhead_scale 0 \
     --tags ideal delay_${DELAY}
 done
@@ -132,7 +132,7 @@ for ANOM_SEED in 101 102 ; do
   LABEL="Anomalous overhead (${ANOM_SEED}, ${ANOM_SCALE}), nominal start, ideal conditions, run at $(date --iso=s)"
   date --iso=s
   run_sv_sim scheduler.p observatory.p "" ${DAYOBS} 3 "${OPSIMRUN}" \
-    --keep_rewards --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
+    --no-downtime --label "${LABEL}" --archive ${ARCHIVE} --capture_env \
     --delay 0 --anom_overhead_scale ${ANOM_SCALE} --anom_overhead_seed ${ANOM_SEED} \
     --tags ideal anomalous_overhead
 done


### PR DESCRIPTION
Three significant changes here, each of which were issues:

1. Updated dependency versions
2. Removed switch to save rewards, because it was making the jobs take long enough that they weren't finishing in the requested time. We may want to turn them back on for at least the "nominal" simulation, and up the requested time a little.
3. Ask for more memory when submitting the slurm job.

To make debugging easier, included stderr in the `.out` file instead of separating it into a separate `.err` file.