### PR TITLE
tickets/SP-3039: Move some functionality from schedview notebooks into rubin_sim where it can be reused

### DIFF
--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -154,7 +154,9 @@ def get_prenight_index(
     Parameters
     ----------
     day_obs : `str` or `int` or `date`
-        Night for which to fetch the index.
+        Night for which to fetch the index. The function
+        will return all simulations that simulate
+        the night designated by the day_obs.
     telescope : `str`
         Telescope name (default ``simonyi``).
     schema : `str` or `None`, optional
@@ -257,7 +259,8 @@ def _get_sim_uuid_from_metadata_index(
         The observation night for which to search for the simulation. Can be a
         date string, YYYYMMDD encoded into an integer, or a
         `datetime.date` object. The date rollover follows SITCOMTN-032
-        (-12hr timezone).
+        (-12hr timezone). This can be any night included in the
+        simulation.
     sim_date : `date`
         The creation date of the simulation to find.
     daily_id : `int` or `str`
@@ -319,7 +322,8 @@ def get_sim_metadata(
         The observation night for which to search for the simulation. Can be a
         date string, YYYYMMDD encoded into an integer, or a
         :class:`datetime.date` object. The date rollover follows SITCOMTN-032
-        (-12hr timezone).
+        (-12hr timezone). This can be any night included in the
+        simulation.
     **kwargs
         Additional keyword arguments passed to :func:`get_prenight_index`.
 

--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -217,6 +217,10 @@ def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str,
     ValueError
         If no simulation is found matching the specified criteria.
     """
+    # Accept ISO style string for day_obs
+    if isinstance(day_obs, str):
+        day_obs = day_obs.replace("-", "")
+
     day_obs = int(
         f"{day_obs.year:04d}{day_obs.month:02d}{day_obs.day:02d}" if isinstance(day_obs, date) else day_obs
     )

--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -290,11 +290,12 @@ def get_sim_index_info(day_obs: int | date | str, visitseq_uuid: UUID | str, **k
     maybe_sim_index_info: None | pd.Series | pd.DataFrame = None
     for telescope in TELESCOPES:
         prenight_index = get_prenight_index(day_obs, telescope, **kwargs)
-        if not isinstance(prenight_index.index[0], str):
+        if len(prenight_index) > 0 and not isinstance(prenight_index.index[0], str):
             prenight_index.index = prenight_index.index.map(str)
         if visitseq_uuid_str in prenight_index.index:
             maybe_sim_index_info = prenight_index.loc[visitseq_uuid_str, :]
             maybe_sim_index_info[prenight_index.index.name] = visitseq_uuid
+            break
 
     if isinstance(maybe_sim_index_info, pd.DataFrame):
         raise ValueError(

--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -1,9 +1,12 @@
-__all__ = ["get_prenight_index", "select_latest_prenight_sim"]
+__all__ = ["get_prenight_index", "select_latest_prenight_sim", "get_sim_uuid", "get_sim_index_info"]
 
 import logging
 import os
 from datetime import date
+from typing import Any
+from uuid import UUID
 
+import numpy as np
 import pandas as pd
 from lsst.resources import ResourcePath
 
@@ -18,6 +21,7 @@ from .util import dayobs_to_date
 
 MAX_AGE = 365
 LOGGER = logging.getLogger(__name__)
+TELESCOPES = ("simonyi", "auxtel")
 
 
 def get_prenight_index_from_database(
@@ -183,6 +187,69 @@ def get_prenight_index(
             prenights = pd.DataFrame()
 
     return prenights
+
+
+def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str, **kwargs: Any) -> UUID:
+
+    day_obs = int(
+        f"{day_obs.year:04d}{day_obs.month:02d}{day_obs.day:02d}" if isinstance(day_obs, date) else day_obs
+    )
+    assert isinstance(day_obs, int)
+
+    maybe_uuid: UUID | None = None
+
+    for telescope in TELESCOPES:
+        prenight_index = get_prenight_index(day_obs, telescope, **kwargs)
+        matching_sims = (prenight_index.sim_creation_day_obs == sim_date) & (
+            prenight_index.daily_id == int(daily_id)
+        )
+        if np.any(matching_sims):
+            matching_uuids = prenight_index.index[matching_sims].values
+            assert matching_uuids.shape == (1,)
+            maybe_uuid = UUID(str(matching_uuids.item()))
+
+    if maybe_uuid is None:
+        raise ValueError(f"No simulation found for {sim_date}, {daily_id}")
+
+    assert isinstance(maybe_uuid, UUID)
+    return maybe_uuid
+
+
+def get_sim_index_info(day_obs: int | date | str, visitseq_uuid: UUID | str, **kwargs: Any) -> pd.Series:
+    day_obs = int(
+        f"{day_obs.year:04d}{day_obs.month:02d}{day_obs.day:02d}" if isinstance(day_obs, date) else day_obs
+    )
+
+    visitseq_uuid_str: str | None = None
+    if isinstance(visitseq_uuid, str):
+        assert isinstance(visitseq_uuid, str)
+        visitseq_uuid_str = visitseq_uuid
+        visitseq_uuid = UUID(visitseq_uuid)
+    else:
+        visitseq_uuid_str = str(visitseq_uuid)
+
+    assert isinstance(visitseq_uuid_str, str)
+    assert isinstance(visitseq_uuid, UUID)
+
+    maybe_sim_index_info: None | pd.Series | pd.DataFrame = None
+    for telescope in TELESCOPES:
+        prenight_index = get_prenight_index(day_obs, telescope, **kwargs)
+        if not isinstance(prenight_index.index[0], str):
+            prenight_index.index = prenight_index.index.map(str)
+        if visitseq_uuid_str in prenight_index.index:
+            maybe_sim_index_info = prenight_index.loc[visitseq_uuid_str, :]
+            maybe_sim_index_info[prenight_index.index.name] = visitseq_uuid
+
+    if isinstance(maybe_sim_index_info, pd.DataFrame):
+        raise ValueError(
+            f"Multiple sims for UUID {visitseq_uuid}: there is a problem in the sim metadata database!"
+        )
+
+    if maybe_sim_index_info is None:
+        raise ValueError(f"No sim with UUID {visitseq_uuid} found")
+
+    assert isinstance(maybe_sim_index_info, pd.Series)
+    return maybe_sim_index_info
 
 
 def select_latest_prenight_sim(

--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -190,7 +190,33 @@ def get_prenight_index(
 
 
 def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str, **kwargs: Any) -> UUID:
+    """Get the UUID of a simulation given its observation night, creation date,
+    and daily ID.
 
+    Parameters
+    ----------
+    day_obs : `int` or `str` or `date`
+        The observation night for which to search for the simulation. Can be a
+        date string, YYYYMMDD encoded into an integer, or a
+        `datetime.date` object. The date rollover follows SITCOMTN-032
+        (-12hr timezone).
+    sim_date : `date`
+        The creation date of the simulation to find.
+    daily_id : `int` or `str`
+        The daily ID of the simulation to find.
+    **kwargs
+        Additional keyword arguments passed to :func:`get_prenight_index`.
+
+    Returns
+    -------
+    uuid : `uuid.UUID`
+        The UUID of the matching simulation.
+
+    Raises
+    ------
+    ValueError
+        If no simulation is found matching the specified criteria.
+    """
     day_obs = int(
         f"{day_obs.year:04d}{day_obs.month:02d}{day_obs.day:02d}" if isinstance(day_obs, date) else day_obs
     )
@@ -216,6 +242,32 @@ def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str,
 
 
 def get_sim_index_info(day_obs: int | date | str, visitseq_uuid: UUID | str, **kwargs: Any) -> pd.Series:
+    """Get metadata for a simulation given its observation night and UUID.
+
+    Parameters
+    ----------
+    day_obs : `int` or `str` or `date`
+        The observation night for which to search for the simulation. Can be a
+        date string, YYYYMMDD encoded into an integer, or a
+        :class:`datetime.date` object. The date rollover follows SITCOMTN-032
+        (-12hr timezone).
+    visitseq_uuid : `uuid.UUID` or `str`
+        The UUID of the simulation to retrieve information for.
+    **kwargs
+        Additional keyword arguments passed to :func:`get_prenight_index`.
+
+    Returns
+    -------
+    info : `pandas.Series`
+        A Series containing the index information for the simulation.
+
+    Raises
+    ------
+    ValueError
+        If no simulation with the given UUID is found, or if multiple
+        simulations are found with the same UUID (indicating a problem in the
+        metadata database).
+    """
     day_obs = int(
         f"{day_obs.year:04d}{day_obs.month:02d}{day_obs.day:02d}" if isinstance(day_obs, date) else day_obs
     )

--- a/rubin_sim/sim_archive/prenightindex.py
+++ b/rubin_sim/sim_archive/prenightindex.py
@@ -1,4 +1,4 @@
-__all__ = ["get_prenight_index", "select_latest_prenight_sim", "get_sim_uuid", "get_sim_index_info"]
+__all__ = ["get_prenight_index", "select_latest_prenight_sim", "get_sim_uuid", "get_sim_metadata"]
 
 import logging
 import os
@@ -189,7 +189,65 @@ def get_prenight_index(
     return prenights
 
 
-def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str, **kwargs: Any) -> UUID:
+def get_sim_uuid(
+    sim_date: date,
+    daily_id: int | str,
+    day_obs: int | date | str | None = None,
+    vsmd: VisitSequenceArchiveMetadata | None = None,
+    **kwargs: Any,
+) -> UUID:
+    """Get the UUID of a simulation given its observation night, creation date,
+    and daily ID.
+
+    Parameters
+    ----------
+    sim_date : `date`
+        The creation date of the simulation to find.
+    daily_id : `int` or `str`
+        The daily ID of the simulation to find. The daily ID is an
+        index of simulations in the metadata added at a given sim_date:
+        A simulation with ``sim_date`` of 2026-04-28 and ``daily_id`` of 4
+        is the 4th simulation added to the metadata database with a creation
+        date of 2026-04-28. The combination ``sim_date`` and ``daily_id``
+        uniquely identifies a simulation in a given metadata database, but
+        unlike UUID is not guaranteed to be unique across different
+        metadata databases.
+    day_obs : `int` or `str` or `date` or `None`
+        The dayobs of a night simulated by the simulation. Can be a
+        date string, YYYYMMDD encoded into an integer, or a
+        `datetime.date` object. The date rollover follows SITCOMTN-032
+        (-12hr timezone). If ``None``, the metadata database must
+        be used.
+    vsmd : `VisitSequenceArchiveMetadata` or `None`
+        The interface to the visit sequence metadata database to query.
+    **kwargs
+        Additional keyword arguments passed to :func:`get_prenight_index`.
+
+    Returns
+    -------
+    uuid : `uuid.UUID`
+        The UUID of the matching simulation.
+
+    Raises
+    ------
+    ValueError
+        If no simulation is found matching the specified criteria.
+    """
+    if day_obs is None or vsmd is not None:
+        if vsmd is None:
+            # If an instance of VisitSequenceArchiveMetada is not
+            # provided, make one with default configuration.
+            vsmd = VisitSequenceArchiveMetadata()
+        sim_uuid = vsmd.get_sim_uuid(sim_date, daily_id)
+    else:
+        sim_uuid = _get_sim_uuid_from_metadata_index(day_obs, sim_date, daily_id, **kwargs)
+
+    return sim_uuid
+
+
+def _get_sim_uuid_from_metadata_index(
+    day_obs: int | date | str, sim_date: date, daily_id: int | str, **kwargs: Any
+) -> UUID:
     """Get the UUID of a simulation given its observation night, creation date,
     and daily ID.
 
@@ -245,7 +303,54 @@ def get_sim_uuid(day_obs: int | date | str, sim_date: date, daily_id: int | str,
     return maybe_uuid
 
 
-def get_sim_index_info(day_obs: int | date | str, visitseq_uuid: UUID | str, **kwargs: Any) -> pd.Series:
+def get_sim_metadata(
+    visitseq_uuid: UUID | str,
+    day_obs: int | date | str | None = None,
+    vsmd: VisitSequenceArchiveMetadata | None = None,
+    **kwargs: Any,
+) -> pd.Series:
+    """Get metadata for a simulation given its observation night and UUID.
+
+    Parameters
+    ----------
+    visitseq_uuid : `uuid.UUID` or `str`
+        The UUID of the simulation to retrieve information for.
+    day_obs : `int` or `str` or `date` or `None`
+        The observation night for which to search for the simulation. Can be a
+        date string, YYYYMMDD encoded into an integer, or a
+        :class:`datetime.date` object. The date rollover follows SITCOMTN-032
+        (-12hr timezone).
+    **kwargs
+        Additional keyword arguments passed to :func:`get_prenight_index`.
+
+    Returns
+    -------
+    info : `pandas.Series`
+        A Series containing the index information for the simulation.
+
+    Raises
+    ------
+    ValueError
+        If no simulation with the given UUID is found, or if multiple
+        simulations are found with the same UUID (indicating a problem in the
+        metadata database).
+    """
+    sim_metadata: pd.Series
+    if day_obs is None:
+        if vsmd is None:
+            # If an instance of VisitSequenceArchiveMetada is not
+            # provided, make one with default configuration.
+            vsmd = VisitSequenceArchiveMetadata()
+        sim_metadata = vsmd.get_visitseq_metadata(visitseq_uuid, "simulations_extra")
+    else:
+        sim_metadata = _get_sim_metadata_from_metadata_index(day_obs, visitseq_uuid, **kwargs)
+
+    return sim_metadata
+
+
+def _get_sim_metadata_from_metadata_index(
+    day_obs: int | date | str, visitseq_uuid: UUID | str, **kwargs: Any
+) -> pd.Series:
     """Get metadata for a simulation given its observation night and UUID.
 
     Parameters

--- a/rubin_sim/sim_archive/vseqmetadata.py
+++ b/rubin_sim/sim_archive/vseqmetadata.py
@@ -1745,3 +1745,44 @@ class VisitSequenceArchiveMetadata:
             sw_versions = sw_versions.loc[present_packages, :]
 
         return sw_versions
+
+    def get_sim_uuid(self, sim_date: str | date | int, daily_id: int | str) -> UUID:
+        """Retrieve metadata for a visit sequence.
+
+        Parameters
+        ----------
+        sim_date : `date` on `str` or `int`
+            The creation date of the simulation to find, as a dayobs
+            (utc-12 hour timezone)
+        daily_id : `int` or `str`
+            The daily ID of the simulation to find. The daily ID is an
+            index of simulations in the metadata added at a given sim_date:
+            A simulation with ``sim_date`` of 2026-04-28 and ``daily_id`` of 4
+            is the 4th simulation added to the metadata database with a
+            creation date of 2026-04-28. The combination ``sim_date``
+            and ``daily_id`` uniquely identifies a simulation in a
+            given metadata database, but unlike UUID is not guaranteed
+            to be unique across different metadata databases.
+
+        Returns
+        -------
+        uuid : `UUID`
+            The UUID corresponding to the sim_date/daily_id combination.
+        """
+        sim_date = dayobs_to_date(sim_date)
+        daily_id = int(daily_id)
+        # offset by 12 hours to get into dayobs tz
+        query_template = """
+            SELECT visitseq_uuid
+            FROM {}.simulations_extra
+            WHERE %s=DATE(creation_time - INTERVAL '12 hours')
+                  AND %s=daily_id
+        """
+        sql_params: list[sql.Composable] = [sql.Identifier(self.metadata_db_schema)]
+        query_params = (sim_date, daily_id)
+        visitseq = self.pd_read_sql(query_template, sql_params, query_params)
+        if len(visitseq) == 0:
+            raise ValueError(f"No simulation {daily_id} from {sim_date} found.")
+        assert not (len(visitseq) > 1), "len(visitseq)>1 should not be possible given the database schema."
+        visitseq_uuid = visitseq["visitseq_uuid"].item()
+        return visitseq_uuid

--- a/rubin_sim/sim_archive/vseqmetadata.py
+++ b/rubin_sim/sim_archive/vseqmetadata.py
@@ -15,7 +15,7 @@ import warnings
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, Sequence, Tuple
 from uuid import UUID
 
 import numpy as np
@@ -1730,3 +1730,18 @@ class VisitSequenceArchiveMetadata:
 
         metadata_yaml = yaml.dump(metadata)
         return metadata_yaml
+
+    def get_software_versions_for_sim(
+        self, visitseq_uuid: UUID, packages: Sequence[str] | None = None
+    ) -> pd.DataFrame:
+
+        query_template = "SELECT * FROM {}.simulation_packages WHERE visitseq_uuid=%s"
+        sql_params: list[sql.Composable] = [sql.Identifier(self.metadata_db_schema)]
+        query_params = (visitseq_uuid,)
+        sw_versions = self.pd_read_sql(query_template, sql_params, query_params).set_index("package_name")
+
+        if packages is not None:
+            present_packages = [p for p in packages if p in sw_versions.index]
+            sw_versions = sw_versions.loc[present_packages, :]
+
+        return sw_versions

--- a/tests/sim_archive/test_prenightindex.py
+++ b/tests/sim_archive/test_prenightindex.py
@@ -12,6 +12,7 @@ from lsst.resources import ResourcePath
 
 from rubin_sim.sim_archive import vseqarchive, vseqmetadata
 from rubin_sim.sim_archive.prenightindex import (
+    get_prenight_index_from_bucket,
     get_prenight_index_from_database,
     get_sim_index_info,
     get_sim_uuid,
@@ -197,3 +198,103 @@ class TestPrenightIndex(unittest.TestCase):
         # Test that it raises ValueError for non-existent UUID
         with self.assertRaises(ValueError):
             get_sim_index_info(20261201, UUID("12345678-1234-1234-1234-123456789012"))
+
+    def test_get_prenight_index_from_bucket(self) -> None:
+        # Test the get_prenight_index_from_bucket function
+        # Create a temporary directory to simulate a bucket
+        with TemporaryDirectory() as temp_dir:
+            # Create a mock prenight index JSON file similar to the sample data
+            mock_index_data = {
+                "6c242afb-edd1-4cea-9f8c-80e0a18b4b75": {
+                    "sim_creation_day_obs": "2026-04-11",
+                    "daily_id": 2,
+                    "visitseq_label": "Nominal start and overhead, ideal conditions",
+                    "telescope": "simonyi",
+                    "first_day_obs": "2026-04-11",
+                    "last_day_obs": "2026-04-13",
+                    "creation_time": "2026-04-11T14:13:55.024Z",
+                    "scheduler_version": "3.21.1",
+                    "sim_runner_kwargs": None,
+                    "conda_env_sha256": "48bcf84e41a741ee67fe644b1ed8d5858d81a7ecfe012473fe2e2f0f3fc05095",
+                    "parent_visitseq_uuid": "94fd43ff-5034-43cd-ac48-6461cdca7979",
+                    "parent_last_day_obs": "2026-04-10",
+                    "tags": ["ideal", "nominal", "prenight"],
+                    "comments": {},
+                    "files": {},
+                },
+                "b9405aaf-dfe8-4508-ad90-cb37527dbc27": {
+                    "sim_creation_day_obs": "2026-04-11",
+                    "daily_id": 3,
+                    "visitseq_label": "Nominal start and overhead, ideal conditions 2",
+                    "telescope": "simonyi",
+                    "first_day_obs": "2026-04-11",
+                    "last_day_obs": "2026-04-13",
+                    "creation_time": "2026-04-11T14:21:27.332Z",
+                    "scheduler_version": "3.21.1",
+                    "sim_runner_kwargs": None,
+                    "conda_env_sha256": "48bcf84e41a741ee67fe644b1ed8d5858d81a7ecfe012473fe2e2f0f3fc05095",
+                    "parent_visitseq_uuid": "94fd43ff-5034-43cd-ac48-6461cdca7979",
+                    "parent_last_day_obs": "2026-04-10",
+                    "tags": ["ideal", "nominal", "prenight", "rewards"],
+                    "comments": {},
+                    "files": {},
+                },
+            }
+
+            # Create a mock bucket structure
+            prenight_index_path = ResourcePath(temp_dir)
+            year = "2026"
+            month = "4"
+            telescope = "simonyi"
+            isodate = "2026-04-11"
+
+            # Create the directory structure
+            mock_bucket_path = (
+                prenight_index_path.join(telescope)
+                .join(year)
+                .join(month)
+                .join(f"{telescope}_prenights_for_{isodate}.json")
+            )
+
+            # Create the directory structure manually
+            import os
+
+            os.makedirs(os.path.dirname(mock_bucket_path.ospath), exist_ok=True)
+
+            # Write the mock data to a JSON file
+            import json
+
+            with open(mock_bucket_path.ospath, "w") as f:
+                json.dump(mock_index_data, f)
+
+            # Test the function
+            result = get_prenight_index_from_bucket(
+                "2026-04-11", telescope="simonyi", prenight_index_path=temp_dir
+            )
+
+            # Should return a DataFrame
+            self.assertIsInstance(result, pd.DataFrame)
+
+            # Should have the expected number of rows (2 from our mock data)
+            self.assertEqual(len(result), 2)
+
+            # Should have the expected UUIDs in the index
+            expected_uuids = ["6c242afb-edd1-4cea-9f8c-80e0a18b4b75", "b9405aaf-dfe8-4508-ad90-cb37527dbc27"]
+            for uuid in expected_uuids:
+                self.assertIn(uuid, result.index)
+
+            # Check that the first row has expected data
+            first_row = result.loc["6c242afb-edd1-4cea-9f8c-80e0a18b4b75"]
+            self.assertEqual(first_row["sim_creation_day_obs"], "2026-04-11")
+            self.assertEqual(first_row["daily_id"], 2)
+            self.assertIn("ideal", first_row["tags"])
+            self.assertIn("nominal", first_row["tags"])
+            self.assertIn("prenight", first_row["tags"])
+
+            # Check that the second row has expected data
+            second_row = result.loc["b9405aaf-dfe8-4508-ad90-cb37527dbc27"]
+            self.assertEqual(second_row["sim_creation_day_obs"], "2026-04-11")
+            self.assertEqual(second_row["daily_id"], 3)
+            self.assertIn("ideal", second_row["tags"])
+            self.assertIn("nominal", second_row["tags"])
+            self.assertIn("prenight", second_row["tags"])

--- a/tests/sim_archive/test_prenightindex.py
+++ b/tests/sim_archive/test_prenightindex.py
@@ -1,0 +1,199 @@
+import os
+import unittest
+from datetime import date
+from io import StringIO
+from tempfile import TemporaryDirectory
+from typing import ClassVar
+from uuid import UUID
+
+import pandas as pd
+import testing.postgresql
+from lsst.resources import ResourcePath
+
+from rubin_sim.sim_archive import vseqarchive, vseqmetadata
+from rubin_sim.sim_archive.prenightindex import (
+    get_prenight_index_from_database,
+    get_sim_index_info,
+    get_sim_uuid,
+)
+from rubin_sim.sim_archive.tempdb import LocalOnlyPostgresql
+
+TEST_VISITS = pd.read_csv(
+    StringIO("""
+observationStartMJD fieldRA   fieldDec   band rotSkyPos  visitExposureTime night target_name
+61376.271368        51.536172 -12.851173 r    122.606347 29.2              1     target1
+61376.271816        52.370715 -9.768649  r    124.357953 29.2              1     target2
+61377.272265        55.094497 -9.088026  r    130.639271 29.2              1     target3
+61377.272712        54.314320 -12.171543 r    130.159006 29.2              1     target4
+61377.273163        57.080518 -11.470472 r    136.801494 29.2              1     target5
+"""),
+    sep=r"\s+",
+)
+
+TEST_METADATA_DB_SCHEMA = "test"
+
+
+class TestPrenightIndex(unittest.TestCase):
+    temp_dir: ClassVar[TemporaryDirectory]
+    test_archive_url: ClassVar[str]
+    test_archive: ClassVar[ResourcePath]
+    test_database: ClassVar[LocalOnlyPostgresql]
+    metadata_db_kwargs: ClassVar[dict]
+    vsarch: ClassVar[vseqmetadata.VisitSequenceArchiveMetadata]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            testing.postgresql.find_program("postgres", ["bin"])
+        except RuntimeError:
+            raise unittest.SkipTest("PostgreSQL not found, skipping visit sequence archive tests")
+
+        cls.temp_dir = TemporaryDirectory()
+        cls.test_archive_url = "file://" + cls.temp_dir.name + "/archive/"
+        cls.test_archive = ResourcePath(cls.test_archive_url)
+
+        cls.test_database = LocalOnlyPostgresql(base_dir=cls.temp_dir.name)
+
+        cls.vsarch = vseqmetadata.VisitSequenceArchiveMetadata(
+            metadata_db_kwargs=cls.test_database.psycopg2_dsn(),
+            metadata_db_schema=TEST_METADATA_DB_SCHEMA,
+        )
+        cls.vsarch.create_schema_in_database()
+
+        # Update module-level variables in vseqmetadata to point to
+        # the test database.
+        vseqmetadata.VSARCHIVE_PGDATABASE = cls.test_database.psycopg2_dsn()["database"]
+        vseqmetadata.VSARCHIVE_PGHOST = cls.test_database.psycopg2_dsn()["host"]
+        vseqmetadata.VSARCHIVE_PGUSER = cls.test_database.psycopg2_dsn()["user"]
+        vseqmetadata.VSARCHIVE_PGPORT = cls.test_database.psycopg2_dsn()["port"]
+        vseqmetadata.VSARCHIVE_PGSCHEMA = TEST_METADATA_DB_SCHEMA
+
+        # Create a simple simulation using TEST_VISITS data
+        cls.sim_uuid = cls.vsarch.record_simulation_metadata(
+            TEST_VISITS,
+            "Test simonyi simulation",
+            first_day_obs="2026-12-01",
+            last_day_obs="2026-12-02",
+            telescope="simonyi",
+        )
+        # Store the sim creation date for our test
+        cls.sim_creation_date = date(2026, 12, 1)
+        cls.vsarch.tag(cls.sim_uuid, "prenight", "nominal", "ideal")
+
+        # Add visits to the simulation
+        with TemporaryDirectory() as temp_dir:
+            visits_file = os.path.join(temp_dir, "visits.h5")
+            TEST_VISITS.to_hdf(visits_file, key="observations")
+            vseqarchive.add_file(cls.vsarch, cls.sim_uuid, visits_file, "visits", cls.test_archive)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            if cls.test_database is not None:
+                cls.test_database.stop()
+        finally:
+            cls.temp_dir.cleanup()
+
+    def setUp(self) -> None:
+        self.start_environ: dict = {}
+        self.start_environ.update(os.environ)
+        os.environ["LSST_DISABLE_BUCKET_VALIDATION"] = "1"
+
+    def tearDown(self) -> None:
+        for key in os.environ:
+            if key not in self.start_environ:
+                del os.environ[key]
+            else:
+                if os.environ[key] != self.start_environ[key]:
+                    os.environ[key] = self.start_environ[key]
+
+    def test_get_prenight_index_from_database(self) -> None:
+        # Test the get_prenight_index_from_database function
+        result = get_prenight_index_from_database("2026-12-01", telescope="simonyi")
+
+        # Should return a DataFrame
+        self.assertIsInstance(result, pd.DataFrame)
+
+        # Should contain the simulation we created
+        self.assertIn(self.sim_uuid, result.index)
+
+        # Should have one row for our simulation
+        self.assertEqual(len(result), 1)
+
+        # Check that the simulation has the expected tags
+        sim_row = result.loc[self.sim_uuid]
+        self.assertIn("prenight", sim_row["tags"])
+        self.assertIn("nominal", sim_row["tags"])
+        self.assertIn("ideal", sim_row["tags"])
+
+    def test_get_prenight_index_from_database_with_different_telescope(self) -> None:
+        # Test with auxtel telescope (should return empty DataFrame since
+        # we only created simonyi sim)
+        result = get_prenight_index_from_database("2026-12-01", telescope="auxtel")
+
+        # Should return an empty DataFrame
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(len(result), 0)
+
+    def test_get_prenight_index_from_database_with_integer_dayobs(self) -> None:
+        # Test with integer day_obs
+        result = get_prenight_index_from_database(20261201, telescope="simonyi")
+
+        # Should return a DataFrame
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertIn(self.sim_uuid, result.index)
+        self.assertEqual(len(result), 1)
+
+    def test_get_sim_uuid(self) -> None:
+        # Test the get_sim_uuid function
+        # We should be able to find our test simulation
+        # Using today's date as requested
+        today = date.today()
+        result = get_sim_uuid(20261201, today, 1)
+
+        # Should return a UUID
+        self.assertIsInstance(result, UUID)
+
+        # Should match the UUID we created
+        self.assertEqual(result, self.sim_uuid)
+
+        # Test with date object for day_obs
+        result2 = get_sim_uuid(date(2026, 12, 1), today, 1)
+        self.assertEqual(result2, self.sim_uuid)
+
+        # Test with str for day_obs
+        result3 = get_sim_uuid("20261201", today, 1)
+        self.assertEqual(result3, self.sim_uuid)
+
+        # Test with iso str for day_obs
+        result4 = get_sim_uuid("2026-12-01", today, 1)
+        self.assertEqual(result4, self.sim_uuid)
+
+        # Test that it raises ValueError for non-existent simulation
+        # (wrong date)
+        with self.assertRaises(ValueError):
+            get_sim_uuid(20261201, date(2022, 12, 2), 1)
+
+        # Test that it raises ValueError for non-existent daily_id
+        with self.assertRaises(ValueError):
+            get_sim_uuid(20261201, today, 2)
+
+    def test_get_sim_index_info(self) -> None:
+        # Test the get_sim_index_info function
+        # Get the index information for our test simulation
+        result = get_sim_index_info(20261201, self.sim_uuid)
+
+        # Should return a pandas Series
+        self.assertIsInstance(result, pd.Series)
+
+        # Should contain the expected UUID
+        self.assertEqual(str(result.name), str(self.sim_uuid))
+
+        # Should have the expected tags
+        self.assertIn("prenight", result["tags"])
+        self.assertIn("nominal", result["tags"])
+        self.assertIn("ideal", result["tags"])
+
+        # Test that it raises ValueError for non-existent UUID
+        with self.assertRaises(ValueError):
+            get_sim_index_info(20261201, UUID("12345678-1234-1234-1234-123456789012"))

--- a/tests/sim_archive/test_prenightindex.py
+++ b/tests/sim_archive/test_prenightindex.py
@@ -16,7 +16,7 @@ from rubin_sim.sim_archive.prenightindex import (
     get_prenight_index,
     get_prenight_index_from_bucket,
     get_prenight_index_from_database,
-    get_sim_index_info,
+    get_sim_metadata,
     get_sim_uuid,
 )
 from rubin_sim.sim_archive.tempdb import LocalOnlyPostgresql
@@ -152,7 +152,7 @@ class TestPrenightIndex(unittest.TestCase):
         # We should be able to find our test simulation
         # Using today's date as requested
         today = date.today()
-        result = get_sim_uuid(20261201, today, 1)
+        result = get_sim_uuid(today, 1, 20261201)
 
         # Should return a UUID
         self.assertIsInstance(result, UUID)
@@ -161,36 +161,40 @@ class TestPrenightIndex(unittest.TestCase):
         self.assertEqual(result, self.sim_uuid)
 
         # Test with date object for day_obs
-        result2 = get_sim_uuid(date(2026, 12, 1), today, 1)
+        result2 = get_sim_uuid(
+            today,
+            1,
+            date(2026, 12, 1),
+        )
         self.assertEqual(result2, self.sim_uuid)
 
         # Test with str for day_obs
-        result3 = get_sim_uuid("20261201", today, 1)
+        result3 = get_sim_uuid(today, 1, "20261201")
         self.assertEqual(result3, self.sim_uuid)
 
         # Test with iso str for day_obs
-        result4 = get_sim_uuid("2026-12-01", today, 1)
+        result4 = get_sim_uuid(today, 1, "2026-12-01")
         self.assertEqual(result4, self.sim_uuid)
 
         # Test that it raises ValueError for non-existent simulation
         # (wrong date)
         with self.assertRaises(ValueError):
-            get_sim_uuid(20261201, date(2022, 12, 2), 1)
+            get_sim_uuid(date(2022, 12, 2), 1, 20261201)
 
         # Test that it raises ValueError for non-existent daily_id
         with self.assertRaises(ValueError):
-            get_sim_uuid(20261201, today, 2)
+            get_sim_uuid(today, 2, 20261201)
 
-    def test_get_sim_index_info(self) -> None:
+    def test_get_sim_metadata(self) -> None:
         # Test the get_sim_index_info function
         # Get the index information for our test simulation
-        result = get_sim_index_info(20261201, self.sim_uuid)
+        result = get_sim_metadata(self.sim_uuid, 20261201)
 
         # Should return a pandas Series
         self.assertIsInstance(result, pd.Series)
 
         # Should contain the expected UUID
-        self.assertEqual(str(result.name), str(self.sim_uuid))
+        self.assertEqual(str(self.sim_uuid), str(result.name))
 
         # Should have the expected tags
         self.assertIn("prenight", result["tags"])
@@ -199,7 +203,7 @@ class TestPrenightIndex(unittest.TestCase):
 
         # Test that it raises ValueError for non-existent UUID
         with self.assertRaises(ValueError):
-            get_sim_index_info(20261201, UUID("12345678-1234-1234-1234-123456789012"))
+            get_sim_metadata(UUID("12345678-1234-1234-1234-123456789012"), 20261201)
 
     def test_get_prenight_index_from_bucket(self) -> None:
         # Test the get_prenight_index_from_bucket function

--- a/tests/sim_archive/test_prenightindex.py
+++ b/tests/sim_archive/test_prenightindex.py
@@ -4,6 +4,7 @@ from datetime import date
 from io import StringIO
 from tempfile import TemporaryDirectory
 from typing import ClassVar
+from unittest.mock import patch
 from uuid import UUID
 
 import pandas as pd
@@ -12,6 +13,7 @@ from lsst.resources import ResourcePath
 
 from rubin_sim.sim_archive import vseqarchive, vseqmetadata
 from rubin_sim.sim_archive.prenightindex import (
+    get_prenight_index,
     get_prenight_index_from_bucket,
     get_prenight_index_from_database,
     get_sim_index_info,
@@ -298,3 +300,82 @@ class TestPrenightIndex(unittest.TestCase):
             self.assertIn("ideal", second_row["tags"])
             self.assertIn("nominal", second_row["tags"])
             self.assertIn("prenight", second_row["tags"])
+
+    def test_get_prenight_index(self) -> None:
+        # Test the get_prenight_index function
+        # Mock the database function to return a DataFrame
+        sample_uuid = "6c242afb-edd1-4cea-9f8c-80e0a18b4b75"
+        mock_result = pd.DataFrame(
+            {
+                "sim_creation_day_obs": ["2026-04-11"],
+                "daily_id": [1],
+                "visitseq_label": ["Test simulation"],
+                "telescope": ["simonyi"],
+                "first_day_obs": ["2026-04-11"],
+                "last_day_obs": ["2026-04-13"],
+                "creation_time": ["2026-04-11T14:13:55.024Z"],
+                "scheduler_version": ["3.21.1"],
+                "sim_runner_kwargs": [None],
+                "conda_env_sha256": ["48bcf84e41a741ee67fe644b1ed8d5858d81a7ecfe012473fe2e2f0f3fc05095"],
+                "parent_visitseq_uuid": ["94fd43ff-5034-43cd-ac48-6461cdca7979"],
+                "parent_last_day_obs": ["2026-04-10"],
+                "tags": [["ideal", "nominal", "prenight"]],
+                "comments": [{}],
+                "files": [{}],
+            },
+            index=[sample_uuid],
+        )
+
+        with patch(
+            "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_database", return_value=mock_result
+        ):
+            with patch(
+                "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_bucket",
+                return_value=pd.DataFrame(),
+            ) as mock_bucket:
+                result = get_prenight_index("2026-04-11", telescope="simonyi")
+
+                # Should return a DataFrame
+                self.assertIsInstance(result, pd.DataFrame)
+
+                # Should contain the data from the database
+                self.assertEqual(len(result), 1)
+                self.assertIn(sample_uuid, result.index)
+
+                # Verify that get_prenight_index_from_bucket was not called
+                mock_bucket.assert_not_called()
+
+        # Test fallback behavior when database fails
+        # Modify mock results so they are distinguishable
+        mock_result.loc[sample_uuid, "scheduler_version"] = "3.2.1"
+        with patch(
+            "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_database",
+            side_effect=Exception("Database error"),
+        ):
+            with patch(
+                "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_bucket", return_value=mock_result
+            ):
+                result = get_prenight_index("2026-04-11", telescope="simonyi")
+
+                # Should return a DataFrame
+                self.assertIsInstance(result, pd.DataFrame)
+
+                # Should contain the data from the bucket (fallback)
+                self.assertEqual(len(result), 1)
+                self.assertIn(sample_uuid, result.index)
+                self.assertEqual(result.loc[sample_uuid, "scheduler_version"], "3.2.1")
+
+        # Test behavior when both database and bucket fail
+        with patch(
+            "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_database",
+            side_effect=Exception("Database error"),
+        ):
+            with patch(
+                "rubin_sim.sim_archive.prenightindex.get_prenight_index_from_bucket",
+                side_effect=FileNotFoundError("Bucket not found"),
+            ):
+                result = get_prenight_index("2026-04-11", telescope="simonyi")
+
+                # Should return an empty DataFrame
+                self.assertIsInstance(result, pd.DataFrame)
+                self.assertEqual(len(result), 0)


### PR DESCRIPTION
These additions to the sim archive code in rubin_sim move some of the code repeated across a couple of schedview notebooks to rubin_sim where it can be reused and tested.

While I was at it, I added tests for some of the sim archive functionality what was previously inadequately tested.
(The new testing was significantly LLM assisted. It tends to be very thorough.)