### PR TITLE
tickets/SP-3296: Add parquet support to get_sim_data/get_visit_data, plus save_visit_as_parquet

### DIFF
--- a/rubin_sim/maf/utils/opsim_utils.py
+++ b/rubin_sim/maf/utils/opsim_utils.py
@@ -1,6 +1,7 @@
 __all__ = (
     "get_sim_data",
     "get_visit_data",
+    "save_visits_as_parquet",
     "scale_benchmarks",
     "calc_coadded_depth",
 )
@@ -159,7 +160,8 @@ def save_visits_as_parquet(
     ----------
     visits : `pandas.DataFrame` or Any
         Visit-like tabular data. If not already a `pandas.DataFrame`, the input
-        must be convertible via ``pandas.DataFrame(visits)``.
+        must be convertible via ``pandas.DataFrame(visits)``. For example,
+        a recarray.
     parquet_file_path : `str` or `pathlib.Path`
         Destination path for the output Parquet file. Parent directories are
         created automatically if they do not exist.

--- a/rubin_sim/maf/utils/opsim_utils.py
+++ b/rubin_sim/maf/utils/opsim_utils.py
@@ -9,6 +9,8 @@ import os
 import sqlite3
 import urllib
 from contextlib import closing
+from pathlib import Path
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -36,12 +38,20 @@ def _local_get_sim_data(
         if os.path.isfile(db_con) is False:
             raise FileNotFoundError("No file %s" % db_con)
 
-    # Check if this is an HDF5 file
-    is_hdf5 = isinstance(db_con, str) and db_con.lower().endswith((".h5", ".hdf5"))
+    # Check what type of source was provided, defaulting
+    # to an sqlite3 file if it is a string without an extinsion
+    # that identifies it as a parquet or hdf5 file name.
+    source_type: str = "sqlite3"
+    if isinstance(db_con, str) and db_con.lower().endswith((".h5", ".hdf5")):
+        source_type = "hdf5"
+    elif isinstance(db_con, str) and db_con.lower().endswith((".parquet", ".pq", ".parq")):
+        source_type = "parquet"
+    elif isinstance(db_con, sqlite3.Connection):
+        source_type = "connection"
 
     # Check if table is "observations" or "SummaryAllProps"
     if (table_name is None) & (full_sql_query is None) & (isinstance(db_con, str)):
-        if is_hdf5:
+        if source_type == "hdf5":
             # For HDF5, detect table names by reading the store keys
             with pd.HDFStore(db_con, mode="r") as store:
                 table_keys = [key.lstrip("/") for key in store.keys()]
@@ -53,6 +63,8 @@ def _local_get_sim_data(
                 table_name = "summary"
             else:
                 raise ValueError("Could not guess table_name, set with table_name or full_sql_query kwargs")
+        elif source_type == "parquet":
+            table_name = "observations"
         else:
             url = make_url("sqlite:///" + db_con)
             eng = create_engine(url)
@@ -83,27 +95,34 @@ def _local_get_sim_data(
         query = full_sql_query
 
     sim_data: np.recarray | pd.DataFrame | None = None
-    if is_hdf5 and not need_sql:
-        # Pure HDF5 path - no SQL filtering needed
-        sim_data = pd.read_hdf(db_con, key=table_name)
-    elif isinstance(db_con, sqlite3.Connection):
-        sim_data = pd.read_sql(query, db_con)
-    elif isinstance(db_con, str) and os.path.isfile(db_con):
-        # Handle HDF5 files with SQL constraints by loading into
-        # in-memory SQLite
-        if is_hdf5:
-            with closing(sqlite3.connect(":memory:")) as con:
-                with pd.HDFStore(db_con, mode="r") as store:
-                    for key in store.keys():
-                        tbl_name = key.lstrip("/")
-                        df = pd.read_hdf(db_con, key=key)
-                        df.to_sql(tbl_name, con, index=False)
-                sim_data = pd.read_sql(query, con)
-        else:
+
+    match source_type:
+        case "connection":
+            sim_data = pd.read_sql(query, db_con)
+        case "sqlite3":
             with closing(sqlite3.connect(db_con)) as con:
                 sim_data = pd.read_sql(query, con)
-    else:
-        raise RuntimeError(f"Cannot find {db_con}.")
+        case "hdf5":
+            if need_sql:
+                with closing(sqlite3.connect(":memory:")) as con:
+                    with pd.HDFStore(db_con, mode="r") as store:
+                        for key in store.keys():
+                            table_name = key.lstrip("/")
+                            table_values = pd.read_hdf(db_con, key=key)
+                            table_values.to_sql(table_name, con, index=False)
+                    sim_data = pd.read_sql(query, con)
+            else:
+                sim_data = pd.read_hdf(db_con, key=table_name)
+        case "parquet":
+            if need_sql:
+                with closing(sqlite3.connect(":memory:")) as con:
+                    raw_observations = pd.read_parquet(db_con)
+                    raw_observations.to_sql("observations", con, index=False)
+                    sim_data = pd.read_sql(query, con)
+            else:
+                sim_data = pd.read_parquet(db_con)
+        case _:
+            raise RuntimeError(f"Cannot find {db_con}.")
 
     if len(sim_data) == 0:
         raise UserWarning("No data found matching sqlconstraint %s" % (sqlconstraint))
@@ -128,6 +147,67 @@ def _local_get_sim_data(
     assert isinstance(sim_data, return_class)
 
     return sim_data
+
+
+def save_visits_as_parquet(
+    visits: Union[pd.DataFrame, Any],
+    parquet_file_path: Union[str, Path],
+) -> None:
+    """Save visit data to a Parquet file.
+
+    Parameters
+    ----------
+    visits : `pandas.DataFrame` or Any
+        Visit-like tabular data. If not already a `pandas.DataFrame`, the input
+        must be convertible via ``pandas.DataFrame(visits)``.
+    parquet_file_path : `str` or `pathlib.Path`
+        Destination path for the output Parquet file. Parent directories are
+        created automatically if they do not exist.
+
+    Notes
+    -----
+    This function works around a few issues with pandas auto-detection
+    of column types for columns with NaN or None values.
+    """
+
+    # Normalize path and ensure parent directory exists.
+    parquet_path = Path(parquet_file_path)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Convert input to DataFrame, and ensure our adjustments
+    # do not alter the originally passed data.
+    if isinstance(visits, pd.DataFrame):
+        cleaned_visits = visits.copy(deep=True)
+    else:
+        try:
+            cleaned_visits = pd.DataFrame(visits).copy(deep=True)
+        except Exception as exc:
+            raise TypeError("visits must be a pandas.DataFrame or a DataFrame-compatible object.") from exc
+
+    if "visit_id" in cleaned_visits.columns:
+        cleaned_visits = cleaned_visits.set_index("visit_id", drop=False).rename_axis(index=None)
+
+    if "index" in cleaned_visits.columns:
+        cleaned_visits = cleaned_visits.drop(columns=["index"])
+
+    # Convert object columns that are entirely NaN to float for parquet.
+    obj_cols = cleaned_visits.select_dtypes(include=["object"]).columns
+    all_nan_obj_cols = [c for c in obj_cols if cleaned_visits[c].isna().all()]
+    if all_nan_obj_cols:
+        cleaned_visits[all_nan_obj_cols] = cleaned_visits[all_nan_obj_cols].astype("float64")
+
+    # For object columns that contain only strings (ignoring nulls),
+    # replace NaN with "".
+    string_columns = []
+    for col in cleaned_visits.select_dtypes(include=["object"]).columns:
+        non_null = cleaned_visits[col].dropna()
+        if non_null.empty or non_null.map(lambda v: isinstance(v, str)).all():
+            string_columns.append(col)
+
+    if string_columns:
+        cleaned_visits[string_columns] = cleaned_visits[string_columns].fillna("")
+
+    cleaned_visits.to_parquet(parquet_path, index=True)
 
 
 def get_sim_data(

--- a/tests/maf/test_opsimutils.py
+++ b/tests/maf/test_opsimutils.py
@@ -151,42 +151,6 @@ class TestOpsimUtils(unittest.TestCase):
                 reloaded["fieldRA"].values, original_rec["fieldRA"], decimal=10
             )
 
-    def test_save_visits_as_parquet_visit_id_index(self):
-        """Test that visit_id becomes the index when present."""
-        df = pd.DataFrame(
-            {
-                "visit_id": [10, 20, 30],
-                "fieldRA": [1.0, 2.0, 3.0],
-                "fieldDec": [-1.0, -2.0, -3.0],
-            }
-        )
-
-        with TemporaryDirectory() as tmpdir:
-            parquet_file = os.path.join(tmpdir, "visits_id.parquet")
-            opsimUtils.save_visits_as_parquet(df, parquet_file)
-
-            reloaded = pd.read_parquet(parquet_file)
-            # visit_id should be the index
-            np.testing.assert_array_equal(reloaded.index.values, [10, 20, 30])
-            # visit_id column should still be present (drop=False)
-            assert "visit_id" in reloaded.columns
-
-    def test_save_visits_as_parquet_drops_index_column(self):
-        """Test that a spurious 'index' column is removed before writing."""
-        df = pd.DataFrame(
-            {
-                "index": [0, 1, 2],
-                "fieldRA": [1.0, 2.0, 3.0],
-            }
-        )
-
-        with TemporaryDirectory() as tmpdir:
-            parquet_file = os.path.join(tmpdir, "visits_index_col.parquet")
-            opsimUtils.save_visits_as_parquet(df, parquet_file)
-
-            reloaded = pd.read_parquet(parquet_file)
-            assert "index" not in reloaded.columns
-
     def test_save_visits_as_parquet_all_nan_object_column(self):
         """Test that object columns that are entirely NaN are cast to
         float64."""
@@ -223,21 +187,6 @@ class TestOpsimUtils(unittest.TestCase):
 
             reloaded = pd.read_parquet(parquet_file)
             assert reloaded["note"].iloc[1] == ""
-
-    def test_save_visits_as_parquet_creates_parent_dirs(self):
-        """Test that missing parent directories are created automatically."""
-        with TemporaryDirectory() as tmpdir:
-            parquet_file = os.path.join(tmpdir, "subdir", "nested", "visits.parquet")
-            df = pd.DataFrame({"fieldRA": [1.0, 2.0]})
-            opsimUtils.save_visits_as_parquet(df, parquet_file)
-            assert os.path.isfile(parquet_file)
-
-    def test_save_visits_as_parquet_bad_input(self):
-        """Test that a non-convertible input raises TypeError."""
-        with TemporaryDirectory() as tmpdir:
-            parquet_file = os.path.join(tmpdir, "visits_bad.parquet")
-            with self.assertRaises(TypeError):
-                opsimUtils.save_visits_as_parquet("not_a_dataframe", parquet_file)
 
     def test_get_sim_data_parquet_roundtrip(self):
         """Test that get_sim_data reads a parquet file written by
@@ -289,32 +238,36 @@ class TestOpsimUtils(unittest.TestCase):
 
             reloaded = opsimUtils.get_visit_data(parquet_file)
             assert isinstance(reloaded, pd.DataFrame)
+
+            # Same number of rows and same set of columns.
             assert len(reloaded) == len(original)
-            np.testing.assert_array_almost_equal(
-                reloaded["fieldRA"].values, original["fieldRA"].values, decimal=10
-            )
+            assert set(reloaded.columns) == set(original.columns)
 
-    def test_save_visits_does_not_mutate_input(self):
-        """Test that save_visits_as_parquet does not modify the caller's
-        DataFrame."""
-        df = pd.DataFrame(
-            {
-                "visit_id": [1, 2, 3],
-                "fieldRA": [10.0, 20.0, 30.0],
-                "note": ["a", None, "c"],
-                "all_nan": pd.array([None, None, None], dtype=object),
-            }
-        )
-        original_note = df["note"].copy()
-        original_all_nan = df["all_nan"].copy()
+            # Check every numeric column for exact value preservation.
+            numeric_cols = original.select_dtypes(include=[np.number]).columns
+            for col in numeric_cols:
+                np.testing.assert_array_almost_equal(
+                    reloaded[col].values,
+                    original[col].values,
+                    decimal=10,
+                    err_msg=f"Column '{col}' differs after parquet round-trip",
+                )
 
-        with TemporaryDirectory() as tmpdir:
-            parquet_file = os.path.join(tmpdir, "visits.parquet")
-            opsimUtils.save_visits_as_parquet(df, parquet_file)
-
-        # The original DataFrame should be unchanged.
-        pd.testing.assert_series_equal(df["note"], original_note)
-        pd.testing.assert_series_equal(df["all_nan"], original_all_nan)
+            # Check string columns: original NaN/None should become ""
+            # and non-null values should be preserved unchanged.
+            string_cols = original.select_dtypes(include=["object"]).columns
+            for col in string_cols:
+                mask_null = original[col].isna()
+                # Non-null values must be identical.
+                np.testing.assert_array_equal(
+                    reloaded.loc[~mask_null, col].values,
+                    original.loc[~mask_null, col].values,
+                    err_msg=f"String column '{col}' differs after round-trip",
+                )
+                # Where the original was null, the reloaded value is "".
+                assert (reloaded.loc[mask_null, col] == "").all(), (
+                    f"String column '{col}': expected '' for originally-null" " entries after round-trip"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/maf/test_opsimutils.py
+++ b/tests/maf/test_opsimutils.py
@@ -4,6 +4,7 @@ import unittest
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import pandas as pd
 from rubin_scheduler.data import get_data_dir
 
 import rubin_sim.maf.utils.opsim_utils as opsimUtils
@@ -111,6 +112,209 @@ class TestOpsimUtils(unittest.TestCase):
 
             data_hdf5 = opsimUtils.get_sim_data(hdf5_file, sqlconstraint="observationId < 10")
             assert np.allclose(data_sqlite["fieldRA"], data_hdf5["fieldRA"])
+
+    def test_save_visits_as_parquet_dataframe(self):
+        """Test that a DataFrame round-trips through save_visits_as_parquet."""
+        database_file = os.path.join(get_data_dir(), "tests", TEST_DB)
+        original = opsimUtils.get_sim_data(database_file, return_class=pd.DataFrame)
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits.parquet")
+            opsimUtils.save_visits_as_parquet(original, parquet_file)
+
+            assert os.path.isfile(parquet_file)
+            reloaded = pd.read_parquet(parquet_file)
+
+            # Same number of rows
+            assert len(reloaded) == len(original)
+
+            # Numeric columns should survive the round-trip
+            for col in ("fieldRA", "fieldDec", "observationStartMJD", "night"):
+                assert col in reloaded.columns
+                np.testing.assert_array_almost_equal(reloaded[col].values, original[col].values, decimal=10)
+
+    def test_save_visits_as_parquet_recarray(self):
+        """Test that a numpy recarray round-trips through
+        save_visits_as_parquet."""
+        database_file = os.path.join(get_data_dir(), "tests", TEST_DB)
+        original_rec = opsimUtils.get_sim_data(database_file, return_class=np.recarray)
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_rec.parquet")
+            opsimUtils.save_visits_as_parquet(original_rec, parquet_file)
+
+            assert os.path.isfile(parquet_file)
+            reloaded = pd.read_parquet(parquet_file)
+
+            assert len(reloaded) == len(original_rec)
+            np.testing.assert_array_almost_equal(
+                reloaded["fieldRA"].values, original_rec["fieldRA"], decimal=10
+            )
+
+    def test_save_visits_as_parquet_visit_id_index(self):
+        """Test that visit_id becomes the index when present."""
+        df = pd.DataFrame(
+            {
+                "visit_id": [10, 20, 30],
+                "fieldRA": [1.0, 2.0, 3.0],
+                "fieldDec": [-1.0, -2.0, -3.0],
+            }
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_id.parquet")
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+
+            reloaded = pd.read_parquet(parquet_file)
+            # visit_id should be the index
+            np.testing.assert_array_equal(reloaded.index.values, [10, 20, 30])
+            # visit_id column should still be present (drop=False)
+            assert "visit_id" in reloaded.columns
+
+    def test_save_visits_as_parquet_drops_index_column(self):
+        """Test that a spurious 'index' column is removed before writing."""
+        df = pd.DataFrame(
+            {
+                "index": [0, 1, 2],
+                "fieldRA": [1.0, 2.0, 3.0],
+            }
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_index_col.parquet")
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+
+            reloaded = pd.read_parquet(parquet_file)
+            assert "index" not in reloaded.columns
+
+    def test_save_visits_as_parquet_all_nan_object_column(self):
+        """Test that object columns that are entirely NaN are cast to
+        float64."""
+        df = pd.DataFrame(
+            {
+                "fieldRA": [1.0, 2.0, 3.0],
+                "all_nan_col": pd.array([None, None, None], dtype=object),
+            }
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_nan.parquet")
+            # Should not raise even though the column has no valid type info.
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+
+            reloaded = pd.read_parquet(parquet_file)
+            assert "all_nan_col" in reloaded.columns
+            # All values should be NaN in the reloaded data.
+            assert reloaded["all_nan_col"].isna().all()
+
+    def test_save_visits_as_parquet_string_nan_filled(self):
+        """Test that NaN values in string columns are replaced with empty
+        strings."""
+        df = pd.DataFrame(
+            {
+                "fieldRA": [1.0, 2.0, 3.0],
+                "note": ["a", None, "c"],
+            }
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_str.parquet")
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+
+            reloaded = pd.read_parquet(parquet_file)
+            assert reloaded["note"].iloc[1] == ""
+
+    def test_save_visits_as_parquet_creates_parent_dirs(self):
+        """Test that missing parent directories are created automatically."""
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "subdir", "nested", "visits.parquet")
+            df = pd.DataFrame({"fieldRA": [1.0, 2.0]})
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+            assert os.path.isfile(parquet_file)
+
+    def test_save_visits_as_parquet_bad_input(self):
+        """Test that a non-convertible input raises TypeError."""
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits_bad.parquet")
+            with self.assertRaises(TypeError):
+                opsimUtils.save_visits_as_parquet("not_a_dataframe", parquet_file)
+
+    def test_get_sim_data_parquet_roundtrip(self):
+        """Test that get_sim_data reads a parquet file written by
+        save_visits_as_parquet."""
+        database_file = os.path.join(get_data_dir(), "tests", TEST_DB)
+        original = opsimUtils.get_sim_data(database_file, return_class=pd.DataFrame)
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits.parquet")
+            opsimUtils.save_visits_as_parquet(original, parquet_file)
+
+            # Read back via get_sim_data as a recarray (the default)
+            reloaded_rec = opsimUtils.get_sim_data(parquet_file)
+            assert isinstance(reloaded_rec, np.recarray)
+            assert len(reloaded_rec) == len(original)
+            np.testing.assert_array_almost_equal(
+                reloaded_rec["fieldRA"], original["fieldRA"].values, decimal=10
+            )
+
+            # Read back via get_sim_data as a DataFrame
+            reloaded_df = opsimUtils.get_sim_data(parquet_file, return_class=pd.DataFrame)
+            assert isinstance(reloaded_df, pd.DataFrame)
+            assert len(reloaded_df) == len(original)
+
+    def test_get_sim_data_parquet_with_sqlconstraint(self):
+        """Test that get_sim_data applies sqlconstraint when reading
+        parquet."""
+        database_file = os.path.join(get_data_dir(), "tests", TEST_DB)
+        original = opsimUtils.get_sim_data(database_file, return_class=pd.DataFrame)
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits.parquet")
+            opsimUtils.save_visits_as_parquet(original, parquet_file)
+
+            filtered = opsimUtils.get_sim_data(parquet_file, sqlconstraint="night < 5")
+            assert isinstance(filtered, np.recarray)
+            assert len(filtered) > 0
+            assert np.all(filtered["night"] < 5)
+
+    def test_get_visit_data_parquet_roundtrip(self):
+        """Test that get_visit_data reads a parquet file as a DataFrame."""
+        database_file = os.path.join(get_data_dir(), "tests", TEST_DB)
+        original = opsimUtils.get_visit_data(database_file)
+        assert isinstance(original, pd.DataFrame)
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits.parquet")
+            opsimUtils.save_visits_as_parquet(original, parquet_file)
+
+            reloaded = opsimUtils.get_visit_data(parquet_file)
+            assert isinstance(reloaded, pd.DataFrame)
+            assert len(reloaded) == len(original)
+            np.testing.assert_array_almost_equal(
+                reloaded["fieldRA"].values, original["fieldRA"].values, decimal=10
+            )
+
+    def test_save_visits_does_not_mutate_input(self):
+        """Test that save_visits_as_parquet does not modify the caller's
+        DataFrame."""
+        df = pd.DataFrame(
+            {
+                "visit_id": [1, 2, 3],
+                "fieldRA": [10.0, 20.0, 30.0],
+                "note": ["a", None, "c"],
+                "all_nan": pd.array([None, None, None], dtype=object),
+            }
+        )
+        original_note = df["note"].copy()
+        original_all_nan = df["all_nan"].copy()
+
+        with TemporaryDirectory() as tmpdir:
+            parquet_file = os.path.join(tmpdir, "visits.parquet")
+            opsimUtils.save_visits_as_parquet(df, parquet_file)
+
+        # The original DataFrame should be unchanged.
+        pd.testing.assert_series_equal(df["note"], original_note)
+        pd.testing.assert_series_equal(df["all_nan"], original_all_nan)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I want to distribute visits as parquet files because bokeh can read and plot them over http. Rather than have separate mostly redundant code for consdb query caching, just let rubin_sim read and write parquet naturally, to the limit of what is supported by parquet. (Unlike hdf5 and sqlite3, parquet only saves _one_ table in the file, so it just includes the `observations` table itself, not any ancillary ones.)

Unit tests in this PR were mostly vibe-coded and checked by hand, while the application code was human-driven with claude code assistance.