### PR TITLE
tickets/SP-3223: Add extinction and cloud stacker

### DIFF
--- a/rubin_sim/maf/stackers/__init__.py
+++ b/rubin_sim/maf/stackers/__init__.py
@@ -1,6 +1,7 @@
 from .base_stacker import *
 from .coord_stackers import *
 from .date_stackers import *
+from .extinction_stacker import *
 from .general_stackers import *
 from .get_col_info import *
 from .label_stackers import *

--- a/rubin_sim/maf/stackers/extinction_stacker.py
+++ b/rubin_sim/maf/stackers/extinction_stacker.py
@@ -12,7 +12,6 @@ from rubin_sim.phot_utils import predicted_zeropoint
 from .base_stacker import BaseStacker
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def _make_default_band_priors():
@@ -72,7 +71,7 @@ def _limits_from_prior(prior):
     return k_min, k_max, zp_min, zp_max
 
 
-def _fit_extinction_one_group(
+def _fit_zp_extinction_one_group(
     airmass,
     zero_point,
     k_min,
@@ -85,11 +84,15 @@ def _fit_extinction_one_group(
     min_inlier_fraction,
     premask=True,
 ):
-    """Fit the extinction coefficient for a single band/dayObs group.
+    """Fit both the zenith zeropoint and extinction coefficient for one group.
 
     Fits the linear model::
 
         zero_point = fitted_zeropoint - extinction_k * airmass
+
+    where both ``fitted_zeropoint`` and ``extinction_k`` are free parameters.
+    Used when the band prior has ``zp_window > 0``.  When the zeropoint is
+    known exactly (``zp_window=0``), use `_fit_extinction_one_group` instead.
 
     Three stages are attempted in order, stopping as soon as one succeeds:
 
@@ -149,7 +152,7 @@ def _fit_extinction_one_group(
     """
     orig_npts = len(airmass)
     if orig_npts == 0:
-        logger.debug("Extinction fit: no data points supplied; returning NaN.")
+        logger.debug("ZP+extinction fit: no data points supplied; returning NaN.")
         return np.nan, np.nan
 
     X = airmass.reshape(-1, 1)
@@ -166,7 +169,7 @@ def _fit_extinction_one_group(
     npts = len(y)
     if npts < min_inliers or (npts / orig_npts) < min_inlier_fraction:
         logger.debug(
-            "Extinction fit: too few points after pre-masking (%d of %d survive; "
+            "ZP+extinction fit: too few points after pre-masking (%d of %d survive; "
             "min_inliers=%d, min_inlier_fraction=%.2f); returning NaN.",
             npts,
             orig_npts,
@@ -197,7 +200,7 @@ def _fit_extinction_one_group(
         )
         if ok:
             logger.debug(
-                "Extinction fit stage 1 (RANSAC) succeeded: k=%.4f, zp=%.4f, "
+                "ZP+extinction fit stage 1 (RANSAC) succeeded: k=%.4f, zp=%.4f, "
                 "inliers=%d/%d.",
                 k,
                 zp,
@@ -205,8 +208,20 @@ def _fit_extinction_one_group(
                 orig_npts,
             )
             return k, zp
+        logger.debug(
+            "ZP+extinction fit stage 1 (RANSAC) rejected: k=%.4f (bounds [%.4f, %.4f]), "
+            "zp=%.4f (bounds [%.4f, %.4f]), inliers=%d/%d.",
+            k,
+            k_min,
+            k_max,
+            zp,
+            zp_min,
+            zp_max,
+            num_inliers,
+            orig_npts,
+        )
     except Exception as exc:
-        logger.debug("Extinction fit stage 1 (RANSAC) raised an exception: %s.", exc)
+        logger.debug("ZP+extinction fit stage 1 (RANSAC) raised an exception: %s.", exc)
 
     # --- Stage 2: Theil-Sen fallback ---
     try:
@@ -218,13 +233,23 @@ def _fit_extinction_one_group(
         zp = float(ts.intercept_)
         if (k_min <= k <= k_max) and (zp_min <= zp <= zp_max):
             logger.debug(
-                "Extinction fit stage 2 (Theil-Sen) succeeded: k=%.4f, zp=%.4f.",
+                "ZP+extinction fit stage 2 (Theil-Sen) succeeded: k=%.4f, zp=%.4f.",
                 k,
                 zp,
             )
             return k, zp
+        logger.debug(
+            "ZP+extinction fit stage 2 (Theil-Sen) rejected: k=%.4f (bounds [%.4f, %.4f]), "
+            "zp=%.4f (bounds [%.4f, %.4f]).",
+            k,
+            k_min,
+            k_max,
+            zp,
+            zp_min,
+            zp_max,
+        )
     except Exception as exc:
-        logger.debug("Extinction fit stage 2 (Theil-Sen) raised an exception: %s.", exc)
+        logger.debug("ZP+extinction fit stage 2 (Theil-Sen) raised an exception: %s.", exc)
 
     # --- Stage 3: Anchored-clip + bounded Huber regression ---
     #
@@ -234,6 +259,7 @@ def _fit_extinction_one_group(
     # The surviving inlier set is passed to a bounded least_squares fit with a
     # Huber loss that jointly optimises both k and zp within their physical
     # bounds, so an out-of-range intercept can never cause rejection.
+    logger.debug("ZP+extinction fit stage 3 (anchored-clip + bounded Huber) triggered.")
 
     airmass_pm = X.ravel()  # post-premask 1-D array
     zp_pm = y
@@ -242,7 +268,7 @@ def _fit_extinction_one_group(
     nonzero = airmass_pm > 0.0
     if nonzero.sum() < min_inliers:
         logger.debug(
-            "Extinction fit stage 3: too few non-zero airmass points (%d); "
+            "ZP+extinction fit stage 3: too few non-zero airmass points (%d); "
             "returning NaN.",
             int(nonzero.sum()),
         )
@@ -251,15 +277,16 @@ def _fit_extinction_one_group(
     k_implied = (zp_prior - zp_pm[nonzero]) / airmass_pm[nonzero]
     k_anchor = float(np.clip(np.median(k_implied), k_min, k_max))
 
-    # Clip outliers relative to the anchored model.
+    # Clip outliers relative to the anchored model (one-sided: clouds only
+    # make sources fainter, so only clip visits that are too faint).
     clip_threshold = 2.0 * residual_threshold
     residuals = zp_pm - (zp_prior - k_anchor * airmass_pm)
-    inlier_mask = np.abs(residuals) <= clip_threshold
+    inlier_mask = residuals >= -clip_threshold
 
     n_inliers = int(inlier_mask.sum())
     if n_inliers < min_inliers or (n_inliers / orig_npts) < min_inlier_fraction:
         logger.debug(
-            "Extinction fit stage 3: too few inliers after anchor-clip (%d of %d; "
+            "ZP+extinction fit stage 3: too few inliers after anchor-clip (%d of %d; "
             "min_inliers=%d, min_inlier_fraction=%.2f); returning NaN.",
             n_inliers,
             orig_npts,
@@ -287,7 +314,7 @@ def _fit_extinction_one_group(
         if result.success or result.cost < np.inf:
             k_fit, zp_fit = float(result.x[0]), float(result.x[1])
             logger.debug(
-                "Extinction fit stage 3 (anchored-clip + bounded Huber) succeeded: "
+                "ZP+extinction fit stage 3 (anchored-clip + bounded Huber) succeeded: "
                 "k=%.4f, zp=%.4f, inliers=%d/%d.",
                 k_fit,
                 zp_fit,
@@ -296,18 +323,123 @@ def _fit_extinction_one_group(
             )
             return k_fit, zp_fit
         logger.debug(
-            "Extinction fit stage 3: least_squares converged to infinite cost; "
+            "ZP+extinction fit stage 3: least_squares converged to infinite cost; "
             "returning NaN."
         )
     except Exception as exc:
         logger.debug(
-            "Extinction fit stage 3 (anchored-clip + bounded Huber) raised an "
+            "ZP+extinction fit stage 3 (anchored-clip + bounded Huber) raised an "
             "exception: %s.",
             exc,
         )
 
-    logger.debug("Extinction fit: all three stages failed; returning NaN.")
+    logger.debug("ZP+extinction fit: all three stages failed; returning NaN.")
     return np.nan, np.nan
+
+
+def _fit_extinction_one_group(
+    airmass,
+    zero_point,
+    zp_fixed,
+    k_min,
+    k_max,
+    min_inliers,
+    min_inlier_fraction,
+):
+    """Fit the extinction coefficient for one group with a fixed zenith zeropoint.
+
+    Used when ``zp_window=0`` in the band prior, i.e. the zenith zeropoint is
+    treated as perfectly known.  Only ``extinction_k`` is estimated; the
+    returned ``fitted_zeropoint`` is always ``zp_fixed``.
+
+    The model is::
+
+        zero_point ≈ zp_fixed - extinction_k * airmass
+
+    so the implied per-visit extinction is::
+
+        k_implied = (zp_fixed - zero_point) / airmass
+
+    Visits are clipped asymmetrically before taking the median:
+
+    * ``k_implied > k_max`` — the visit is cloud-dimmed; excluded.
+    * ``k_implied < k_min`` — unphysically bright; excluded.
+
+    Visits with normal low-but-positive extinction (``k_min ≤ k_implied``)
+    are always retained.
+
+    Parameters
+    ----------
+    airmass : `np.ndarray`, shape (N,)
+        Airmass values for the group.  Entries with ``airmass == 0`` are
+        silently ignored.
+    zero_point : `np.ndarray`, shape (N,)
+        Photometric zeropoints for the group, normalized to a 1-second
+        exposure time (i.e., ``raw_zp - 2.5 * log10(exptime)``).
+    zp_fixed : `float`
+        Fixed zenith zeropoint (``expected_zp_X0`` from the band prior).
+    k_min : `float`
+        Minimum physically plausible extinction coefficient (mag/airmass).
+    k_max : `float`
+        Maximum physically plausible extinction coefficient (mag/airmass).
+    min_inliers : `int`
+        Minimum number of inlier visits required for a valid fit.
+    min_inlier_fraction : `float`
+        Minimum fraction of the original visit count that must be inliers.
+
+    Returns
+    -------
+    extinction_k : `float`
+        Median extinction coefficient of the inlier visits, clipped to
+        ``[k_min, k_max]``, or `np.nan` if the fit failed.
+    fitted_zeropoint : `float`
+        Always ``zp_fixed``, or `np.nan` if the fit failed.
+    """
+    orig_npts = len(airmass)
+    if orig_npts == 0:
+        logger.debug("Extinction fit (fixed ZP): no data points supplied; returning NaN.")
+        return np.nan, np.nan
+
+    # Exclude airmass == 0 entries to avoid division by zero.
+    nonzero = airmass > 0.0
+    airmass_nz = airmass[nonzero]
+    zp_nz = zero_point[nonzero]
+
+    if len(airmass_nz) == 0:
+        logger.debug(
+            "Extinction fit (fixed ZP): all airmass values are zero; returning NaN."
+        )
+        return np.nan, np.nan
+
+    # Per-visit implied extinction coefficient.
+    k_implied = (zp_fixed - zp_nz) / airmass_nz
+
+    # Asymmetric clip: remove cloud-dimmed visits (k_implied > k_max) and
+    # unphysically bright visits (k_implied < k_min); retain everything else.
+    inlier_mask = (k_implied >= k_min) & (k_implied <= k_max)
+    n_inliers = int(inlier_mask.sum())
+
+    if n_inliers < min_inliers or (n_inliers / orig_npts) < min_inlier_fraction:
+        logger.debug(
+            "Extinction fit (fixed ZP): too few inliers after physical-bounds clip "
+            "(%d of %d; min_inliers=%d, min_inlier_fraction=%.2f); returning NaN.",
+            n_inliers,
+            orig_npts,
+            min_inliers,
+            min_inlier_fraction,
+        )
+        return np.nan, np.nan
+
+    k_fit = float(np.clip(np.median(k_implied[inlier_mask]), k_min, k_max))
+    logger.debug(
+        "Extinction fit (fixed ZP) succeeded: k=%.4f, zp=%.4f (fixed), "
+        "inliers=%d/%d.",
+        k_fit,
+        zp_fixed,
+        n_inliers,
+        orig_npts,
+    )
+    return k_fit, zp_fixed
 
 
 class ExtinctionStacker(BaseStacker):
@@ -320,16 +452,23 @@ class ExtinctionStacker(BaseStacker):
 
     where ``zp_1s = zero_point_median - 2.5 * log10(visitExposureTime)``.
 
-    Three fitting stages are attempted in order for each group:
+    Two fitting modes are available, selected per band by ``zp_window``:
+
+    **Fixed-ZP mode** (``zp_window=0``): the zenith zeropoint is held fixed at
+    ``expected_zp_X0``; only ``extinction_k`` is estimated.  Per-visit implied
+    k values are computed and clipped to ``[k_min, k_max]`` (cloud-dimmed
+    visits have high implied k and are excluded; unphysically bright visits are
+    also excluded).  The median of the surviving inliers is returned.
+
+    **Free-ZP mode** (``zp_window > 0``): both parameters are free.  Three
+    stages are attempted in order for each group:
 
     1. **RANSAC** free two-parameter regression with physical bounds check.
     2. **Theil-Sen** robust regression with physical bounds check.
-    3. **Anchored-clip + bounded Huber regression**: the expected zenith
-       zeropoint ``expected_zp_X0`` from the band prior is used as a fixed
-       anchor to identify inliers via a median-based slope estimate;
+    3. **Anchored-clip + bounded Huber regression**: ``expected_zp_X0`` is used
+       as a fixed anchor to identify inliers via a median-based slope estimate;
        `scipy.optimize.least_squares` then fits both parameters with hard
-       physical bounds so an out-of-range intercept can never cause
-       rejection.
+       physical bounds so an out-of-range intercept can never cause rejection.
 
     Parameters
     ----------
@@ -367,6 +506,8 @@ class ExtinctionStacker(BaseStacker):
             Half-width of the allowed zeropoint range (mag); the fit
             bounds become
             ``[expected_zp_X0 - zp_window, expected_zp_X0 + zp_window]``.
+            Set to ``0.0`` to fix the zeropoint at ``expected_zp_X0`` and
+            fit only ``extinction_k`` (fixed-ZP mode).
 
         If ``None``, the Rubin Observatory defaults
         (`DEFAULT_BAND_PRIORS`) are used.
@@ -483,19 +624,30 @@ class ExtinctionStacker(BaseStacker):
                 # Normalize to 1-second exposure time
                 zp_1s = raw_zp - 2.5 * np.log10(exptime)
 
-                k, zp = _fit_extinction_one_group(
-                    airmass,
-                    zp_1s,
-                    k_min=k_min,
-                    k_max=k_max,
-                    zp_min=zp_min,
-                    zp_max=zp_max,
-                    zp_prior=zp_prior,
-                    residual_threshold=self.residual_threshold,
-                    min_inliers=self.min_inliers,
-                    min_inlier_fraction=self.min_inlier_fraction,
-                    premask=self.premask,
-                )
+                if prior.get("zp_window", 1.0) == 0.0:
+                    k, zp = _fit_extinction_one_group(
+                        airmass,
+                        zp_1s,
+                        zp_fixed=zp_prior,
+                        k_min=k_min,
+                        k_max=k_max,
+                        min_inliers=self.min_inliers,
+                        min_inlier_fraction=self.min_inlier_fraction,
+                    )
+                else:
+                    k, zp = _fit_zp_extinction_one_group(
+                        airmass,
+                        zp_1s,
+                        k_min=k_min,
+                        k_max=k_max,
+                        zp_min=zp_min,
+                        zp_max=zp_max,
+                        zp_prior=zp_prior,
+                        residual_threshold=self.residual_threshold,
+                        min_inliers=self.min_inliers,
+                        min_inlier_fraction=self.min_inlier_fraction,
+                        premask=self.premask,
+                    )
 
                 if np.isnan(k):
                     logger.debug(

--- a/rubin_sim/maf/stackers/extinction_stacker.py
+++ b/rubin_sim/maf/stackers/extinction_stacker.py
@@ -1,0 +1,500 @@
+__all__ = ("ExtinctionStacker", "CloudExtinctionStacker")
+
+import logging
+import warnings
+
+import numpy as np
+from sklearn.linear_model import LinearRegression, RANSACRegressor, TheilSenRegressor
+
+from rubin_sim.phot_utils import predicted_zeropoint
+
+from .base_stacker import BaseStacker
+
+logger = logging.getLogger(__name__)
+
+
+def _make_band_limits(k_fraction_tolerance=0.5, zp_mag_window=0.5):
+    """Generate per-band physical limits for the extinction fit.
+
+    Derives limits from the predicted zeropoint model in
+    `rubin_sim.phot_utils.predicted_zeropoints`.  All zeropoint limits
+    are expressed on a 1-second exposure time scale (the
+    `ExtinctionStacker` normalizes raw zeropoints to 1-second before
+    fitting).
+
+    Parameters
+    ----------
+    k_fraction_tolerance : `float`, optional
+        The extinction coefficient limits are set to
+        ``(1 - k_fraction_tolerance) * k_predicted`` (min, floored at 0)
+        and ``(1 + k_fraction_tolerance) * k_predicted`` (max) for each
+        band, where ``k_predicted`` is the standard extinction
+        coefficient from the throughput model.  Default is 0.5.
+    zp_mag_window : `float`, optional
+        The zeropoint limits are set to
+        ``zp_at_X0 +/- zp_mag_window`` for each band, where
+        ``zp_at_X0`` is the predicted zeropoint extrapolated to
+        airmass 0 (above the atmosphere) for a 1-second exposure.
+        This corresponds to the intercept of the fitted model.
+        Default is 0.5 mag.
+
+    Returns
+    -------
+    band_limits : `dict`
+        Keys are single-character band names; values are dicts with
+        keys ``k_min``, ``k_max``, ``zp_min``, ``zp_max``.
+    """
+    band_limits = {}
+    for band in "ugrizy":
+        # Extract k from the model by evaluating at two airmasses.
+        # The extinction coefficient is independent of exptime.
+        zp_at_X1 = predicted_zeropoint(band, airmass=1.0, exptime=1.0)
+        zp_at_X2 = predicted_zeropoint(band, airmass=2.0, exptime=1.0)
+        k_predicted = zp_at_X1 - zp_at_X2  # positive extinction coefficient
+
+        # The fitted zeropoint is the intercept at airmass=0.
+        zp_at_X0 = zp_at_X1 + k_predicted
+
+        band_limits[band] = {
+            "k_min": max(0.0, (1 - k_fraction_tolerance) * k_predicted),
+            "k_max": (1 + k_fraction_tolerance) * k_predicted,
+            "zp_min": zp_at_X0 - zp_mag_window,
+            "zp_max": zp_at_X0 + zp_mag_window,
+        }
+    return band_limits
+
+
+DEFAULT_BAND_LIMITS = _make_band_limits()
+
+
+def _fit_extinction_one_group(
+    airmass,
+    zero_point,
+    k_min,
+    k_max,
+    zp_min,
+    zp_max,
+    residual_threshold,
+    min_inliers,
+    min_inlier_fraction,
+    premask=True,
+):
+    """Fit the extinction coefficient for a single band/dayObs group.
+
+    Fits the linear model::
+
+        zero_point = fitted_zeropoint - extinction_k * airmass
+
+    using RANSAC robust regression, with Theil-Sen as a fallback when
+    RANSAC fails or yields unphysical parameters.
+
+    Parameters
+    ----------
+    airmass : `np.ndarray`, shape (N,)
+        Airmass values for the group.
+    zero_point : `np.ndarray`, shape (N,)
+        Photometric zeropoints for the group, normalized to a 1-second
+        exposure time (i.e., ``raw_zp - 2.5 * log10(exptime)``).
+    k_min : `float`
+        Minimum physically plausible extinction coefficient (mag/airmass).
+    k_max : `float`
+        Maximum physically plausible extinction coefficient (mag/airmass).
+    zp_min : `float`
+        Minimum physically plausible zenith zeropoint (mag).
+    zp_max : `float`
+        Maximum physically plausible zenith zeropoint (mag).
+    residual_threshold : `float`
+        RANSAC inlier residual threshold in magnitudes.
+    min_inliers : `int`
+        Minimum number of inlier visits required for a valid RANSAC fit.
+    min_inlier_fraction : `float`
+        Minimum fraction of the original visit count that must be inliers.
+    premask : `bool`, optional
+        If True (default), remove visits whose zeropoint is implausibly
+        low (i.e., consistent with extinction greater than ``k_max``)
+        before fitting.
+
+    Returns
+    -------
+    extinction_k : `float`
+        Fitted extinction coefficient, or `np.nan` if the fit failed.
+    fitted_zeropoint : `float`
+        Fitted zenith zeropoint, or `np.nan` if the fit failed.
+    """
+    orig_npts = len(airmass)
+    if orig_npts == 0:
+        return np.nan, np.nan
+
+    X = airmass.reshape(-1, 1)
+    y = zero_point.copy()
+
+    # Pre-mask visits whose raw zeropoint is too low to be plausible even
+    # under maximum allowed extinction (proxy for heavily clouded exposures).
+    if premask:
+        min_expected_zp = zp_min - k_max * airmass
+        keep = y > min_expected_zp
+        X = X[keep]
+        y = y[keep]
+
+    npts = len(y)
+    if npts < min_inliers or (npts / orig_npts) < min_inlier_fraction:
+        return np.nan, np.nan
+
+    # --- RANSAC robust linear regression ---
+    ransac = RANSACRegressor(
+        estimator=LinearRegression(),
+        residual_threshold=residual_threshold,
+        max_trials=10,
+    )
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ransac.fit(X, y)
+        num_inliers = int(ransac.inlier_mask_.sum())
+        k = float(-ransac.estimator_.coef_[0])
+        zp = float(ransac.estimator_.intercept_)
+
+        ok = (
+            (k_min <= k <= k_max)
+            and (zp_min <= zp <= zp_max)
+            and (num_inliers >= min_inliers)
+            and (num_inliers >= min_inlier_fraction * orig_npts)
+        )
+        if ok:
+            return k, zp
+    except Exception:
+        pass
+
+    # --- Theil-Sen fallback ---
+    try:
+        ts = TheilSenRegressor(max_subpopulation=100)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ts.fit(X, y)
+        k = float(-ts.coef_[0])
+        zp = float(ts.intercept_)
+        if (k_min <= k <= k_max) and (zp_min <= zp <= zp_max):
+            return k, zp
+    except Exception:
+        pass
+
+    return np.nan, np.nan
+
+
+class ExtinctionStacker(BaseStacker):
+    """Fit atmospheric extinction per band/dayObs and add to each visit.
+
+    For each unique (band, dayObs) combination, normalizes the raw
+    zeropoints to a 1-second exposure time and fits the linear model::
+
+        zp_1s = fitted_zeropoint - extinction_k * airmass
+
+    where ``zp_1s = zero_point_median - 2.5 * log10(visitExposureTime)``.
+
+    Parameters
+    ----------
+    zero_point_col : `str`, optional
+        Name of the raw photometric zeropoint column.
+        Default ``'zero_point_median'``.
+    airmass_col : `str`, optional
+        Name of the airmass column.  Default ``'airmass'``.
+    band_col : `str`, optional
+        Name of the band (filter) column.  Default ``'band'``.
+    exptime_col : `str`, optional
+        Name of the exposure time column (seconds).
+        Default ``'visitExposureTime'``.
+    day_obs_col : `str`, optional
+        Name of the dayObs column (integer YYYYMMDD, as defined by
+        SITCOMTN-32).  Default ``'dayObs'``.
+    band_limits : `dict` or `None`, optional
+        Per-band physical limits for the fit (on a 1-second zeropoint
+        scale).  Keys are single-character band names (``'u'``, ``'g'``,
+        ``'r'``, ``'i'``, ``'z'``, ``'y'``); values are dicts with keys
+        ``k_min``, ``k_max``, ``zp_min``, ``zp_max``.  If ``None``, the
+        Rubin Observatory defaults (`DEFAULT_BAND_LIMITS`) are used.
+    residual_threshold : `float`, optional
+        RANSAC inlier residual threshold in magnitudes.  Default 0.05.
+    min_inliers : `int`, optional
+        Minimum number of inlier visits required for a valid RANSAC fit.
+        Default 10.
+    min_inlier_fraction : `float`, optional
+        Minimum fraction of visits (before pre-masking) that must be
+        inliers.  Default 0.1.
+    premask : `bool`, optional
+        If True (default), visits with implausibly low zeropoints are
+        removed before fitting to reduce the impact of heavily clouded
+        frames.
+
+    Notes
+    -----
+
+    This uses RANSAC robust regression (with Theil-Sen fallback).  The
+    fitted ``extinction_k`` and ``fitted_zeropoint`` (at 1-second) are
+    then assigned to every visit belonging to that group.  Visits from
+    groups where the fit failed (too few data points, or no physically
+    plausible solution found) receive `NaN` in both columns.
+
+    This stacker is intended for use with consdb visit tables, which
+    contain the ``zero_point_median`` column (raw, uncorrected photometric
+    zeropoint) that is absent from opsim output.
+
+    Two columns are added to the data:
+
+    ``extinction_k``
+        Atmospheric extinction coefficient fitted for the visit's band
+        and night (mag/airmass).
+    ``fitted_zeropoint``
+        Instrument+atmosphere zenith zeropoint fitted for the visit's
+        band and night, normalized to a 1-second exposure time (mag).
+
+    The ``dayObs`` column (integer YYYYMMDD) must already be present in
+    the data.  If it is not, run `DayObsStacker` first.
+    """
+
+    cols_added = ["extinction_k", "fitted_zeropoint"]
+
+    def __init__(
+        self,
+        zero_point_col="zero_point_median",
+        airmass_col="airmass",
+        band_col="band",
+        exptime_col="visitExposureTime",
+        day_obs_col="dayObs",
+        band_limits=None,
+        residual_threshold=0.05,
+        min_inliers=10,
+        min_inlier_fraction=0.1,
+        premask=True,
+    ):
+        self.zero_point_col = zero_point_col
+        self.airmass_col = airmass_col
+        self.band_col = band_col
+        self.exptime_col = exptime_col
+        self.day_obs_col = day_obs_col
+        self.band_limits = band_limits if band_limits is not None else DEFAULT_BAND_LIMITS
+        self.residual_threshold = residual_threshold
+        self.min_inliers = min_inliers
+        self.min_inlier_fraction = min_inlier_fraction
+        self.premask = premask
+
+        self.cols_req = [zero_point_col, airmass_col, band_col, exptime_col, day_obs_col]
+        self.units = ["mag/airmass", "mag"]
+        self.cols_added_dtypes = [float, float]
+
+    def _run(self, sim_data, cols_present=False):
+        if cols_present:
+            return sim_data
+
+        # Check that the required source columns are actually present.
+        # They will be absent when this stacker is exercised against opsim
+        # data that does not carry consdb columns such as zero_point_median.
+        col_names = sim_data.dtype.names if hasattr(sim_data, "dtype") else list(sim_data.keys())
+        for col in self.cols_req:
+            if col not in col_names:
+                logger.warning(
+                    "ExtinctionStacker: required column '%s' not found in data; "
+                    "extinction_k and fitted_zeropoint will be NaN.",
+                    col,
+                )
+                sim_data["extinction_k"] = np.nan
+                sim_data["fitted_zeropoint"] = np.nan
+                return sim_data
+
+        sim_data["extinction_k"] = np.nan
+        sim_data["fitted_zeropoint"] = np.nan
+
+        for band in np.unique(sim_data[self.band_col]):
+            limits = self.band_limits.get(band)
+            if limits is None:
+                logger.warning(
+                    "No band limits defined for band '%s'; skipping extinction fit.",
+                    band,
+                )
+                continue
+
+            band_mask = sim_data[self.band_col] == band
+
+            for day_obs in np.unique(sim_data[self.day_obs_col][band_mask]):
+                group_mask = band_mask & (sim_data[self.day_obs_col] == day_obs)
+                airmass = sim_data[self.airmass_col][group_mask].astype(float)
+                raw_zp = sim_data[self.zero_point_col][group_mask].astype(float)
+                exptime = sim_data[self.exptime_col][group_mask].astype(float)
+
+                # Normalize to 1-second exposure time
+                zp_1s = raw_zp - 2.5 * np.log10(exptime)
+
+                k, zp = _fit_extinction_one_group(
+                    airmass,
+                    zp_1s,
+                    k_min=limits["k_min"],
+                    k_max=limits["k_max"],
+                    zp_min=limits["zp_min"],
+                    zp_max=limits["zp_max"],
+                    residual_threshold=self.residual_threshold,
+                    min_inliers=self.min_inliers,
+                    min_inlier_fraction=self.min_inlier_fraction,
+                    premask=self.premask,
+                )
+
+                if np.isnan(k):
+                    logger.debug(
+                        "Extinction fit failed for band=%s dayObs=%s (%d visits).",
+                        band,
+                        day_obs,
+                        int(group_mask.sum()),
+                    )
+
+                sim_data["extinction_k"][group_mask] = k
+                sim_data["fitted_zeropoint"][group_mask] = zp
+
+        return sim_data
+
+
+class CloudExtinctionStacker(BaseStacker):
+    """Estimate extinction due to clouds for each visit.
+
+    Computes the difference between the expected clear-sky zeropoint
+    (accounting for atmospheric extinction along the line of sight) and
+    the observed raw zeropoint::
+
+        cloud_extinction = (fitted_zeropoint - extinction_k * airmass)
+                           - zero_point_median
+
+    A positive ``cloud_extinction`` means the visit was dimmer than the
+    photometric model predicts (i.e., clouds were present).  A value of
+    zero means the visit was consistent with a clear sky.
+
+    When the `ExtinctionStacker` was unable to produce a photometric
+    solution for a given visit (``extinction_k`` is NaN), the predicted
+    zeropoint from `rubin_sim.phot_utils.predicted_zeropoint` (plus an
+    optional per-band offset) is used as the fallback expected zeropoint
+    for that visit.
+
+    Parameters
+    ----------
+    zero_point_col : `str`, optional
+        Name of the raw photometric zeropoint column.
+        Default ``'zero_point_median'``.
+    airmass_col : `str`, optional
+        Name of the airmass column.  Default ``'airmass'``.
+    band_col : `str`, optional
+        Name of the band (filter) column.  Default ``'band'``.
+    exptime_col : `str`, optional
+        Name of the exposure time column (seconds).
+        Default ``'visitExposureTime'``.
+    extinction_k_col : `str`, optional
+        Name of the fitted extinction coefficient column (output of
+        `ExtinctionStacker`).  Default ``'extinction_k'``.
+    fitted_zeropoint_col : `str`, optional
+        Name of the fitted zenith zeropoint column (output of
+        `ExtinctionStacker`).  Default ``'fitted_zeropoint'``.
+    zeropoint_offsets : `dict` or `None`, optional
+        Per-band offsets (in magnitudes) to apply to the
+        ``predicted_zeropoint`` fallback values, accounting for
+        recently measured differences between the throughput model and
+        the actual instrument.  Keys are single-character band names;
+        values are floats added to the predicted zeropoint.  Bands not
+        present in the dict receive no offset.  If ``None`` (default),
+        no offsets are applied.
+
+    Notes
+    -----
+    This stacker depends on the columns produced by `ExtinctionStacker`
+    (``extinction_k`` and ``fitted_zeropoint``).  It should be run after
+    `ExtinctionStacker`, or the ``extinction_k`` and ``fitted_zeropoint``
+    columns should already be present in the data.
+
+    One column is added:
+
+    ``cloud_extinction``
+        Estimated extinction due to clouds in magnitudes.  Positive values
+        indicate cloud absorption; values near zero indicate photometric
+        conditions.  Negative values (visit brighter than the model) are
+        possible due to noise or model imperfections.
+    """
+
+    cols_added = ["cloud_extinction"]
+
+    def __init__(
+        self,
+        zero_point_col="zero_point_median",
+        airmass_col="airmass",
+        band_col="band",
+        exptime_col="visitExposureTime",
+        extinction_k_col="extinction_k",
+        fitted_zeropoint_col="fitted_zeropoint",
+        zeropoint_offsets=None,
+    ):
+        self.zero_point_col = zero_point_col
+        self.airmass_col = airmass_col
+        self.band_col = band_col
+        self.exptime_col = exptime_col
+        self.extinction_k_col = extinction_k_col
+        self.fitted_zeropoint_col = fitted_zeropoint_col
+        self.zeropoint_offsets = zeropoint_offsets if zeropoint_offsets is not None else {}
+
+        self.cols_req = [
+            zero_point_col,
+            airmass_col,
+            band_col,
+            exptime_col,
+            extinction_k_col,
+            fitted_zeropoint_col,
+        ]
+        self.units = ["mag"]
+        self.cols_added_dtypes = [float]
+
+    def _run(self, sim_data, cols_present=False):
+        if cols_present:
+            return sim_data
+
+        # Check that the required source columns are actually present.
+        col_names = sim_data.dtype.names if hasattr(sim_data, "dtype") else list(sim_data.keys())
+        for col in self.cols_req:
+            if col not in col_names:
+                logger.warning(
+                    "CloudExtinctionStacker: required column '%s' not found "
+                    "in data; cloud_extinction will be NaN.",
+                    col,
+                )
+                sim_data["cloud_extinction"] = np.nan
+                return sim_data
+
+        airmass = sim_data[self.airmass_col].astype(float)
+        zero_point = sim_data[self.zero_point_col].astype(float)
+        exptime = sim_data[self.exptime_col].astype(float)
+        extinction_k = sim_data[self.extinction_k_col].astype(float)
+        fitted_zp = sim_data[self.fitted_zeropoint_col].astype(float)
+
+        # fitted_zeropoint is on a 1-second scale, so the expected raw
+        # zeropoint at the actual exposure time and airmass is:
+        #   expected = fitted_zeropoint - k * airmass + 2.5 * log10(exptime)
+        expected_zp = fitted_zp - extinction_k * airmass + 2.5 * np.log10(exptime)
+
+        # For visits where the extinction fit failed (NaN), use the
+        # predicted_zeropoint function (plus any configured offset) as
+        # fallback.  predicted_zeropoint already accounts for airmass
+        # and exptime.
+        nan_mask = np.isnan(extinction_k)
+        if np.any(nan_mask):
+            for band in np.unique(sim_data[self.band_col][nan_mask]):
+                band_nan_mask = nan_mask & (sim_data[self.band_col] == band)
+                band_airmass = airmass[band_nan_mask]
+                band_exptime = exptime[band_nan_mask]
+                try:
+                    fallback_zp = predicted_zeropoint(band, band_airmass, band_exptime)
+                    fallback_zp += self.zeropoint_offsets.get(band, 0.0)
+                    expected_zp[band_nan_mask] = fallback_zp
+                except KeyError:
+                    logger.warning(
+                        "CloudExtinctionStacker: predicted_zeropoint does not "
+                        "support band '%s'; cloud_extinction will be NaN for "
+                        "those visits.",
+                        band,
+                    )
+                    expected_zp[band_nan_mask] = np.nan
+
+        # cloud_extinction = expected_zp - observed_zp
+        sim_data["cloud_extinction"] = expected_zp - zero_point
+
+        return sim_data

--- a/rubin_sim/maf/stackers/extinction_stacker.py
+++ b/rubin_sim/maf/stackers/extinction_stacker.py
@@ -4,6 +4,7 @@ import logging
 import warnings
 
 import numpy as np
+from scipy.optimize import least_squares
 from sklearn.linear_model import LinearRegression, RANSACRegressor, TheilSenRegressor
 
 from rubin_sim.phot_utils import predicted_zeropoint
@@ -11,60 +12,64 @@ from rubin_sim.phot_utils import predicted_zeropoint
 from .base_stacker import BaseStacker
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
-def _make_band_limits(k_fraction_tolerance=0.5, zp_mag_window=0.5):
-    """Generate per-band physical limits for the extinction fit.
+def _make_default_band_priors():
+    """Build the default per-band prior dictionary from the throughput model.
 
-    Derives limits from the predicted zeropoint model in
-    `rubin_sim.phot_utils.predicted_zeropoints`.  All zeropoint limits
-    are expressed on a 1-second exposure time scale (the
-    `ExtinctionStacker` normalizes raw zeropoints to 1-second before
-    fitting).
-
-    Parameters
-    ----------
-    k_fraction_tolerance : `float`, optional
-        The extinction coefficient limits are set to
-        ``(1 - k_fraction_tolerance) * k_predicted`` (min, floored at 0)
-        and ``(1 + k_fraction_tolerance) * k_predicted`` (max) for each
-        band, where ``k_predicted`` is the standard extinction
-        coefficient from the throughput model.  Default is 0.5.
-    zp_mag_window : `float`, optional
-        The zeropoint limits are set to
-        ``zp_at_X0 +/- zp_mag_window`` for each band, where
-        ``zp_at_X0`` is the predicted zeropoint extrapolated to
-        airmass 0 (above the atmosphere) for a 1-second exposure.
-        This corresponds to the intercept of the fitted model.
-        Default is 0.5 mag.
+    Derives ``expected_k`` and ``expected_zp_X0`` for each of the six
+    Rubin bands by evaluating `~rubin_sim.phot_utils.predicted_zeropoint`
+    at two airmasses on a 1-second exposure time scale.
 
     Returns
     -------
-    band_limits : `dict`
-        Keys are single-character band names; values are dicts with
-        keys ``k_min``, ``k_max``, ``zp_min``, ``zp_max``.
+    band_priors : `dict`
+        Keys are single-character band names; values are dicts with keys
+        ``expected_k``, ``k_fraction_tolerance``, ``expected_zp_X0``,
+        and ``zp_window``.  See `ExtinctionStacker` for a description of
+        each key.
     """
-    band_limits = {}
+    band_priors = {}
     for band in "ugrizy":
-        # Extract k from the model by evaluating at two airmasses.
-        # The extinction coefficient is independent of exptime.
         zp_at_X1 = predicted_zeropoint(band, airmass=1.0, exptime=1.0)
         zp_at_X2 = predicted_zeropoint(band, airmass=2.0, exptime=1.0)
         k_predicted = zp_at_X1 - zp_at_X2  # positive extinction coefficient
-
-        # The fitted zeropoint is the intercept at airmass=0.
         zp_at_X0 = zp_at_X1 + k_predicted
-
-        band_limits[band] = {
-            "k_min": max(0.0, (1 - k_fraction_tolerance) * k_predicted),
-            "k_max": (1 + k_fraction_tolerance) * k_predicted,
-            "zp_min": zp_at_X0 - zp_mag_window,
-            "zp_max": zp_at_X0 + zp_mag_window,
+        band_priors[band] = {
+            "expected_k": k_predicted,
+            "k_fraction_tolerance": 0.5,
+            "expected_zp_X0": zp_at_X0,
+            "zp_window": 0.5,
         }
-    return band_limits
+    return band_priors
 
 
-DEFAULT_BAND_LIMITS = _make_band_limits()
+DEFAULT_BAND_PRIORS = _make_default_band_priors()
+
+
+def _limits_from_prior(prior):
+    """Compute ``k_min``, ``k_max``, ``zp_min``, ``zp_max`` from a prior dict.
+
+    Parameters
+    ----------
+    prior : `dict`
+        Must contain ``expected_k``, ``k_fraction_tolerance``,
+        ``expected_zp_X0``, and ``zp_window``.
+
+    Returns
+    -------
+    k_min, k_max, zp_min, zp_max : `float`
+    """
+    k = prior["expected_k"]
+    tol = prior["k_fraction_tolerance"]
+    zp0 = prior["expected_zp_X0"]
+    win = prior["zp_window"]
+    k_min = max(0.0, (1.0 - tol) * k)
+    k_max = (1.0 + tol) * k
+    zp_min = zp0 - win
+    zp_max = zp0 + win
+    return k_min, k_max, zp_min, zp_max
 
 
 def _fit_extinction_one_group(
@@ -74,6 +79,7 @@ def _fit_extinction_one_group(
     k_max,
     zp_min,
     zp_max,
+    zp_prior,
     residual_threshold,
     min_inliers,
     min_inlier_fraction,
@@ -85,8 +91,22 @@ def _fit_extinction_one_group(
 
         zero_point = fitted_zeropoint - extinction_k * airmass
 
-    using RANSAC robust regression, with Theil-Sen as a fallback when
-    RANSAC fails or yields unphysical parameters.
+    Three stages are attempted in order, stopping as soon as one succeeds:
+
+    **Stage 1 — RANSAC** free two-parameter linear regression.  The fit is
+    accepted if both ``extinction_k`` and ``fitted_zeropoint`` fall within
+    their physical bounds and the inlier count passes the quality thresholds.
+
+    **Stage 2 — Theil-Sen** robust regression, used as a fallback when RANSAC
+    fails or its result is out of bounds.  Subject to the same acceptance
+    criteria.
+
+    **Stage 3 — Anchored-clip + bounded Huber regression**.  Used when both
+    free fits fail.  ``zp_prior`` is used as a fixed anchor to identify
+    inliers via a median-based k estimate; bounded
+    ``scipy.optimize.least_squares`` with a Huber loss then fits both
+    parameters jointly within their physical bounds, so an out-of-range
+    intercept can never cause rejection.
 
     Parameters
     ----------
@@ -103,10 +123,16 @@ def _fit_extinction_one_group(
         Minimum physically plausible zenith zeropoint (mag).
     zp_max : `float`
         Maximum physically plausible zenith zeropoint (mag).
+    zp_prior : `float`
+        Expected zenith zeropoint used as the fixed anchor in Stage 3
+        (typically ``expected_zp_X0`` from the band prior, i.e. the
+        midpoint of ``[zp_min, zp_max]``).
     residual_threshold : `float`
-        RANSAC inlier residual threshold in magnitudes.
+        RANSAC inlier residual threshold in magnitudes.  Also used as the
+        Huber ``f_scale`` in Stage 3; the Stage 3 clip threshold is
+        ``2 * residual_threshold``.
     min_inliers : `int`
-        Minimum number of inlier visits required for a valid RANSAC fit.
+        Minimum number of inlier visits required for a valid fit.
     min_inlier_fraction : `float`
         Minimum fraction of the original visit count that must be inliers.
     premask : `bool`, optional
@@ -117,12 +143,13 @@ def _fit_extinction_one_group(
     Returns
     -------
     extinction_k : `float`
-        Fitted extinction coefficient, or `np.nan` if the fit failed.
+        Fitted extinction coefficient, or `np.nan` if all stages failed.
     fitted_zeropoint : `float`
-        Fitted zenith zeropoint, or `np.nan` if the fit failed.
+        Fitted zenith zeropoint, or `np.nan` if all stages failed.
     """
     orig_npts = len(airmass)
     if orig_npts == 0:
+        logger.debug("Extinction fit: no data points supplied; returning NaN.")
         return np.nan, np.nan
 
     X = airmass.reshape(-1, 1)
@@ -138,9 +165,17 @@ def _fit_extinction_one_group(
 
     npts = len(y)
     if npts < min_inliers or (npts / orig_npts) < min_inlier_fraction:
+        logger.debug(
+            "Extinction fit: too few points after pre-masking (%d of %d survive; "
+            "min_inliers=%d, min_inlier_fraction=%.2f); returning NaN.",
+            npts,
+            orig_npts,
+            min_inliers,
+            min_inlier_fraction,
+        )
         return np.nan, np.nan
 
-    # --- RANSAC robust linear regression ---
+    # --- Stage 1: RANSAC robust linear regression ---
     ransac = RANSACRegressor(
         estimator=LinearRegression(),
         residual_threshold=residual_threshold,
@@ -161,11 +196,19 @@ def _fit_extinction_one_group(
             and (num_inliers >= min_inlier_fraction * orig_npts)
         )
         if ok:
+            logger.debug(
+                "Extinction fit stage 1 (RANSAC) succeeded: k=%.4f, zp=%.4f, "
+                "inliers=%d/%d.",
+                k,
+                zp,
+                num_inliers,
+                orig_npts,
+            )
             return k, zp
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Extinction fit stage 1 (RANSAC) raised an exception: %s.", exc)
 
-    # --- Theil-Sen fallback ---
+    # --- Stage 2: Theil-Sen fallback ---
     try:
         ts = TheilSenRegressor(max_subpopulation=100)
         with warnings.catch_warnings():
@@ -174,10 +217,96 @@ def _fit_extinction_one_group(
         k = float(-ts.coef_[0])
         zp = float(ts.intercept_)
         if (k_min <= k <= k_max) and (zp_min <= zp <= zp_max):
+            logger.debug(
+                "Extinction fit stage 2 (Theil-Sen) succeeded: k=%.4f, zp=%.4f.",
+                k,
+                zp,
+            )
             return k, zp
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("Extinction fit stage 2 (Theil-Sen) raised an exception: %s.", exc)
 
+    # --- Stage 3: Anchored-clip + bounded Huber regression ---
+    #
+    # Fix the intercept to zp_prior and compute the implied k for each visit,
+    # then take the median as a robust anchor estimate.  Visits whose residual
+    # against the anchored model exceeds 2 * residual_threshold are clipped.
+    # The surviving inlier set is passed to a bounded least_squares fit with a
+    # Huber loss that jointly optimises both k and zp within their physical
+    # bounds, so an out-of-range intercept can never cause rejection.
+
+    airmass_pm = X.ravel()  # post-premask 1-D array
+    zp_pm = y
+
+    # Guard against any airmass == 0 entries (shouldn't occur in practice).
+    nonzero = airmass_pm > 0.0
+    if nonzero.sum() < min_inliers:
+        logger.debug(
+            "Extinction fit stage 3: too few non-zero airmass points (%d); "
+            "returning NaN.",
+            int(nonzero.sum()),
+        )
+        return np.nan, np.nan
+
+    k_implied = (zp_prior - zp_pm[nonzero]) / airmass_pm[nonzero]
+    k_anchor = float(np.clip(np.median(k_implied), k_min, k_max))
+
+    # Clip outliers relative to the anchored model.
+    clip_threshold = 2.0 * residual_threshold
+    residuals = zp_pm - (zp_prior - k_anchor * airmass_pm)
+    inlier_mask = np.abs(residuals) <= clip_threshold
+
+    n_inliers = int(inlier_mask.sum())
+    if n_inliers < min_inliers or (n_inliers / orig_npts) < min_inlier_fraction:
+        logger.debug(
+            "Extinction fit stage 3: too few inliers after anchor-clip (%d of %d; "
+            "min_inliers=%d, min_inlier_fraction=%.2f); returning NaN.",
+            n_inliers,
+            orig_npts,
+            min_inliers,
+            min_inlier_fraction,
+        )
+        return np.nan, np.nan
+
+    airmass_in = airmass_pm[inlier_mask]
+    zp_in = zp_pm[inlier_mask]
+
+    def _residuals(params):
+        k_fit, zp_fit = params
+        return zp_in - (zp_fit - k_fit * airmass_in)
+
+    try:
+        result = least_squares(
+            _residuals,
+            x0=[k_anchor, zp_prior],
+            bounds=([k_min, zp_min], [k_max, zp_max]),
+            loss="huber",
+            f_scale=residual_threshold,
+            method="trf",
+        )
+        if result.success or result.cost < np.inf:
+            k_fit, zp_fit = float(result.x[0]), float(result.x[1])
+            logger.debug(
+                "Extinction fit stage 3 (anchored-clip + bounded Huber) succeeded: "
+                "k=%.4f, zp=%.4f, inliers=%d/%d.",
+                k_fit,
+                zp_fit,
+                n_inliers,
+                orig_npts,
+            )
+            return k_fit, zp_fit
+        logger.debug(
+            "Extinction fit stage 3: least_squares converged to infinite cost; "
+            "returning NaN."
+        )
+    except Exception as exc:
+        logger.debug(
+            "Extinction fit stage 3 (anchored-clip + bounded Huber) raised an "
+            "exception: %s.",
+            exc,
+        )
+
+    logger.debug("Extinction fit: all three stages failed; returning NaN.")
     return np.nan, np.nan
 
 
@@ -190,6 +319,17 @@ class ExtinctionStacker(BaseStacker):
         zp_1s = fitted_zeropoint - extinction_k * airmass
 
     where ``zp_1s = zero_point_median - 2.5 * log10(visitExposureTime)``.
+
+    Three fitting stages are attempted in order for each group:
+
+    1. **RANSAC** free two-parameter regression with physical bounds check.
+    2. **Theil-Sen** robust regression with physical bounds check.
+    3. **Anchored-clip + bounded Huber regression**: the expected zenith
+       zeropoint ``expected_zp_X0`` from the band prior is used as a fixed
+       anchor to identify inliers via a median-based slope estimate;
+       `scipy.optimize.least_squares` then fits both parameters with hard
+       physical bounds so an out-of-range intercept can never cause
+       rejection.
 
     Parameters
     ----------
@@ -206,16 +346,35 @@ class ExtinctionStacker(BaseStacker):
     day_obs_col : `str`, optional
         Name of the dayObs column (integer YYYYMMDD, as defined by
         SITCOMTN-32).  Default ``'dayObs'``.
-    band_limits : `dict` or `None`, optional
-        Per-band physical limits for the fit (on a 1-second zeropoint
-        scale).  Keys are single-character band names (``'u'``, ``'g'``,
-        ``'r'``, ``'i'``, ``'z'``, ``'y'``); values are dicts with keys
-        ``k_min``, ``k_max``, ``zp_min``, ``zp_max``.  If ``None``, the
-        Rubin Observatory defaults (`DEFAULT_BAND_LIMITS`) are used.
+    band_priors : `dict` or `None`, optional
+        Per-band prior parameters used to derive physical limits for the
+        fit (on a 1-second zeropoint scale).  Keys are single-character
+        band names (``'u'``, ``'g'``, ``'r'``, ``'i'``, ``'z'``,
+        ``'y'``); values are dicts with keys:
+
+        ``expected_k`` : `float`
+            Expected atmospheric extinction coefficient (mag/airmass).
+        ``k_fraction_tolerance`` : `float`
+            Allowed fractional deviation from ``expected_k``; the fit
+            bounds become
+            ``[(1 - tol) * expected_k, (1 + tol) * expected_k]``
+            (floored at 0).
+        ``expected_zp_X0`` : `float`
+            Expected zenith zeropoint at airmass 0, 1-second exposure
+            (mag).  Used as both the centre of the zeropoint window and
+            the fixed anchor in Stage 3.
+        ``zp_window`` : `float`
+            Half-width of the allowed zeropoint range (mag); the fit
+            bounds become
+            ``[expected_zp_X0 - zp_window, expected_zp_X0 + zp_window]``.
+
+        If ``None``, the Rubin Observatory defaults
+        (`DEFAULT_BAND_PRIORS`) are used.
     residual_threshold : `float`, optional
-        RANSAC inlier residual threshold in magnitudes.  Default 0.05.
+        RANSAC inlier residual threshold in magnitudes.  Also used as
+        the Huber ``f_scale`` in Stage 3.  Default 0.05.
     min_inliers : `int`, optional
-        Minimum number of inlier visits required for a valid RANSAC fit.
+        Minimum number of inlier visits required for a valid fit.
         Default 10.
     min_inlier_fraction : `float`, optional
         Minimum fraction of visits (before pre-masking) that must be
@@ -227,11 +386,9 @@ class ExtinctionStacker(BaseStacker):
 
     Notes
     -----
-
-    This uses RANSAC robust regression (with Theil-Sen fallback).  The
-    fitted ``extinction_k`` and ``fitted_zeropoint`` (at 1-second) are
-    then assigned to every visit belonging to that group.  Visits from
-    groups where the fit failed (too few data points, or no physically
+    The fitted ``extinction_k`` and ``fitted_zeropoint`` (at 1-second) are
+    assigned to every visit belonging to that group.  Visits from groups
+    where all fitting stages failed (too few data points, or no physically
     plausible solution found) receive `NaN` in both columns.
 
     This stacker is intended for use with consdb visit tables, which
@@ -260,7 +417,7 @@ class ExtinctionStacker(BaseStacker):
         band_col="band",
         exptime_col="visitExposureTime",
         day_obs_col="dayObs",
-        band_limits=None,
+        band_priors=None,
         residual_threshold=0.05,
         min_inliers=10,
         min_inlier_fraction=0.1,
@@ -271,7 +428,7 @@ class ExtinctionStacker(BaseStacker):
         self.band_col = band_col
         self.exptime_col = exptime_col
         self.day_obs_col = day_obs_col
-        self.band_limits = band_limits if band_limits is not None else DEFAULT_BAND_LIMITS
+        self.band_priors = band_priors if band_priors is not None else DEFAULT_BAND_PRIORS
         self.residual_threshold = residual_threshold
         self.min_inliers = min_inliers
         self.min_inlier_fraction = min_inlier_fraction
@@ -304,13 +461,16 @@ class ExtinctionStacker(BaseStacker):
         sim_data["fitted_zeropoint"] = np.nan
 
         for band in np.unique(sim_data[self.band_col]):
-            limits = self.band_limits.get(band)
-            if limits is None:
+            prior = self.band_priors.get(band)
+            if prior is None:
                 logger.warning(
-                    "No band limits defined for band '%s'; skipping extinction fit.",
+                    "No band priors defined for band '%s'; skipping extinction fit.",
                     band,
                 )
                 continue
+
+            k_min, k_max, zp_min, zp_max = _limits_from_prior(prior)
+            zp_prior = prior["expected_zp_X0"]
 
             band_mask = sim_data[self.band_col] == band
 
@@ -326,10 +486,11 @@ class ExtinctionStacker(BaseStacker):
                 k, zp = _fit_extinction_one_group(
                     airmass,
                     zp_1s,
-                    k_min=limits["k_min"],
-                    k_max=limits["k_max"],
-                    zp_min=limits["zp_min"],
-                    zp_max=limits["zp_max"],
+                    k_min=k_min,
+                    k_max=k_max,
+                    zp_min=zp_min,
+                    zp_max=zp_max,
+                    zp_prior=zp_prior,
                     residual_threshold=self.residual_threshold,
                     min_inliers=self.min_inliers,
                     min_inlier_fraction=self.min_inlier_fraction,

--- a/tests/maf/test_extinction_stacker.py
+++ b/tests/maf/test_extinction_stacker.py
@@ -7,6 +7,7 @@ import numpy as np
 import rubin_sim.maf.stackers as stackers
 from rubin_sim.maf.stackers.extinction_stacker import (
     _fit_extinction_one_group,
+    _fit_zp_extinction_one_group,
     _limits_from_prior,
 )
 from rubin_sim.phot_utils import predicted_zeropoint
@@ -60,8 +61,8 @@ def _stack_many(arrays):
     return np.concatenate(arrays)
 
 
-class TestFitExtinctionOneGroup(unittest.TestCase):
-    """Unit tests for the _fit_extinction_one_group helper."""
+class TestFitZpExtinctionOneGroup(unittest.TestCase):
+    """Unit tests for the _fit_zp_extinction_one_group helper (free ZP + k)."""
 
     def test_clean_data_recovery(self):
         """Fit recovers known k/zp on clean synthetic data."""
@@ -69,7 +70,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
         airmass = rng.uniform(1.0, 2.0, 100)
         true_k, true_zp = 0.12, 32.4
         zp = true_zp - true_k * airmass + rng.normal(0, 0.01, 100)
-        k, fitted_zp = _fit_extinction_one_group(
+        k, fitted_zp = _fit_zp_extinction_one_group(
             airmass,
             zp,
             k_min=0.0,
@@ -96,7 +97,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
         n_out = int(0.15 * n)
         outlier_idx = rng.choice(n, n_out, replace=False)
         zp[outlier_idx] -= 2.0
-        k, _ = _fit_extinction_one_group(
+        k, _ = _fit_zp_extinction_one_group(
             airmass,
             zp,
             k_min=0.0,
@@ -116,7 +117,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
         rng = np.random.default_rng(2)
         airmass = rng.uniform(1.0, 2.0, 5)
         zp = 32.4 - 0.1 * airmass
-        k, fzp = _fit_extinction_one_group(
+        k, fzp = _fit_zp_extinction_one_group(
             airmass,
             zp,
             k_min=0.0,
@@ -137,7 +138,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
         airmass = rng.uniform(1.0, 2.0, 50)
         # True k = 0.9, far above k_max=0.4
         zp = 32.4 - 0.9 * airmass + rng.normal(0, 0.005, 50)
-        k, fzp = _fit_extinction_one_group(
+        k, fzp = _fit_zp_extinction_one_group(
             airmass,
             zp,
             k_min=0.0,
@@ -154,7 +155,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
 
     def test_empty_input_returns_nan(self):
         """Empty arrays should produce NaN without raising."""
-        k, fzp = _fit_extinction_one_group(
+        k, fzp = _fit_zp_extinction_one_group(
             np.array([]),
             np.array([]),
             k_min=0.0,
@@ -166,6 +167,78 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             min_inliers=10,
             min_inlier_fraction=0.1,
         )
+        self.assertTrue(np.isnan(k))
+        self.assertTrue(np.isnan(fzp))
+
+
+class TestFitExtinctionOneGroup(unittest.TestCase):
+    """Unit tests for _fit_extinction_one_group (fixed ZP, k-only fit)."""
+
+    # Common parameters used across tests.
+    ZP_FIXED = 32.5
+    K_MIN = 0.0
+    K_MAX = 0.4
+
+    def _call(self, airmass, zero_point, min_inliers=10, min_inlier_fraction=0.1):
+        return _fit_extinction_one_group(
+            airmass,
+            zero_point,
+            zp_fixed=self.ZP_FIXED,
+            k_min=self.K_MIN,
+            k_max=self.K_MAX,
+            min_inliers=min_inliers,
+            min_inlier_fraction=min_inlier_fraction,
+        )
+
+    def test_clean_data_recovery(self):
+        """Median k should recover the true extinction on clean data."""
+        rng = np.random.default_rng(50)
+        true_k = 0.12
+        airmass = rng.uniform(1.0, 2.0, 100)
+        zp = self.ZP_FIXED - true_k * airmass + rng.normal(0, 0.01, 100)
+        k, fitted_zp = self._call(airmass, zp)
+        self.assertFalse(np.isnan(k), "Fit should succeed on clean data")
+        self.assertAlmostEqual(k, true_k, delta=0.02)
+        self.assertEqual(fitted_zp, self.ZP_FIXED, "Returned zeropoint must equal zp_fixed")
+
+    def test_cloud_clip(self):
+        """Cloud-dimmed visits (k_implied > k_max) should be excluded."""
+        rng = np.random.default_rng(51)
+        true_k = 0.10
+        n = 80
+        airmass = rng.uniform(1.0, 2.0, n)
+        zp = self.ZP_FIXED - true_k * airmass + rng.normal(0, 0.01, n)
+        # Inject 20 % heavily clouded visits: subtract 2 mag (high implied k)
+        n_cloud = int(0.20 * n)
+        cloud_idx = rng.choice(n, n_cloud, replace=False)
+        zp[cloud_idx] -= 2.0
+        k, _ = self._call(airmass, zp)
+        self.assertFalse(np.isnan(k), "Fit should succeed despite cloudy outliers")
+        self.assertAlmostEqual(k, true_k, delta=0.03)
+
+    def test_low_extinction_not_clipped(self):
+        """Visits with k_implied just above k_min should be retained."""
+        rng = np.random.default_rng(52)
+        # Use k close to k_min but still above it; all visits should survive.
+        true_k = 0.02  # above K_MIN=0.0 but low
+        airmass = rng.uniform(1.0, 2.0, 60)
+        zp = self.ZP_FIXED - true_k * airmass + rng.normal(0, 0.005, 60)
+        k, _ = self._call(airmass, zp)
+        self.assertFalse(np.isnan(k), "Low-extinction visits must not be clipped")
+        self.assertAlmostEqual(k, true_k, delta=0.02)
+
+    def test_too_few_visits_returns_nan(self):
+        """Fewer than min_inliers surviving visits should yield NaN."""
+        rng = np.random.default_rng(53)
+        airmass = rng.uniform(1.0, 2.0, 5)
+        zp = self.ZP_FIXED - 0.10 * airmass
+        k, fzp = self._call(airmass, zp)
+        self.assertTrue(np.isnan(k))
+        self.assertTrue(np.isnan(fzp))
+
+    def test_empty_input_returns_nan(self):
+        """Empty arrays should return NaN without raising."""
+        k, fzp = self._call(np.array([]), np.array([]))
         self.assertTrue(np.isnan(k))
         self.assertTrue(np.isnan(fzp))
 
@@ -309,7 +382,7 @@ class TestExtinctionStacker(unittest.TestCase):
             "zp_window": 0.05,  # very tight: stages 1 & 2 likely fail on ZP
         }
         k_min, k_max, zp_min, zp_max = _limits_from_prior(tight_prior)
-        k, fitted_zp = _fit_extinction_one_group(
+        k, fitted_zp = _fit_zp_extinction_one_group(
             airmass,
             zp_1s,
             k_min=k_min,
@@ -328,6 +401,38 @@ class TestExtinctionStacker(unittest.TestCase):
         # zp must also be within bounds
         self.assertGreaterEqual(fitted_zp, zp_min)
         self.assertLessEqual(fitted_zp, zp_max)
+
+    def test_zp_window_zero_uses_k_only(self):
+        """When zp_window=0 the stacker should fix zp and fit only k."""
+        rng = np.random.default_rng(20)
+        true_k = 0.09
+        # Use a slightly wrong expected_zp_X0 to confirm it is not adjusted.
+        fixed_zp = self.TRUE_ZP_1S_R + 0.05
+        custom_priors = {
+            "r": {
+                "expected_k": true_k,
+                "k_fraction_tolerance": 0.5,
+                "expected_zp_X0": fixed_zp,
+                "zp_window": 0.0,  # fixed-ZP mode
+            }
+        }
+        visits = _make_visits("r", 20260101, true_k, self.TRUE_ZP_1S_R, n_visits=80, rng=rng)
+        stacker = stackers.ExtinctionStacker(band_priors=custom_priors)
+        result = stacker.run(visits)
+
+        k_vals = result["extinction_k"]
+        zp_vals = result["fitted_zeropoint"]
+
+        self.assertFalse(np.all(np.isnan(k_vals)), "Fixed-ZP fit should succeed")
+        # All visits in the group share the same k
+        self.assertTrue(np.allclose(k_vals, k_vals[0], equal_nan=False))
+        # k should be reasonable (within 0.05 of true; slight bias from wrong ZP is OK)
+        self.assertAlmostEqual(float(k_vals[0]), true_k, delta=0.05)
+        # fitted_zeropoint must be exactly the fixed value, never adjusted
+        self.assertTrue(
+            np.all(zp_vals == fixed_zp),
+            "fitted_zeropoint must equal expected_zp_X0 when zp_window=0",
+        )
 
     def test_registered_in_registry(self):
         """ExtinctionStacker should appear in the stacker registry."""

--- a/tests/maf/test_extinction_stacker.py
+++ b/tests/maf/test_extinction_stacker.py
@@ -1,0 +1,612 @@
+"""Tests for ExtinctionStacker and CloudExtinctionStacker."""
+
+import unittest
+
+import numpy as np
+
+import rubin_sim.maf.stackers as stackers
+from rubin_sim.maf.stackers.extinction_stacker import (
+    _fit_extinction_one_group,
+)
+from rubin_sim.phot_utils import predicted_zeropoint
+
+
+def _make_visits(
+    band,
+    day_obs,
+    true_k,
+    true_zp_1s,
+    n_visits=50,
+    airmass_range=(1.0, 2.0),
+    noise_sigma=0.01,
+    exptime=30.0,
+    rng=None,
+):
+    """Return a numpy structured array of synthetic visits for one group.
+
+    Parameters
+    ----------
+    true_zp_1s : `float`
+        True zenith zeropoint at 1-second exposure time.
+    exptime : `float`
+        Exposure time in seconds.  The raw zeropoint stored in
+        ``zero_point_median`` will include the ``2.5*log10(exptime)`` term.
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+    airmass = rng.uniform(*airmass_range, size=n_visits)
+    noise = rng.normal(0, noise_sigma, size=n_visits)
+    # Raw zeropoint = 1s zeropoint - k*airmass + 2.5*log10(exptime) + noise
+    zp = true_zp_1s - true_k * airmass + 2.5 * np.log10(exptime) + noise
+    dtype = [
+        ("band", "U1"),
+        ("dayObs", int),
+        ("airmass", float),
+        ("zero_point_median", float),
+        ("visitExposureTime", float),
+    ]
+    data = np.empty(n_visits, dtype=dtype)
+    data["band"] = band
+    data["dayObs"] = day_obs
+    data["airmass"] = airmass
+    data["zero_point_median"] = zp
+    data["visitExposureTime"] = exptime
+    return data
+
+
+def _stack_many(arrays):
+    """Concatenate a list of structured arrays with the same dtype."""
+    return np.concatenate(arrays)
+
+
+class TestFitExtinctionOneGroup(unittest.TestCase):
+    """Unit tests for the _fit_extinction_one_group helper."""
+
+    def test_clean_data_recovery(self):
+        """Fit recovers known k/zp on clean synthetic data."""
+        rng = np.random.default_rng(0)
+        airmass = rng.uniform(1.0, 2.0, 100)
+        true_k, true_zp = 0.12, 32.4
+        zp = true_zp - true_k * airmass + rng.normal(0, 0.01, 100)
+        k, fitted_zp = _fit_extinction_one_group(
+            airmass,
+            zp,
+            k_min=0.0,
+            k_max=0.4,
+            zp_min=32.0,
+            zp_max=33.0,
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertFalse(np.isnan(k), "Fit should succeed on clean data")
+        self.assertAlmostEqual(k, true_k, delta=0.02)
+        self.assertAlmostEqual(fitted_zp, true_zp, delta=0.05)
+
+    def test_outlier_rejection(self):
+        """RANSAC should reject cloud-affected outliers and still recover k."""
+        rng = np.random.default_rng(1)
+        n = 80
+        airmass = rng.uniform(1.0, 2.0, n)
+        true_k, true_zp = 0.10, 32.4
+        zp = true_zp - true_k * airmass + rng.normal(0, 0.01, n)
+        # Inject 15 % heavily clouded outliers (very low zeropoint)
+        n_out = int(0.15 * n)
+        outlier_idx = rng.choice(n, n_out, replace=False)
+        zp[outlier_idx] -= 2.0
+        k, _ = _fit_extinction_one_group(
+            airmass,
+            zp,
+            k_min=0.0,
+            k_max=0.4,
+            zp_min=32.0,
+            zp_max=33.0,
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertFalse(np.isnan(k), "Fit should succeed despite outliers")
+        self.assertAlmostEqual(k, true_k, delta=0.03)
+
+    def test_too_few_visits_returns_nan(self):
+        """Fit should return NaN when fewer than min_inliers visits."""
+        rng = np.random.default_rng(2)
+        airmass = rng.uniform(1.0, 2.0, 5)
+        zp = 32.4 - 0.1 * airmass
+        k, fzp = _fit_extinction_one_group(
+            airmass,
+            zp,
+            k_min=0.0,
+            k_max=0.4,
+            zp_min=32.0,
+            zp_max=33.0,
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertTrue(np.isnan(k))
+        self.assertTrue(np.isnan(fzp))
+
+    def test_unphysical_k_returns_nan(self):
+        """Fit should return NaN when the true k is outside allowed bounds."""
+        rng = np.random.default_rng(3)
+        airmass = rng.uniform(1.0, 2.0, 50)
+        # True k = 0.9, far above k_max=0.4
+        zp = 32.4 - 0.9 * airmass + rng.normal(0, 0.005, 50)
+        k, fzp = _fit_extinction_one_group(
+            airmass,
+            zp,
+            k_min=0.0,
+            k_max=0.4,
+            zp_min=32.0,
+            zp_max=33.0,
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertTrue(np.isnan(k))
+        self.assertTrue(np.isnan(fzp))
+
+    def test_empty_input_returns_nan(self):
+        """Empty arrays should produce NaN without raising."""
+        k, fzp = _fit_extinction_one_group(
+            np.array([]),
+            np.array([]),
+            k_min=0.0,
+            k_max=0.4,
+            zp_min=32.0,
+            zp_max=33.0,
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertTrue(np.isnan(k))
+        self.assertTrue(np.isnan(fzp))
+
+
+class TestExtinctionStacker(unittest.TestCase):
+    """Integration tests for the ExtinctionStacker class."""
+
+    # True 1-second zeropoints at airmass=0 (intercept of the fit model,
+    # within DEFAULT_BAND_LIMITS zp windows)
+    TRUE_ZP_1S_R = 28.48
+    TRUE_ZP_1S_G = 28.72
+
+    def _make_multi_band_data(self, rng=None):
+        """Build a structured array with visits across two bands and nights."""
+        if rng is None:
+            rng = np.random.default_rng(10)
+        pieces = []
+        # Two bands, two nights each
+        for band, true_k, true_zp_1s in [
+            ("r", 0.09, self.TRUE_ZP_1S_R),
+            ("g", 0.15, self.TRUE_ZP_1S_G),
+        ]:
+            for day_obs in [20260101, 20260102]:
+                v = _make_visits(band, day_obs, true_k, true_zp_1s, rng=rng)
+                pieces.append(v)
+        return _stack_many(pieces)
+
+    def test_columns_added(self):
+        """Stacker should add extinction_k and fitted_zeropoint columns."""
+        data = self._make_multi_band_data()
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(data)
+        self.assertIn("extinction_k", result.dtype.names)
+        self.assertIn("fitted_zeropoint", result.dtype.names)
+
+    def test_recovered_k_per_group(self):
+        """Stacker should recover reasonable k values per band/night."""
+        rng = np.random.default_rng(11)
+        true_k_r = 0.09
+        visits = _make_visits("r", 20260101, true_k_r, self.TRUE_ZP_1S_R, n_visits=80, rng=rng)
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(visits)
+        # All visits in one group should have the same k
+        k_vals = result["extinction_k"]
+        self.assertFalse(np.all(np.isnan(k_vals)), "Fit should succeed")
+        self.assertTrue(
+            np.allclose(k_vals, k_vals[0], equal_nan=False), "All visits in a group should share the same k"
+        )
+        self.assertAlmostEqual(float(k_vals[0]), true_k_r, delta=0.02)
+
+    def test_nan_for_failed_fit(self):
+        """Groups with insufficient data should yield NaN."""
+        rng = np.random.default_rng(12)
+        # Only 3 visits — below min_inliers=10
+        visits = _make_visits("r", 20260103, 0.09, self.TRUE_ZP_1S_R, n_visits=3, rng=rng)
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertTrue(np.all(np.isnan(result["extinction_k"])))
+        self.assertTrue(np.all(np.isnan(result["fitted_zeropoint"])))
+
+    def test_multiple_bands_independent(self):
+        """Each band/night should get its own independent k estimate."""
+        rng = np.random.default_rng(13)
+        r_visits = _make_visits("r", 20260101, 0.09, self.TRUE_ZP_1S_R, n_visits=60, rng=rng)
+        g_visits = _make_visits("g", 20260101, 0.18, self.TRUE_ZP_1S_G, n_visits=60, rng=rng)
+        data = _stack_many([r_visits, g_visits])
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(data)
+
+        r_mask = result["band"] == "r"
+        g_mask = result["band"] == "g"
+        k_r = result["extinction_k"][r_mask][0]
+        k_g = result["extinction_k"][g_mask][0]
+        self.assertFalse(np.isnan(k_r))
+        self.assertFalse(np.isnan(k_g))
+        # k values should differ (r ~0.09, g ~0.18)
+        self.assertGreater(k_g, k_r)
+
+    def test_cols_present_skips_recalculation(self):
+        """If extinction_k already present (cols_present=True), skip refit."""
+        rng = np.random.default_rng(14)
+        visits = _make_visits("r", 20260101, 0.09, self.TRUE_ZP_1S_R, n_visits=60, rng=rng)
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(visits)
+        # Manually corrupt the result to detect if _run is called again
+        result["extinction_k"][:] = -999.0
+        # Running again without override should not overwrite (cols_present)
+        result2 = stacker.run(result)
+        self.assertTrue(
+            np.all(result2["extinction_k"] == -999.0),
+            "Stacker should not recalculate when cols already present",
+        )
+
+    def test_unknown_band_no_crash(self):
+        """Visits with unknown band should produce NaN, not crash."""
+        rng = np.random.default_rng(15)
+        visits = _make_visits("q", 20260101, 0.10, 27.0, n_visits=60, rng=rng)
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertTrue(np.all(np.isnan(result["extinction_k"])))
+
+    def test_custom_band_limits(self):
+        """Custom band_limits should override the defaults."""
+        rng = np.random.default_rng(16)
+        custom_limits = {"r": {"k_min": 0.0, "k_max": 0.3, "zp_min": 28.0, "zp_max": 29.0}}
+        visits = _make_visits("r", 20260101, 0.09, self.TRUE_ZP_1S_R, n_visits=60, rng=rng)
+        stacker = stackers.ExtinctionStacker(band_limits=custom_limits)
+        result = stacker.run(visits)
+        self.assertFalse(
+            np.all(np.isnan(result["extinction_k"])), "Should fit with custom limits that allow k~0.09"
+        )
+
+    def test_registered_in_registry(self):
+        """ExtinctionStacker should appear in the stacker registry."""
+        self.assertIn("ExtinctionStacker", stackers.BaseStacker.registry)
+
+    def test_cols_added_dtypes(self):
+        """Both added columns should be float dtype."""
+        rng = np.random.default_rng(17)
+        visits = _make_visits("r", 20260101, 0.09, self.TRUE_ZP_1S_R, n_visits=60, rng=rng)
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertTrue(np.issubdtype(result["extinction_k"].dtype, np.floating))
+        self.assertTrue(np.issubdtype(result["fitted_zeropoint"].dtype, np.floating))
+
+    def test_mixed_exposure_times(self):
+        """Stacker should handle mixed exposure times within a group."""
+        rng = np.random.default_rng(18)
+        true_k = 0.10
+        true_zp_1s = self.TRUE_ZP_1S_R
+        # Create visits with 15s and 30s exposures mixed together
+        v1 = _make_visits("r", 20260101, true_k, true_zp_1s, n_visits=40, exptime=15.0, rng=rng)
+        v2 = _make_visits("r", 20260101, true_k, true_zp_1s, n_visits=40, exptime=30.0, rng=rng)
+        data = _stack_many([v1, v2])
+        stacker = stackers.ExtinctionStacker()
+        result = stacker.run(data)
+        k_vals = result["extinction_k"]
+        self.assertFalse(np.all(np.isnan(k_vals)), "Fit should succeed with mixed exptimes")
+        self.assertAlmostEqual(float(k_vals[0]), true_k, delta=0.02)
+
+
+def _make_visits_with_extinction_cols(
+    band,
+    day_obs,
+    true_k,
+    true_zp_1s,
+    cloud_ext=0.0,
+    n_visits=50,
+    airmass_range=(1.0, 2.0),
+    noise_sigma=0.01,
+    exptime=30.0,
+    rng=None,
+):
+    """Return visits with extinction_k and fitted_zeropoint already set.
+
+    Simulates what the data looks like after ExtinctionStacker has run.
+    The zero_point_median includes the effect of clouds.
+
+    Parameters
+    ----------
+    true_zp_1s : `float`
+        True zenith zeropoint at 1-second exposure time.
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+    airmass = rng.uniform(*airmass_range, size=n_visits)
+    noise = rng.normal(0, noise_sigma, size=n_visits)
+    # Raw observed zp includes exptime term, extinction, and clouds
+    observed_zp = true_zp_1s - true_k * airmass + 2.5 * np.log10(exptime) - cloud_ext + noise
+    dtype = [
+        ("band", "U1"),
+        ("dayObs", int),
+        ("airmass", float),
+        ("zero_point_median", float),
+        ("visitExposureTime", float),
+        ("extinction_k", float),
+        ("fitted_zeropoint", float),
+    ]
+    data = np.empty(n_visits, dtype=dtype)
+    data["band"] = band
+    data["dayObs"] = day_obs
+    data["airmass"] = airmass
+    data["zero_point_median"] = observed_zp
+    data["visitExposureTime"] = exptime
+    data["extinction_k"] = true_k
+    data["fitted_zeropoint"] = true_zp_1s  # 1-second scale
+    return data
+
+
+class TestCloudExtinctionStacker(unittest.TestCase):
+    """Tests for the CloudExtinctionStacker class."""
+
+    def test_column_added(self):
+        """Stacker should add cloud_extinction column."""
+        rng = np.random.default_rng(30)
+        visits = _make_visits_with_extinction_cols("r", 20260101, 0.10, 32.35, rng=rng)
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertIn("cloud_extinction", result.dtype.names)
+
+    def test_clear_sky_near_zero(self):
+        """cloud_extinction should be near zero for clear-sky visits."""
+        rng = np.random.default_rng(31)
+        visits = _make_visits_with_extinction_cols(
+            "r",
+            20260101,
+            0.10,
+            32.35,
+            cloud_ext=0.0,
+            n_visits=100,
+            noise_sigma=0.01,
+            rng=rng,
+        )
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        # Should be near zero (within noise)
+        self.assertAlmostEqual(float(np.median(result["cloud_extinction"])), 0.0, delta=0.02)
+
+    def test_cloudy_visits_positive(self):
+        """cloud_extinction should be positive for cloudy visits."""
+        rng = np.random.default_rng(32)
+        cloud_mag = 0.5
+        visits = _make_visits_with_extinction_cols(
+            "r",
+            20260101,
+            0.10,
+            32.35,
+            cloud_ext=cloud_mag,
+            n_visits=100,
+            noise_sigma=0.01,
+            rng=rng,
+        )
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        median_cloud = float(np.median(result["cloud_extinction"]))
+        self.assertAlmostEqual(median_cloud, cloud_mag, delta=0.03)
+
+    def test_fallback_to_predicted_zeropoint_when_nan(self):
+        """When extinction_k is NaN, predicted_zeropoint should be used."""
+        rng = np.random.default_rng(33)
+        exptime = 30.0
+        cloud_mag = 0.3
+        n_visits = 60
+
+        # Create visits with airmass/band/exptime, compute what
+        # predicted_zeropoint would give, then set observed_zp accordingly.
+        airmass = rng.uniform(1.0, 2.0, n_visits)
+        noise = rng.normal(0, 0.01, n_visits)
+        # predicted_zeropoint gives the expected zp for clear sky
+        expected_zp = predicted_zeropoint("r", airmass, exptime)
+        observed_zp = expected_zp - cloud_mag + noise
+
+        dtype = [
+            ("band", "U1"),
+            ("dayObs", int),
+            ("airmass", float),
+            ("zero_point_median", float),
+            ("visitExposureTime", float),
+            ("extinction_k", float),
+            ("fitted_zeropoint", float),
+        ]
+        visits = np.empty(n_visits, dtype=dtype)
+        visits["band"] = "r"
+        visits["dayObs"] = 20260101
+        visits["airmass"] = airmass
+        visits["zero_point_median"] = observed_zp
+        visits["visitExposureTime"] = exptime
+        visits["extinction_k"] = np.nan
+        visits["fitted_zeropoint"] = np.nan
+
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+
+        # Should recover ~cloud_mag via the predicted_zeropoint fallback
+        median_cloud = float(np.median(result["cloud_extinction"]))
+        self.assertAlmostEqual(median_cloud, cloud_mag, delta=0.03)
+
+    def test_mixed_nan_and_fitted(self):
+        """NaN fallback should apply only to visits with NaN extinction_k."""
+        rng = np.random.default_rng(34)
+        exptime = 30.0
+
+        # Night 1: fit succeeded, no clouds
+        v1 = _make_visits_with_extinction_cols(
+            "r",
+            20260101,
+            0.10,
+            32.35,
+            cloud_ext=0.0,
+            n_visits=40,
+            noise_sigma=0.005,
+            exptime=exptime,
+            rng=rng,
+        )
+        # Night 2: fit failed (NaN), 0.4 mag clouds
+        # Use predicted_zeropoint to generate the "true" expected values
+        airmass_n2 = rng.uniform(1.0, 2.0, 40)
+        noise_n2 = rng.normal(0, 0.005, 40)
+        expected_zp_n2 = predicted_zeropoint("r", airmass_n2, exptime)
+        observed_zp_n2 = expected_zp_n2 - 0.4 + noise_n2
+
+        dtype = v1.dtype
+        v2 = np.empty(40, dtype=dtype)
+        v2["band"] = "r"
+        v2["dayObs"] = 20260102
+        v2["airmass"] = airmass_n2
+        v2["zero_point_median"] = observed_zp_n2
+        v2["visitExposureTime"] = exptime
+        v2["extinction_k"] = np.nan
+        v2["fitted_zeropoint"] = np.nan
+
+        data = np.concatenate([v1, v2])
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(data)
+
+        # Night 1 visits should be near zero
+        night1_mask = result["dayObs"] == 20260101
+        self.assertAlmostEqual(
+            float(np.median(result["cloud_extinction"][night1_mask])),
+            0.0,
+            delta=0.02,
+        )
+        # Night 2 visits should be near 0.4
+        night2_mask = result["dayObs"] == 20260102
+        self.assertAlmostEqual(
+            float(np.median(result["cloud_extinction"][night2_mask])),
+            0.4,
+            delta=0.03,
+        )
+
+    def test_cols_present_skips_recalculation(self):
+        """If cloud_extinction already present, skip recalculation."""
+        rng = np.random.default_rng(36)
+        visits = _make_visits_with_extinction_cols("r", 20260101, 0.10, 32.35, rng=rng)
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        # Corrupt and re-run
+        result["cloud_extinction"][:] = -999.0
+        result2 = stacker.run(result)
+        self.assertTrue(
+            np.all(result2["cloud_extinction"] == -999.0),
+            "Stacker should not recalculate when col already present",
+        )
+
+    def test_unknown_band_nan_fallback(self):
+        """Visits with a band not supported by predicted_zeropoint get NaN."""
+        rng = np.random.default_rng(37)
+        visits = _make_visits_with_extinction_cols("q", 20260101, 0.10, 31.0, rng=rng)
+        visits["extinction_k"] = np.nan
+        visits["fitted_zeropoint"] = np.nan
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertTrue(np.all(np.isnan(result["cloud_extinction"])))
+
+    def test_registered_in_registry(self):
+        """CloudExtinctionStacker should appear in the stacker registry."""
+        self.assertIn("CloudExtinctionStacker", stackers.BaseStacker.registry)
+
+    def test_missing_required_column_no_crash(self):
+        """Should produce NaN and not crash if a required column is missing."""
+        rng = np.random.default_rng(38)
+        # Make data WITHOUT extinction_k column
+        visits = _make_visits("r", 20260101, 0.10, 32.35, n_visits=30, rng=rng)
+        stacker = stackers.CloudExtinctionStacker()
+        result = stacker.run(visits)
+        self.assertIn("cloud_extinction", result.dtype.names)
+        self.assertTrue(np.all(np.isnan(result["cloud_extinction"])))
+
+    def test_exptime_affects_fallback(self):
+        """Different exptimes should give different fallback zeropoints."""
+        rng = np.random.default_rng(39)
+        n_visits = 40
+        airmass = rng.uniform(1.0, 1.5, n_visits)
+
+        # Two sets with different exposure times, both with NaN extinction
+        for exptime in [15.0, 30.0]:
+            expected_zp = predicted_zeropoint("r", airmass, exptime)
+            cloud_mag = 0.25
+            observed_zp = expected_zp - cloud_mag
+
+            dtype = [
+                ("band", "U1"),
+                ("dayObs", int),
+                ("airmass", float),
+                ("zero_point_median", float),
+                ("visitExposureTime", float),
+                ("extinction_k", float),
+                ("fitted_zeropoint", float),
+            ]
+            visits = np.empty(n_visits, dtype=dtype)
+            visits["band"] = "r"
+            visits["dayObs"] = 20260101
+            visits["airmass"] = airmass
+            visits["zero_point_median"] = observed_zp
+            visits["visitExposureTime"] = exptime
+            visits["extinction_k"] = np.nan
+            visits["fitted_zeropoint"] = np.nan
+
+            stacker = stackers.CloudExtinctionStacker()
+            result = stacker.run(visits)
+            median_cloud = float(np.median(result["cloud_extinction"]))
+            self.assertAlmostEqual(median_cloud, cloud_mag, delta=0.01, msg=f"Failed for exptime={exptime}")
+
+    def test_zeropoint_offsets(self):
+        """zeropoint_offsets should shift the fallback predicted zeropoint."""
+        rng = np.random.default_rng(40)
+        exptime = 30.0
+        n_visits = 60
+        offset = 0.15  # instrument is 0.15 mag brighter than model
+
+        airmass = rng.uniform(1.0, 2.0, n_visits)
+        # The "true" expected zp includes the offset
+        true_expected_zp = predicted_zeropoint("r", airmass, exptime) + offset
+        cloud_mag = 0.2
+        observed_zp = true_expected_zp - cloud_mag
+
+        dtype = [
+            ("band", "U1"),
+            ("dayObs", int),
+            ("airmass", float),
+            ("zero_point_median", float),
+            ("visitExposureTime", float),
+            ("extinction_k", float),
+            ("fitted_zeropoint", float),
+        ]
+        visits = np.empty(n_visits, dtype=dtype)
+        visits["band"] = "r"
+        visits["dayObs"] = 20260101
+        visits["airmass"] = airmass
+        visits["zero_point_median"] = observed_zp
+        visits["visitExposureTime"] = exptime
+        visits["extinction_k"] = np.nan
+        visits["fitted_zeropoint"] = np.nan
+
+        # Without offset, cloud_extinction would be biased by 0.15
+        stacker_no_offset = stackers.CloudExtinctionStacker()
+        result_no_offset = stacker_no_offset.run(visits.copy())
+        median_no_offset = float(np.median(result_no_offset["cloud_extinction"]))
+        # Should be cloud_mag - offset = 0.05 (biased low)
+        self.assertAlmostEqual(median_no_offset, cloud_mag - offset, delta=0.02)
+
+        # With offset, should correctly recover cloud_mag
+        stacker_with_offset = stackers.CloudExtinctionStacker(zeropoint_offsets={"r": offset})
+        result_with_offset = stacker_with_offset.run(visits.copy())
+        median_with_offset = float(np.median(result_with_offset["cloud_extinction"]))
+        self.assertAlmostEqual(median_with_offset, cloud_mag, delta=0.02)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/maf/test_extinction_stacker.py
+++ b/tests/maf/test_extinction_stacker.py
@@ -7,6 +7,7 @@ import numpy as np
 import rubin_sim.maf.stackers as stackers
 from rubin_sim.maf.stackers.extinction_stacker import (
     _fit_extinction_one_group,
+    _limits_from_prior,
 )
 from rubin_sim.phot_utils import predicted_zeropoint
 
@@ -75,6 +76,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             k_max=0.4,
             zp_min=32.0,
             zp_max=33.0,
+            zp_prior=32.5,
             residual_threshold=0.05,
             min_inliers=10,
             min_inlier_fraction=0.1,
@@ -101,6 +103,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             k_max=0.4,
             zp_min=32.0,
             zp_max=33.0,
+            zp_prior=32.5,
             residual_threshold=0.05,
             min_inliers=10,
             min_inlier_fraction=0.1,
@@ -120,6 +123,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             k_max=0.4,
             zp_min=32.0,
             zp_max=33.0,
+            zp_prior=32.5,
             residual_threshold=0.05,
             min_inliers=10,
             min_inlier_fraction=0.1,
@@ -140,6 +144,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             k_max=0.4,
             zp_min=32.0,
             zp_max=33.0,
+            zp_prior=32.5,
             residual_threshold=0.05,
             min_inliers=10,
             min_inlier_fraction=0.1,
@@ -156,6 +161,7 @@ class TestFitExtinctionOneGroup(unittest.TestCase):
             k_max=0.4,
             zp_min=32.0,
             zp_max=33.0,
+            zp_prior=32.5,
             residual_threshold=0.05,
             min_inliers=10,
             min_inlier_fraction=0.1,
@@ -261,16 +267,67 @@ class TestExtinctionStacker(unittest.TestCase):
         result = stacker.run(visits)
         self.assertTrue(np.all(np.isnan(result["extinction_k"])))
 
-    def test_custom_band_limits(self):
-        """Custom band_limits should override the defaults."""
+    def test_custom_band_priors(self):
+        """Custom band_priors should override the defaults."""
         rng = np.random.default_rng(16)
-        custom_limits = {"r": {"k_min": 0.0, "k_max": 0.3, "zp_min": 28.0, "zp_max": 29.0}}
+        custom_priors = {
+            "r": {
+                "expected_k": 0.09,
+                "k_fraction_tolerance": 0.5,
+                "expected_zp_X0": self.TRUE_ZP_1S_R,
+                "zp_window": 0.5,
+            }
+        }
         visits = _make_visits("r", 20260101, 0.09, self.TRUE_ZP_1S_R, n_visits=60, rng=rng)
-        stacker = stackers.ExtinctionStacker(band_limits=custom_limits)
+        stacker = stackers.ExtinctionStacker(band_priors=custom_priors)
         result = stacker.run(visits)
         self.assertFalse(
-            np.all(np.isnan(result["extinction_k"])), "Should fit with custom limits that allow k~0.09"
+            np.all(np.isnan(result["extinction_k"])), "Should fit with custom priors that allow k~0.09"
         )
+
+    def test_stage3_fallback_high_scatter(self):
+        """Stage 3 should recover k when scatter is high enough to push the
+        free-fit intercept outside its allowed window."""
+        # Construct data where the free ZP intercept will be pulled out of
+        # range by high scatter, but the slope (k) is physically reasonable.
+        # Use a very tight zp_window so stages 1 and 2 reliably fail on the
+        # intercept check, then confirm stage 3 returns a valid result.
+        rng = np.random.default_rng(99)
+        true_k = 0.09
+        true_zp = self.TRUE_ZP_1S_R
+        n = 60
+        airmass = rng.uniform(1.0, 1.3, n)  # short lever arm → poor intercept
+        # Large scatter: sigma = 0.3 mag, enough to pull the free-fit ZP out
+        # of a ±0.05 mag window around true_zp.
+        noise = rng.normal(0, 0.3, n)
+        zp_1s = true_zp - true_k * airmass + noise
+
+        tight_prior = {
+            "expected_k": true_k,
+            "k_fraction_tolerance": 0.5,
+            "expected_zp_X0": true_zp,
+            "zp_window": 0.05,  # very tight: stages 1 & 2 likely fail on ZP
+        }
+        k_min, k_max, zp_min, zp_max = _limits_from_prior(tight_prior)
+        k, fitted_zp = _fit_extinction_one_group(
+            airmass,
+            zp_1s,
+            k_min=k_min,
+            k_max=k_max,
+            zp_min=zp_min,
+            zp_max=zp_max,
+            zp_prior=tight_prior["expected_zp_X0"],
+            residual_threshold=0.05,
+            min_inliers=10,
+            min_inlier_fraction=0.1,
+        )
+        self.assertFalse(np.isnan(k), "Stage 3 should recover k on high-scatter data")
+        # k must be within the allowed bounds (guaranteed by the bounded solver)
+        self.assertGreaterEqual(k, k_min)
+        self.assertLessEqual(k, k_max)
+        # zp must also be within bounds
+        self.assertGreaterEqual(fitted_zp, zp_min)
+        self.assertLessEqual(fitted_zp, zp_max)
 
     def test_registered_in_registry(self):
         """ExtinctionStacker should appear in the stacker registry."""


### PR DESCRIPTION
Two stackers are added to maf here, intended to be applied to visit sequences from consdb queries rather than opsim output.

The first uses sklearn robust linear fitting tools to fit for photometric extinction and zero point given the the zero_point_median, band, and airmass columns from consdb.
The next uses the results of this and zero_point_median to estimate the extinction from clouds, falling back on rubin_sim.phot_utils.predicted_zeropoint if there was no good fit. It supports an optional offset, so you can (and I probably will) feed in rubin_nights.reference_values.ZEROPOINT_OFFSETS_LSSTCAM, which if I understand what's going on will replicate what rubin_sim_addons does.

This was developed with a mixture of hand-coding and claude code assistance using the experimental support of claude code at the USDF. 