### PR TITLE
tickets/SP-3021: make AnomalousOverheadFunc more flexible

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 26.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.13
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -15,8 +15,8 @@ import numpy as np
 import scipy.stats
 from matplotlib.pylab import Generator
 from rubin_scheduler.scheduler import sim_runner
-from rubin_scheduler.site_models import Almanac
 from rubin_scheduler.scheduler.utils.observation_array import ObservationArray
+from rubin_scheduler.site_models import Almanac
 
 from rubin_sim.sim_archive import make_sim_data_dir
 
@@ -212,9 +212,9 @@ class AnomalousOverheadFunc:
 
         # If we have the available parameters, make sure the final overhead
         # is more than min_overhead
-        overhead_checked : bool = False
+        overhead_checked: bool = False
         if obs is not None:
-            needed_data_found : bool = False
+            needed_data_found: bool = False
             try:
                 model_overhead = obs["slewtime"] + obs["visittime"] - obs["exptime"]
                 needed_data_found = True
@@ -225,7 +225,7 @@ class AnomalousOverheadFunc:
                 if after_offset_overhead < self.min_overhead:
                     overhead_offset = self.min_overhead - model_overhead
                 overhead_checked = True
-    
+
         if not overhead_checked:
             warnings.warn("Could not verify that the overhead was greater than the minimum.")
 

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -9,9 +9,10 @@ import warnings
 from copy import deepcopy
 from datetime import date
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable, Mapping, Protocol
 
 import numpy as np
+import scipy.stats
 from matplotlib.pylab import Generator
 from rubin_scheduler.scheduler import sim_runner
 from rubin_scheduler.site_models import Almanac
@@ -21,6 +22,16 @@ from rubin_sim.sim_archive import make_sim_data_dir
 from .util import dayobs_to_date
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Type hint to match scipy.stats style distribution classes
+class ContinuousDistribution(Protocol):
+    def rvs(
+        self,
+        size: int | tuple[int, ...] | None = None,
+        random_state: np.random.RandomState | np.random.Generator | int | None = None,
+    ) -> float:
+        ...
 
 
 class AnomalousOverheadFunc:
@@ -73,7 +84,7 @@ class AnomalousOverheadFunc:
 
     """
 
-    default_overhead_scatter_dist = "normal"
+    default_overhead_scatter_dist: ContinuousDistribution = scipy.stats.halfnorm
     default_overhead_scatter_kwargs = {"scale": 0.0, "loc": 0.0}
 
     def __init__(
@@ -84,7 +95,7 @@ class AnomalousOverheadFunc:
         slew_loc: float = 0.0,
         visit_loc: float = 0.0,
         min_overhead: float = 0.0,
-        scatter_distribution: str | None = None,
+        scatter_distribution: str | ContinuousDistribution | None = None,
         scatter_kwargs: dict | None = None,
     ) -> None:
         self.rng: Generator = np.random.default_rng(seed)
@@ -93,42 +104,67 @@ class AnomalousOverheadFunc:
         self.slew_loc: float = slew_loc
         self.slew_scale: float = slew_scale
 
-        if scatter_distribution is None:
-            scatter_distribution = self.default_overhead_scatter_dist
-        assert isinstance(scatter_distribution, str)
-        try:
-            maybe_scatter_dist_func = getattr(self.rng, scatter_distribution)
-            # If scatter_distribution is a plain attribute rather than a true
-            # method, it won't work for us, and confuses the type checker.
-        except AttributeError as exc:
-            raise AttributeError(
-                "'scatter_distribution' must be valid NumPy random Generator method, "
-                f"and '{scatter_distribution}' is not."
-            ) from exc
-        assert callable(maybe_scatter_dist_func), "'scatter_distribution' must be callable"
-        self.scatter_dist_func: Callable = maybe_scatter_dist_func
-
         if scatter_kwargs is None:
             scatter_kwargs = self.default_overhead_scatter_kwargs
-
         assert isinstance(scatter_kwargs, dict)
         self.scatter_kwargs = deepcopy(scatter_kwargs)
 
+        self.scatter_dist_func: Callable
+        if scatter_distribution is None:
+            scatter_distribution = self.default_overhead_scatter_dist
+
+        if isinstance(scatter_distribution, str):
+            # If scatter_distribution is a string, interpret it
+            # as a numpy random number distribution.
+            try:
+                maybe_scatter_dist_func = getattr(self.rng, scatter_distribution)
+                # If scatter_distribution is a plain attribute
+                # rather than a true
+                # method, it won't work for us, and confuses the type checker.
+            except AttributeError as exc:
+                raise AttributeError(
+                    "'scatter_distribution' must be valid NumPy random Generator method, "
+                    f"and '{scatter_distribution}' is not."
+                ) from exc
+            assert callable(maybe_scatter_dist_func), "'scatter_distribution' must be callable"
+            self.scatter_dist_func = maybe_scatter_dist_func
+        else:
+            maybe_scatter_dist_func = getattr(scatter_distribution, "rvs", None)
+            assert callable(
+                maybe_scatter_dist_func
+            ), f"Cannot use scatter distribution of type {str(scatter_distribution.__class__.__name__)}"
+
+            if "random_state" not in self.scatter_kwargs:
+                self.scatter_kwargs["random_state"] = self.rng
+
+            self.scatter_dist_func = maybe_scatter_dist_func
+
         self.min_overhead: float = min_overhead
 
+        if self.visit_scale > 0:
+            raise NotImplementedError("Visit scale scatter is no longer implemented.")
+
     def __call__(
-        self, visittime: float | np.ndarray, slewtime: float | np.ndarray, exptime: float | np.ndarray = 30.0
+        self,
+        visittime: float | np.ndarray | None = None,
+        slewtime: float | np.ndarray | None = None,
+        obs: Mapping[str, Any] | None = None,
     ) -> float:
         """Return a randomized offset for the visit overhead.
 
         Parameters
         ----------
-        visittime : `float`
-            The visit time (seconds).
-        slewtime : `float`
-            The slew time (seconds).
-        exptime : `float`
-            Exposure time (seconds).
+        visittime : `float` or `None`
+            The visit time (seconds). No longer does anything,
+            and will be removed.
+        slewtime : `float` or `None`
+            The slew time (seconds). If the ``slew_scale`` attribute
+            is greater than zero, either ``slewtime`` must not be
+            ``None`` or ``obs`` (below) must have a ``slewtime`` key.
+            The use of ``slewtime`` is deprecated in favor of using
+            ``obs``.
+        obs : `Mapping[str, Any]`
+            Observation record.
 
         Returns
         -------
@@ -141,51 +177,49 @@ class AnomalousOverheadFunc:
             So, the ``offset`` here is time to be added to
             the modeled start of an exposure.
         """
-        if isinstance(visittime, np.ndarray):
-            assert visittime.shape == (1,)
-            visittime = float(visittime.item())
-        assert isinstance(visittime, float)
+        if visittime is not None:
+            warnings.warn(
+                "The visittime argument is deprecated and does nothing.", DeprecationWarning, stacklevel=2
+            )
 
-        if isinstance(slewtime, np.ndarray):
-            assert slewtime.shape == (1,)
-            slewtime = float(slewtime.item())
-        assert isinstance(slewtime, float)
+        slew_overhead_offset: float
+        if self.slew_scale > 0 or self.slew_loc > 0:
+            # we are actually using slew time scattering, so
+            # get the model slewtime.
+            if slewtime is not None:
+                if isinstance(slewtime, np.ndarray):
+                    assert slewtime.shape == (1,)
+                    slewtime = float(slewtime.item())
+                assert isinstance(slewtime, float)
+                warnings.warn(
+                    "The visittime argument is deprecated and unused", DeprecationWarning, stacklevel=2
+                )
+            else:
+                assert isinstance(obs, Mapping)
+                assert isinstance(obs["slewtime"], float)
+                slewtime = obs["slewtime"]
 
-        if isinstance(exptime, np.ndarray):
-            assert exptime.shape == (1,)
-            exptime = float(exptime.item())
-        assert isinstance(exptime, float)
-
-        slew_overhead_offset: float = slewtime * self.rng.normal(self.slew_loc, self.slew_scale)
-
-        # Slew might be faster that expected, but it will never take negative
-        # time.
-        if (slewtime + slew_overhead_offset) < 0:
+            slew_overhead_offset = slewtime * self.rng.normal(self.slew_loc, self.slew_scale)
+            # Slew might be faster than expected,
+            # but it will never take negative time.
+            if (slewtime + slew_overhead_offset) < 0:
+                slew_overhead_offset = -1 * slewtime
+        else:
             slew_overhead_offset = 0.0
-
-        # visit overhead includes shutter and readout time
-        visit_overhead: float = visittime - exptime
-        visit_overhead_offset: float = visit_overhead * self.rng.normal(self.visit_loc, self.visit_scale)
-        # There might be anomalous overhead that makes visits take longer,
-        # but faster is unlikely.
-        if visit_overhead_offset < 0:
-            visit_overhead_offset = 0.0
 
         scatter_offset: float = self.scatter_dist_func(**self.scatter_kwargs)
 
-        # Likely distributions (e.g. normal) for scatter_offest
-        # can have infinite negative tails, resulting in negative
-        # overhead, which is not physical.
-        # Make sure the total offset does not result in a total
-        # overhead that is less than min_overhead. If it would,
-        # return an offset that results in min_overhead as the
-        # overhead, once the slew and visit overhead are added
-        # back in.
-        expected_overhead: float = slewtime + visit_overhead
-        min_overhead_offset: float = self.min_overhead - expected_overhead
-        overhead_offset: float = max(
-            slew_overhead_offset + visit_overhead_offset + scatter_offset, min_overhead_offset
-        )
+        overhead_offset: float = slew_overhead_offset + scatter_offset
+
+        # If we have the available parameters, make sure the final overhead
+        # is more than min_overhead
+        if obs is not None and "visittime" in obs and "exptime" in obs and "slewtime" in obs:
+            model_overhead = obs["slewtime"] + obs["visittime"] - obs["exptime"]
+            after_offset_overhead = model_overhead + overhead_offset
+            if after_offset_overhead < self.min_overhead:
+                overhead_offset = self.min_overhead - model_overhead
+        else:
+            warnings.warn("Could not verify that the overhead was greater than the minimum.")
 
         return overhead_offset
 

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -44,15 +44,16 @@ class AnomalousOverheadFunc:
         The scale for the scatter in the slew offest (seconds).
         Defaults to 0.0.
     visit_scale : `float`, optional
-        The scale for the scatter in the visit overhead offset (seconds).
+        The paramater no longer does anything, and will be
+        removed in future versions.
         Defaults to 0.0.
     slew_loc : `float`, optional
         The location of the scatter in the slew offest (seconds).
         It is unlikely that this should ever be non-zero.
         Defaults to 0.0.
     visit_loc : `float`, optional
-        The location of the scatter in the visit offset (seconds).
-        It is unlikely that this should ever be non-zero.
+        The paramater no longer does anything, and will be
+        removed in future versions.
         Defaults to 0.0.
     scatter_distribution: `str` or `None`, optional
         The distribution from which the scatter should be taken.
@@ -73,10 +74,8 @@ class AnomalousOverheadFunc:
       proportional to the slew time following a normal distribution.
       A non-zero ``slew_loc`` will sysetmatically move the center of
       the distribution.
-    - The ``visit_scale`` and ``visit_loc`` parameters introduce an offset
-      proportional to the visit time following a normal distribution.
-      A non-zero ``visit_loc`` will sysetmatically move the center of
-      the distribution.
+    - The ``visit_scale`` and ``visit_loc`` parameters are no longer
+      functional, and persist only to support backward compatibility.
     - The ``scatter_distribution`` and ``scatter_kwargs`` introduce an
       offset independent of the modeled slew and visit times, and support
       any distribution offered by `numpy.random.Generator`.

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -16,6 +16,7 @@ import scipy.stats
 from matplotlib.pylab import Generator
 from rubin_scheduler.scheduler import sim_runner
 from rubin_scheduler.site_models import Almanac
+from rubin_scheduler.scheduler.utils.observation_array import ObservationArray
 
 from rubin_sim.sim_archive import make_sim_data_dir
 
@@ -146,7 +147,7 @@ class AnomalousOverheadFunc:
         self,
         visittime: float | np.ndarray | None = None,
         slewtime: float | np.ndarray | None = None,
-        obs: Mapping[str, Any] | None = None,
+        obs: Mapping[str, Any] | ObservationArray | None = None,
     ) -> float:
         """Return a randomized offset for the visit overhead.
 
@@ -211,12 +212,21 @@ class AnomalousOverheadFunc:
 
         # If we have the available parameters, make sure the final overhead
         # is more than min_overhead
-        if obs is not None and "visittime" in obs and "exptime" in obs and "slewtime" in obs:
-            model_overhead = obs["slewtime"] + obs["visittime"] - obs["exptime"]
-            after_offset_overhead = model_overhead + overhead_offset
-            if after_offset_overhead < self.min_overhead:
-                overhead_offset = self.min_overhead - model_overhead
-        else:
+        overhead_checked : bool = False
+        if obs is not None:
+            needed_data_found : bool = False
+            try:
+                model_overhead = obs["slewtime"] + obs["visittime"] - obs["exptime"]
+                needed_data_found = True
+            except (KeyError, ValueError):
+                pass
+            if needed_data_found:
+                after_offset_overhead = model_overhead + overhead_offset
+                if after_offset_overhead < self.min_overhead:
+                    overhead_offset = self.min_overhead - model_overhead
+                overhead_checked = True
+    
+        if not overhead_checked:
             warnings.warn("Could not verify that the overhead was greater than the minimum.")
 
         return overhead_offset

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -116,7 +116,9 @@ class AnomalousOverheadFunc:
 
         self.min_overhead: float = min_overhead
 
-    def __call__(self, visittime: float | np.ndarray, slewtime: float | np.ndarray) -> float:
+    def __call__(
+        self, visittime: float | np.ndarray, slewtime: float | np.ndarray, exptime: float | np.ndarray = 30.0
+    ) -> float:
         """Return a randomized offset for the visit overhead.
 
         Parameters
@@ -125,11 +127,19 @@ class AnomalousOverheadFunc:
             The visit time (seconds).
         slewtime : `float`
             The slew time (seconds).
+        exptime : `float`
+            Exposure time (seconds).
 
         Returns
         -------
         offset: `float`
-            Random offset (seconds).
+            The offset (in seconds) between the modeled overhead
+            between exposures and the overhead to be applied.
+            "Overhead" is the difference in start times between
+            succesive expusures, minus the exposure times:
+            ``overhead = exp_start_2 - exp_start_1 - exptime_1``.
+            So, the ``offset`` here is time to be added to
+            the modeled start of an exposure.
         """
         if isinstance(visittime, np.ndarray):
             assert visittime.shape == (1,)
@@ -141,25 +151,43 @@ class AnomalousOverheadFunc:
             slewtime = float(slewtime.item())
         assert isinstance(slewtime, float)
 
-        slew_overhead: float = slewtime * self.rng.normal(self.slew_loc, self.slew_scale)
+        if isinstance(exptime, np.ndarray):
+            assert exptime.shape == (1,)
+            exptime = float(exptime.item())
+        assert isinstance(exptime, float)
+
+        slew_overhead_offset: float = slewtime * self.rng.normal(self.slew_loc, self.slew_scale)
 
         # Slew might be faster that expected, but it will never take negative
         # time.
-        if (slewtime + slew_overhead) < 0:
-            slew_overhead = 0.0
+        if (slewtime + slew_overhead_offset) < 0:
+            slew_overhead_offset = 0.0
 
-        visit_overhead: float = visittime * self.rng.normal(self.visit_loc, self.visit_scale)
+        # visit overhead includes shutter and readout time
+        visit_overhead: float = visittime - exptime
+        visit_overhead_offset: float = visit_overhead * self.rng.normal(self.visit_loc, self.visit_scale)
         # There might be anomalous overhead that makes visits take longer,
         # but faster is unlikely.
-        if visit_overhead < 0:
-            visit_overhead = 0.0
+        if visit_overhead_offset < 0:
+            visit_overhead_offset = 0.0
 
-        scatter: float = self.scatter_dist_func(**self.scatter_kwargs)
-        overhead: float = max(
-            slew_overhead + visit_overhead + scatter, self.min_overhead - slewtime - visittime
+        scatter_offset: float = self.scatter_dist_func(**self.scatter_kwargs)
+
+        # Likely distributions (e.g. normal) for scatter_offest
+        # can have infinite negative tails, resulting in negative
+        # overhead, which is not physical.
+        # Make sure the total offset does not result in a total
+        # overhead that is less than min_overhead. If it would,
+        # return an offset that results in min_overhead as the
+        # overhead, once the slew and visit overhead are added
+        # back in.
+        expected_overhead: float = slewtime + visit_overhead
+        min_overhead_offset: float = self.min_overhead - expected_overhead
+        overhead_offset: float = max(
+            slew_overhead_offset + visit_overhead_offset + scatter_offset, min_overhead_offset
         )
 
-        return overhead
+        return overhead_offset
 
 
 def compute_sim_start_and_end(day_obs: int, sim_nights: int, delay: float = 0) -> tuple[float, float]:

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -6,8 +6,10 @@ import argparse
 import logging
 import pickle
 import warnings
+from copy import deepcopy
 from datetime import date
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
 from matplotlib.pylab import Generator
@@ -30,24 +32,60 @@ class AnomalousOverheadFunc:
         Random number seed.
     slew_scale : `float`
         The scale for the scatter in the slew offest (seconds).
+        Defaults to 0.0.
     visit_scale : `float`, optional
         The scale for the scatter in the visit overhead offset (seconds).
         Defaults to 0.0.
     slew_loc : `float`, optional
         The location of the scatter in the slew offest (seconds).
+        It is unlikely that this should ever be non-zero.
         Defaults to 0.0.
     visit_loc : `float`, optional
         The location of the scatter in the visit offset (seconds).
+        It is unlikely that this should ever be non-zero.
         Defaults to 0.0.
+    scatter_distribution: `str` or `None`, optional
+        The distribution from which the scatter should be taken.
+        This must be the name of a method of `numpy.random.Generator`.
+        If `None`, the distribution is taken from
+        `DEFAULT_OVERHEAD_SCATTER_DIST`.
+        Defaults to ``None``.
+    scatter_kwargs: `dict` or `None`, optional
+        Dictionary of arguments passed to ``scatter_distribution``.
+        If `None`, the argumentns taken from
+        `DEFAULT_OVERHEAD_SCATTER_KWARGS`.
+    min_overhead : `float`, optional
+        The minimum possible overhead
+
+    Notes
+    -----
+    - The ``slew_scale`` and ``slew_loc`` parameters introduce an offset
+      proportional to the slew time following a normal distribution.
+      A non-zero ``slew_loc`` will sysetmatically move the center of
+      the distribution.
+    - The ``visit_scale`` and ``visit_loc`` parameters introduce an offset
+      proportional to the visit time following a normal distribution.
+      A non-zero ``visit_loc`` will sysetmatically move the center of
+      the distribution.
+    - The ``scatter_distribution`` and ``scatter_kwargs`` introduce an
+      offset independent of the modeled slew and visit times, and support
+      any distribution offered by `numpy.random.Generator`.
+
     """
+
+    default_overhead_scatter_dist = "normal"
+    default_overhead_scatter_kwargs = {"scale": 0.0, "loc": 0.0}
 
     def __init__(
         self,
         seed: int,
-        slew_scale: float,
+        slew_scale: float = 0.0,
         visit_scale: float = 0.0,
         slew_loc: float = 0.0,
         visit_loc: float = 0.0,
+        min_overhead: float = 0.0,
+        scatter_distribution: str | None = None,
+        scatter_kwargs: dict | None = None,
     ) -> None:
         self.rng: Generator = np.random.default_rng(seed)
         self.visit_loc: float = visit_loc
@@ -55,7 +93,30 @@ class AnomalousOverheadFunc:
         self.slew_loc: float = slew_loc
         self.slew_scale: float = slew_scale
 
-    def __call__(self, visittime: float, slewtime: float) -> float:
+        if scatter_distribution is None:
+            scatter_distribution = self.default_overhead_scatter_dist
+        assert isinstance(scatter_distribution, str)
+        try:
+            maybe_scatter_dist_func = getattr(self.rng, scatter_distribution)
+            # If scatter_distribution is a plain attribute rather than a true
+            # method, it won't work for us, and confuses the type checker.
+        except AttributeError as exc:
+            raise AttributeError(
+                "'scatter_distribution' must be valid NumPy random Generator method, "
+                f"and '{scatter_distribution}' is not."
+            ) from exc
+        assert callable(maybe_scatter_dist_func), "'scatter_distribution' must be callable"
+        self.scatter_dist_func: Callable = maybe_scatter_dist_func
+
+        if scatter_kwargs is None:
+            scatter_kwargs = self.default_overhead_scatter_kwargs
+
+        assert isinstance(scatter_kwargs, dict)
+        self.scatter_kwargs = deepcopy(scatter_kwargs)
+
+        self.min_overhead: float = min_overhead
+
+    def __call__(self, visittime: float | np.ndarray, slewtime: float | np.ndarray) -> float:
         """Return a randomized offset for the visit overhead.
 
         Parameters
@@ -70,6 +131,15 @@ class AnomalousOverheadFunc:
         offset: `float`
             Random offset (seconds).
         """
+        if isinstance(visittime, np.ndarray):
+            assert visittime.shape == (1,)
+            visittime = float(visittime.item())
+        assert isinstance(visittime, float)
+
+        if isinstance(slewtime, np.ndarray):
+            assert slewtime.shape == (1,)
+            slewtime = float(slewtime.item())
+        assert isinstance(slewtime, float)
 
         slew_overhead: float = slewtime * self.rng.normal(self.slew_loc, self.slew_scale)
 
@@ -78,13 +148,18 @@ class AnomalousOverheadFunc:
         if (slewtime + slew_overhead) < 0:
             slew_overhead = 0.0
 
-        visit_overhead: float = visittime * self.rng.normal(self.slew_loc, self.slew_scale)
+        visit_overhead: float = visittime * self.rng.normal(self.visit_loc, self.visit_scale)
         # There might be anomalous overhead that makes visits take longer,
         # but faster is unlikely.
         if visit_overhead < 0:
             visit_overhead = 0.0
 
-        return slew_overhead + visit_overhead
+        scatter: float = self.scatter_dist_func(**self.scatter_kwargs)
+        overhead: float = max(
+            slew_overhead + visit_overhead + scatter, self.min_overhead - slewtime - visittime
+        )
+
+        return overhead
 
 
 def compute_sim_start_and_end(day_obs: int, sim_nights: int, delay: float = 0) -> tuple[float, float]:
@@ -140,6 +215,9 @@ def run_prenight_sim_cli(cli_args: list = []) -> int:
     parser.add_argument("--delay", type=float, default=0.0, help="Minutes after nominal to start.")
     parser.add_argument("--anom_overhead_scale", type=float, default=0.0, help="scale of scatter in the slew")
     parser.add_argument(
+        "--anom_overhead_scatter", type=float, default=0.0, help="absolute scatter in the overhead"
+    )
+    parser.add_argument(
         "--anom_overhead_seed",
         type=int,
         default=1,
@@ -156,6 +234,7 @@ def run_prenight_sim_cli(cli_args: list = []) -> int:
     telescope = args.telescope
     delay = args.delay
     anom_overhead_scale = args.anom_overhead_scale
+    anom_overhead_scatter = args.anom_overhead_scatter
     anom_overhead_seed = args.anom_overhead_seed
     results_dir = args.results if len(args.results) > 0 else None
 
@@ -165,10 +244,15 @@ def run_prenight_sim_cli(cli_args: list = []) -> int:
     with open(args.observatory, "rb") as observatory_io:
         observatory = pickle.load(observatory_io)
 
-    if anom_overhead_scale > 0:
-        anomalous_overhead_func = AnomalousOverheadFunc(anom_overhead_seed, anom_overhead_scale)
-    else:
-        anomalous_overhead_func = None
+    anomalous_overhead_func: Callable | None = None
+    anom_overhead_args = {}
+    if anom_overhead_scale != 0.0:
+        anom_overhead_args["slew_scale"] = anom_overhead_scale
+    if anom_overhead_scatter != 0.0:
+        anom_overhead_args["scatter_kwargs"] = {"scale": anom_overhead_scatter}
+    if len(anom_overhead_args) > 0:
+        anom_overhead_args["seed"] = anom_overhead_seed
+        anomalous_overhead_func = AnomalousOverheadFunc(**anom_overhead_args)
 
     if keep_rewards:
         scheduler.keep_rewards = keep_rewards

--- a/rubin_sim/sim_archive/prenight.py
+++ b/rubin_sim/sim_archive/prenight.py
@@ -30,8 +30,7 @@ class ContinuousDistribution(Protocol):
         self,
         size: int | tuple[int, ...] | None = None,
         random_state: np.random.RandomState | np.random.Generator | int | None = None,
-    ) -> float:
-        ...
+    ) -> float: ...
 
 
 class AnomalousOverheadFunc:

--- a/tests/sim_archive/test_prenight.py
+++ b/tests/sim_archive/test_prenight.py
@@ -10,14 +10,17 @@ from rubin_sim.sim_archive.prenight import AnomalousOverheadFunc
 class TestAnomalousOverheadFunc(unittest.TestCase):
     def test_scatter_overhead_normal_dist(self):
         sample_size = 20
+        exptime = 30.0
         for scale in [1.75, 2]:
             for loc in [0.0, 3.0]:
                 dist_params = {"scale": scale, "loc": loc}
                 cdf = partial(stats.norm.cdf, loc=loc, scale=scale)
                 func = AnomalousOverheadFunc(seed=6563, scatter_kwargs=dist_params)
                 for slewtime in [0.0, 100.0]:
-                    for visittime in [3.0, 30.0]:
-                        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+                    for visittime in [40.0, 50.0]:
+                        overheads = np.array(
+                            list(func(visittime, slewtime, exptime=exptime) for i in range(sample_size))
+                        )
                         _, p_value = stats.kstest(overheads, cdf)
                         # Depending on the random number seed, there's a
                         # 0.1% chance per iteration of failing this test even
@@ -26,6 +29,7 @@ class TestAnomalousOverheadFunc(unittest.TestCase):
 
     def test_scatter_overhead_uniform_dist(self):
         sample_size = 20
+        exptime = 30.0
         for scale in [1.75, 2]:
             for loc in [0.0, 3.0]:
                 low = loc - scale / 2
@@ -36,8 +40,10 @@ class TestAnomalousOverheadFunc(unittest.TestCase):
                     seed=6563, scatter_distribution="uniform", scatter_kwargs=dist_params
                 )
                 for slewtime in [0.0, 100.0]:
-                    for visittime in [3.0, 30.0]:
-                        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+                    for visittime in [60.0, 40.0]:
+                        overheads = np.array(
+                            list(func(visittime, slewtime, exptime) for i in range(sample_size))
+                        )
                         _, p_value = stats.kstest(overheads, cdf)
                         # Depending on the random number seed, there's a
                         # 0.1% chance per iteration of failing this test even
@@ -47,21 +53,23 @@ class TestAnomalousOverheadFunc(unittest.TestCase):
     def test_no_negative_overhead(self):
         sample_size = 20
         slewtime = 2.0
-        visittime = 3.0
+        visittime = 35.0
+        exptime = 30.0
         min_overhead = visittime + slewtime
         func = AnomalousOverheadFunc(
             seed=6563, scatter_kwargs={"scale": 100.0, "loc": 0.0}, min_overhead=min_overhead
         )
-        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
-        assert np.all(overheads + visittime + slewtime >= min_overhead)
+        offsets = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
+        assert np.all(offsets + visittime + slewtime - exptime >= min_overhead)
 
     def test_slew_scale(self):
         sample_size = 20
         slewtime = 20.0
-        visittime = 3.0
+        visittime = 36.0
+        exptime = 30.0
         slew_scale = 0.1
         func = AnomalousOverheadFunc(seed=6563, slew_scale=slew_scale)
-        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+        overheads = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
         fractional_overheads = overheads / slewtime
         cdf = partial(stats.norm.cdf, loc=0.0, scale=slew_scale)
         _, p_value = stats.kstest(fractional_overheads, cdf)
@@ -73,11 +81,12 @@ class TestAnomalousOverheadFunc(unittest.TestCase):
     def test_visit_scale(self):
         sample_size = 20
         slewtime = 20.0
-        visittime = 3.0
+        exptime = 30.0
+        visittime = 35.0
         visit_scale = 0.1
         func = AnomalousOverheadFunc(seed=6563, visit_scale=visit_scale)
-        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
-        fractional_overheads = overheads / visittime
+        overheads = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
+        fractional_overheads = overheads / (visittime - exptime)
 
         assert np.all(fractional_overheads >= 0.0)
 

--- a/tests/sim_archive/test_prenight.py
+++ b/tests/sim_archive/test_prenight.py
@@ -1,0 +1,93 @@
+import unittest
+from functools import partial
+
+import numpy as np
+from scipy import stats
+
+from rubin_sim.sim_archive.prenight import AnomalousOverheadFunc
+
+
+class TestAnomalousOverheadFunc(unittest.TestCase):
+    def test_scatter_overhead_normal_dist(self):
+        sample_size = 20
+        for scale in [1.75, 2]:
+            for loc in [0.0, 3.0]:
+                dist_params = {"scale": scale, "loc": loc}
+                cdf = partial(stats.norm.cdf, loc=loc, scale=scale)
+                func = AnomalousOverheadFunc(seed=6563, scatter_kwargs=dist_params)
+                for slewtime in [0.0, 100.0]:
+                    for visittime in [3.0, 30.0]:
+                        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+                        _, p_value = stats.kstest(overheads, cdf)
+                        # Depending on the random number seed, there's a
+                        # 0.1% chance per iteration of failing this test even
+                        # if everything is okay.
+                        assert p_value > 0.001
+
+    def test_scatter_overhead_uniform_dist(self):
+        sample_size = 20
+        for scale in [1.75, 2]:
+            for loc in [0.0, 3.0]:
+                low = loc - scale / 2
+                high = loc + scale / 2
+                dist_params = {"low": low, "high": high}
+                cdf = partial(stats.uniform.cdf, loc=low, scale=scale)
+                func = AnomalousOverheadFunc(
+                    seed=6563, scatter_distribution="uniform", scatter_kwargs=dist_params
+                )
+                for slewtime in [0.0, 100.0]:
+                    for visittime in [3.0, 30.0]:
+                        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+                        _, p_value = stats.kstest(overheads, cdf)
+                        # Depending on the random number seed, there's a
+                        # 0.1% chance per iteration of failing this test even
+                        # if everything is okay.
+                        assert p_value > 0.001
+
+    def test_no_negative_overhead(self):
+        sample_size = 20
+        slewtime = 2.0
+        visittime = 3.0
+        min_overhead = visittime + slewtime
+        func = AnomalousOverheadFunc(
+            seed=6563, scatter_kwargs={"scale": 100.0, "loc": 0.0}, min_overhead=min_overhead
+        )
+        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+        assert np.all(overheads + visittime + slewtime >= min_overhead)
+
+    def test_slew_scale(self):
+        sample_size = 20
+        slewtime = 20.0
+        visittime = 3.0
+        slew_scale = 0.1
+        func = AnomalousOverheadFunc(seed=6563, slew_scale=slew_scale)
+        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+        fractional_overheads = overheads / slewtime
+        cdf = partial(stats.norm.cdf, loc=0.0, scale=slew_scale)
+        _, p_value = stats.kstest(fractional_overheads, cdf)
+        # Depending on the random number seed, there's a
+        # 0.1% chance per iteration of failing this test even
+        # if everything is okay.
+        assert p_value > 0.001
+
+    def test_visit_scale(self):
+        sample_size = 20
+        slewtime = 20.0
+        visittime = 3.0
+        visit_scale = 0.1
+        func = AnomalousOverheadFunc(seed=6563, visit_scale=visit_scale)
+        overheads = np.array(list(func(visittime, slewtime) for i in range(sample_size)))
+        fractional_overheads = overheads / visittime
+
+        assert np.all(fractional_overheads >= 0.0)
+
+        cdf = partial(stats.halfnorm.cdf, loc=0.0, scale=visit_scale)
+        _, p_value = stats.kstest(fractional_overheads[fractional_overheads > 0], cdf)
+        # Depending on the random number seed, there's a
+        # 0.1% chance per iteration of failing this test even
+        # if everything is okay.
+        assert p_value > 0.001
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sim_archive/test_prenight.py
+++ b/tests/sim_archive/test_prenight.py
@@ -8,90 +8,63 @@ from rubin_sim.sim_archive.prenight import AnomalousOverheadFunc
 
 
 class TestAnomalousOverheadFunc(unittest.TestCase):
-    def test_scatter_overhead_normal_dist(self):
+    def test_scatter_overhead_normal_dist(self) -> None:
         sample_size = 20
-        exptime = 30.0
         for scale in [1.75, 2]:
             for loc in [0.0, 3.0]:
                 dist_params = {"scale": scale, "loc": loc}
                 cdf = partial(stats.norm.cdf, loc=loc, scale=scale)
-                func = AnomalousOverheadFunc(seed=6563, scatter_kwargs=dist_params)
-                for slewtime in [0.0, 100.0]:
-                    for visittime in [40.0, 50.0]:
-                        overheads = np.array(
-                            list(func(visittime, slewtime, exptime=exptime) for i in range(sample_size))
-                        )
-                        _, p_value = stats.kstest(overheads, cdf)
-                        # Depending on the random number seed, there's a
-                        # 0.1% chance per iteration of failing this test even
-                        # if everything is okay.
-                        assert p_value > 0.001
-
-    def test_scatter_overhead_uniform_dist(self):
-        sample_size = 20
-        exptime = 30.0
-        for scale in [1.75, 2]:
-            for loc in [0.0, 3.0]:
-                low = loc - scale / 2
-                high = loc + scale / 2
-                dist_params = {"low": low, "high": high}
-                cdf = partial(stats.uniform.cdf, loc=low, scale=scale)
                 func = AnomalousOverheadFunc(
-                    seed=6563, scatter_distribution="uniform", scatter_kwargs=dist_params
+                    seed=6563, scatter_distribution="normal", scatter_kwargs=dist_params
                 )
                 for slewtime in [0.0, 100.0]:
-                    for visittime in [60.0, 40.0]:
-                        overheads = np.array(
-                            list(func(visittime, slewtime, exptime) for i in range(sample_size))
-                        )
-                        _, p_value = stats.kstest(overheads, cdf)
-                        # Depending on the random number seed, there's a
-                        # 0.1% chance per iteration of failing this test even
-                        # if everything is okay.
-                        assert p_value > 0.001
+                    obs = {"slewtime": slewtime}
+                    overheads = np.array(list(func(obs=obs) for i in range(sample_size)))
+                    _, p_value = stats.kstest(overheads, cdf)
+                    # Depending on the random number seed, there's a
+                    # 0.1% chance per iteration of failing this test even
+                    # if everything is okay.
+                    assert p_value > 0.001
 
-    def test_no_negative_overhead(self):
+    def test_scatter_overhead_halfnormal_dist(self) -> None:
         sample_size = 20
-        slewtime = 2.0
-        visittime = 35.0
-        exptime = 30.0
-        min_overhead = visittime + slewtime
+        for scale in [1.75, 2]:
+            for loc in [0.0, 3.0]:
+                dist_params = {"scale": scale, "loc": loc}
+                cdf = partial(stats.halfnorm.cdf, loc=loc, scale=scale)
+                func = AnomalousOverheadFunc(seed=6563, scatter_kwargs=dist_params)
+                for slewtime in [0.0, 100.0]:
+                    obs = {"slewtime": slewtime}
+                    overheads = np.array(list(func(obs=obs) for i in range(sample_size)))
+                    _, p_value = stats.kstest(overheads, cdf)
+                    # Depending on the random number seed, there's a
+                    # 0.1% chance per iteration of failing this test even
+                    # if everything is okay.
+                    assert p_value > 0.001
+
+    def test_no_negative_overhead(self) -> None:
+        sample_size = 20
+        obs = dict(slewtime=2.0, visittime=35.0, exptime=30.0)
+        min_overhead = 7.0
         func = AnomalousOverheadFunc(
             seed=6563, scatter_kwargs={"scale": 100.0, "loc": 0.0}, min_overhead=min_overhead
         )
-        offsets = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
-        assert np.all(offsets + visittime + slewtime - exptime >= min_overhead)
+        offsets = np.array(list(func(obs=obs) for i in range(sample_size)))
+        assert np.all(offsets + obs["visittime"] + obs["slewtime"] - obs["exptime"] >= min_overhead)
 
-    def test_slew_scale(self):
+    def test_slew_scale(self) -> None:
         sample_size = 20
-        slewtime = 20.0
-        visittime = 36.0
-        exptime = 30.0
+        obs = dict(
+            slewtime=20.0,
+            visittime=36.0,
+            exptime=30.0,
+        )
         slew_scale = 0.1
         func = AnomalousOverheadFunc(seed=6563, slew_scale=slew_scale)
-        overheads = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
-        fractional_overheads = overheads / slewtime
+        overheads = np.array(list(func(obs=obs) for i in range(sample_size)))
+        fractional_overheads = overheads / obs["slewtime"]
         cdf = partial(stats.norm.cdf, loc=0.0, scale=slew_scale)
         _, p_value = stats.kstest(fractional_overheads, cdf)
-        # Depending on the random number seed, there's a
-        # 0.1% chance per iteration of failing this test even
-        # if everything is okay.
-        assert p_value > 0.001
-
-    def test_visit_scale(self):
-        sample_size = 20
-        slewtime = 20.0
-        exptime = 30.0
-        visittime = 35.0
-        visit_scale = 0.1
-        func = AnomalousOverheadFunc(seed=6563, visit_scale=visit_scale)
-        overheads = np.array(list(func(visittime, slewtime, exptime) for i in range(sample_size)))
-        fractional_overheads = overheads / (visittime - exptime)
-
-        assert np.all(fractional_overheads >= 0.0)
-
-        cdf = partial(stats.halfnorm.cdf, loc=0.0, scale=visit_scale)
-        _, p_value = stats.kstest(fractional_overheads[fractional_overheads > 0], cdf)
         # Depending on the random number seed, there's a
         # 0.1% chance per iteration of failing this test even
         # if everything is okay.


### PR DESCRIPTION
The previous version just supported randomized changes to the scale, not a randomized offset. That is, the offset in the overhead was always proportional to the original overhead, while what we need currently is a random offset independent of the original overhead. This change adds support for the later, following any distribution supported directly by numpy's random number generator (although right now "normal" is all we need).